### PR TITLE
feat(ci): check-no-in-process-placement — the placement-vocabulary gate

### DIFF
--- a/.github/workflows/check-no-in-process-placement.yml
+++ b/.github/workflows/check-no-in-process-placement.yml
@@ -1,0 +1,56 @@
+name: Check No In-Process Placement
+
+# CI gate for the helper-process-placement-only ruling (owner 2026-08-04).
+# `cargo xtask check-no-in-process-placement` walks the engine tree and
+# `docs/` and fails on the vocabulary of the banned model — the patterns and
+# the two escape hatches are enumerated in
+# `xtask/src/check_no_in_process_placement.rs`.
+#
+# Markdown and Rust doc comments are in scope on purpose: the shipped
+# violation announced itself in a `//!` line that three review rounds read
+# past. See `docs/decisions/helper-process-placement-only.md` and
+# `.claude/rules/placement.md`.
+#
+# Vocabulary, not behaviour — the behavioural proof that the parent never
+# hosts a processor class is
+# `sdk/streamlib-python-wheel/tests/test_helper_placement.py`.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-no-in-process-placement:
+    name: xtask check-no-in-process-placement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-no-in-process-placement
+        run: cargo run --locked -q -p xtask -- check-no-in-process-placement
+
+      - name: cargo test -p xtask check_no_in_process_placement (fixture tests)
+        run: cargo test --locked -p xtask check_no_in_process_placement

--- a/docs/decisions/importable-python-library.md
+++ b/docs/decisions/importable-python-library.md
@@ -1,5 +1,8 @@
 # Importable Python library — the SDK-shape pivot
 
+<!-- check-no-in-process-placement:allow-file — this ADR's placement clauses are retracted in
+     place, so it must quote the banned model and the retracted numbers to supersede them -->
+
 Rationale for the `[importable-python-library]` entries across `docs/plan/ARCHITECTURE.md`,
 decided by the owner 2026-08-01, direction confirmed verbatim 2026-08-02. Supersedes parts of
 `single-binary-launch.md`, `media-io-layering.md`, and `product-mvp-sentence.md` (annotated

--- a/docs/decisions/importable-python-library.md
+++ b/docs/decisions/importable-python-library.md
@@ -1,8 +1,5 @@
 # Importable Python library — the SDK-shape pivot
 
-<!-- check-no-in-process-placement:allow-file — this ADR's placement clauses are retracted in
-     place, so it must quote the banned model and the retracted numbers to supersede them -->
-
 Rationale for the `[importable-python-library]` entries across `docs/plan/ARCHITECTURE.md`,
 decided by the owner 2026-08-01, direction confirmed verbatim 2026-08-02. Supersedes parts of
 `single-binary-launch.md`, `media-io-layering.md`, and `product-mvp-sentence.md` (annotated

--- a/runtime/streamlib-engine/src/core/logging/mod.rs
+++ b/runtime/streamlib-engine/src/core/logging/mod.rs
@@ -16,8 +16,8 @@ pub(crate) use record::LogRecord;
 pub use worker::format_event_pretty;
 pub(crate) use worker::now_ns;
 
-/// Emit one record from an in-process Python processor into the unified
-/// JSONL pipeline, carrying caller-supplied dynamic attrs.
+/// Emit one record from the app's own interpreter into the unified JSONL
+/// pipeline, carrying caller-supplied dynamic attrs.
 ///
 /// Bypasses `tracing::event!` deliberately: the macro cannot carry a
 /// runtime-shaped attr map, and routing through the polyglot sink keeps

--- a/sdk/streamlib-python-wheel/tests/test_helper_placement.py
+++ b/sdk/streamlib-python-wheel/tests/test_helper_placement.py
@@ -8,9 +8,9 @@ GIL. That is the library's reason to exist, so it is asserted behaviourally
 rather than trusted: the app's own interpreter never loads a second copy of the
 processor's module, and the pid a bag was produced in is not the app's.
 
-`cargo xtask check-no-in-process-placement` gates the vocabulary once its
-ticket lands; this gates the behaviour. A change that reintroduces in-process
-hosting without using any of the banned words still turns these red.
+`cargo xtask check-no-in-process-placement` gates the vocabulary; this gates
+the behaviour. A change that reintroduces the banned model without using any
+of the banned words still turns these red.
 """
 
 import os

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -38,6 +38,13 @@
 //! Markdown supersession spans (`~~…~~`) are skipped, because the docs policy
 //! requires a retraction to quote what it retracts.
 //!
+//! Part of the pattern set is sourced from the projects the ADR itself cites,
+//! rather than invented here — an author looking for words for the banned shape
+//! borrows theirs. dora-rs calls it an *operator* "linked into a runtime
+//! process" sharing "a single address space"; CPython calls the pre-3.12
+//! behaviour a *shared* or *process-wide GIL*, and the alternative the ADR
+//! rejects a *subinterpreter* with a *per-interpreter GIL*.
+//!
 //! Honest limits, so nobody reads a green run as more than it is:
 //!
 //! - This is vocabulary, not behaviour. A watchdog renamed to avoid these
@@ -51,7 +58,9 @@
 //!   another processor, a per-processor "placement decision" or "placement
 //!   choice", `in-process` beside a Python processor (tried as a shape and
 //!   removed — it fires on the boundary, where built-ins and in-process Rust
-//!   are discussed alongside processors), and any paraphrase of the retracted
+//!   are discussed alongside processors), PEP 703 free-threading (the wheel
+//!   legitimately discusses its own build support), and any paraphrase of the
+//!   retracted
 //!   numbers — "roughly half the subprocess latency", "0.6% of a frame budget"
 //!   — which no literal list catches. A green run means these patterns are
 //!   absent, never that the rule is satisfied; the reviewers are the coverage
@@ -258,6 +267,7 @@ const CO_TENANCY_GUIDANCE: &str = "processors never share an interpreter or a GI
 const DIAGNOSTIC_GUIDANCE: &str = "a diagnostic premised on shared-GIL contention measures something that cannot happen under helper-process placement";
 const PLACEMENT_GUIDANCE: &str =
     "there is one placement; say `app-process` for the legitimate in-that-process senses";
+const REJECTED_ALTERNATIVE_GUIDANCE: &str = "subinterpreters and a per-interpreter GIL are a rejected alternative — a private interpreter is not a private process, and one C-extension segfault still takes down every processor";
 const RETRACTED_NUMBERS_GUIDANCE: &str = "the #1702 spike's latency numbers are retracted as placement evidence — the two arms ran different CPython builds and were never re-measured";
 
 /// The paired-term rules exist because the bare words are legitimate: the
@@ -316,9 +326,39 @@ const BANNED_SHAPES: &[BannedShape] = &[
         also_requires_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
+    // Sourced from the ecosystem, not invented here: an author reaching for a
+    // way to say "co-locate the processors" borrows the vocabulary of the
+    // projects the ADR itself cites. dora-rs — the process-per-node model
+    // StreamLib adopts — calls its in-process variant an *operator* "linked
+    // into a runtime process", sharing "a single address space"; CPython's
+    // PEP 684 calls the pre-3.12 behaviour a *shared GIL* and the alternative
+    // it rejects a *subinterpreter* with a *per-interpreter GIL*.
+    BannedShape {
+        all_of: &["processor"],
+        any_of: &["same address space", "single address space", "shared address space", "one address space"],
+        also_requires_any_of: &[],
+        guidance: CO_TENANCY_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["processor"],
+        any_of: &["subinterpreter", "sub-interpreter", "per-interpreter gil", "concurrent.interpreters"],
+        also_requires_any_of: &[],
+        guidance: REJECTED_ALTERNATIVE_GUIDANCE,
+    },
+    // `global interpreter lock` spelled out contains no `gil`, so it bypasses
+    // every shape above it.
+    BannedShape {
+        all_of: &["processor", "global interpreter lock"],
+        any_of: &[],
+        also_requires_any_of: &["share", "shares", "sharing", "shared", "same", "one", "single", "contend"],
+        guidance: CO_TENANCY_GUIDANCE,
+    },
     BannedShape {
         all_of: &[],
         any_of: &[
+            "process-wide gil",
+            "single gil",
+            "share a single gil",
             "gil contention",
             "gil-contention",
             "contend for the gil",
@@ -1180,6 +1220,64 @@ mod tests {
             tmp.path(),
             "docs/architecture/a.md",
             "Running in-process is the lowest latency option.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// dora-rs is the process-per-node model the ADR adopts, and it ships the
+    /// banned shape under its own name: an *operator* "linked into a runtime
+    /// process", sharing "a single address space". Someone who reads the ADR
+    /// goes and reads dora, so dora's words are the ones they will reach for.
+    #[test]
+    fn flags_co_location_in_doras_vocabulary() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Run the processors as operators sharing a single address space.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// CPython's own words for what PEP 684 rejects and replaces.
+    #[test]
+    fn flags_the_cpython_shared_gil_vocabulary() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Every processor runs under the process-wide GIL.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "The interpreters share a single GIL, so a processor can block another.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 2);
+    }
+
+    /// PEP 684 / PEP 734 are a rejected alternative in the ADR: a private
+    /// interpreter is not a private process.
+    #[test]
+    fn flags_subinterpreters_as_a_rejected_alternative() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Host each processor in a subinterpreter with a per-interpreter GIL.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// `global interpreter lock` spelled out contains no `gil` substring, so it
+    /// slips past every shape keyed on the acronym.
+    #[test]
+    fn flags_the_spelled_out_global_interpreter_lock() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Two processors share one global interpreter lock.\n",
         );
         assert_eq!(lint(tmp.path()).len(), 1);
     }

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -27,11 +27,13 @@
 //!   have to quote the banned vocabulary at length in order to retract and ban
 //!   it; [`EXPECTED_ALLOW_FILE_PATHS`] pins the set.
 //! - [`EXEMPT_PROHIBITION_LINES`] exempts individual lines that state the
-//!   prohibition itself in `docs/plan/**` — files a source session cannot edit,
-//!   since plan edits are gated to the plan skills. Exempting those files whole
-//!   would blind the lint at the one place the ADR blames for the original
-//!   drift, so the exemption is per line and matched on exact text: a new banned
-//!   line in `ARCHITECTURE.md` still fails.
+//!   prohibition itself, in the decision records under
+//!   [`EXEMPT_PROHIBITION_LINE_ROOTS`]. `ARCHITECTURE.md`, `GLOSSARY.md` and the
+//!   2026-08-02 pivot ADR are the documents the ruling names as the drift
+//!   vector, so exempting them whole would blind the lint at the worst possible
+//!   place. Per line, matched on exact text: a new banned line in
+//!   `ARCHITECTURE.md` still fails, and editing an exempted one forces
+//!   re-review.
 //!
 //! Markdown supersession spans (`~~…~~`) are skipped, because the docs policy
 //! requires a retraction to quote what it retracts.
@@ -41,11 +43,22 @@
 //! - This is vocabulary, not behaviour. A watchdog renamed to avoid these
 //!   patterns passes. The behavioural proof that the parent never hosts a
 //!   processor class is `sdk/streamlib-python-wheel/tests/test_helper_placement.py`.
-//! - `.claude/` is not scanned — the rules and reviewer definitions quote the
-//!   banned shapes to forbid them, and they change through their own dedicated
-//!   PRs.
+//! - **The pattern set is a chosen subset of the rule's STOP-WORK vocabulary,
+//!   not the whole of it.** `.claude/rules/placement.md` names shapes this gate
+//!   does not match — `share a GIL`, `own interpreter` beside a processor, the
+//!   runtime described as "one process", `either placement`, `placement
+//!   heuristics`, in-process called "lowest latency", a per-callback duration
+//!   monitor naming another processor, and bare `both placements`. The subset is
+//!   what the commissioning change file specified; widening it is a plan edit,
+//!   not a gate edit. A green run means these patterns are absent, never that
+//!   the rule is satisfied — the reviewers are the coverage for the rest.
+//! - `.claude/` and `.github/` are not scanned. The rules and reviewer
+//!   definitions quote the banned shapes to forbid them and change through their
+//!   own dedicated PRs; `.github/` is CI configuration, and this gate's own
+//!   workflow is named after what it bans.
 //! - The repo-root `CHANGELOG.md` is not scanned: it is release-please-generated
-//!   history of what shipped, not a claim about what the runtime is.
+//!   history of what shipped, not a claim about what the runtime is. `README.md`
+//!   and `CLAUDE.md` are.
 
 // check-no-in-process-placement:allow-file — this file defines the banned
 // patterns and so must contain them literally.
@@ -72,6 +85,11 @@ const SKIP_PATH_FRAGMENTS: &[&str] = &[
     "/.venv/",
 ];
 
+/// Release-please-generated history of what shipped, including the release that
+/// shipped the model this gate now bans. History is not a claim about what the
+/// runtime is, and it is not ours to rewrite.
+const SKIP_FILE_NAMES: &[&str] = &["CHANGELOG.md"];
+
 const SCAN_EXTENSIONS: &[&str] = &["rs", "md", "py", "pyi", "ts", "toml", "yaml", "yml"];
 
 /// Marker comment that exempts an entire file. See the module doc — the set is
@@ -84,15 +102,22 @@ const ALLOW_FILE_PRAGMA: &str = "check-no-in-process-placement:allow-file";
 /// pasted to get CI green.
 const EXPECTED_ALLOW_FILE_PATHS: &[&str] = &[
     "docs/decisions/helper-process-placement-only.md",
-    "docs/decisions/importable-python-library.md",
     "docs/plan/changes/archive/2026-08-07-in-process-hosting-ripout.md",
     "xtask/src/check_no_in_process_placement.rs",
 ];
 
-/// Lines that state the prohibition, in plan documents a source session cannot
-/// edit. Matched on exact trimmed text, so editing one of these lines fails the
-/// lint and forces the edit through review, and a *new* banned line in the same
-/// file still fails.
+/// The two decision-record trees a prohibition may be stated in. A per-line
+/// exemption anywhere else would be a hole in source a session can edit.
+const EXEMPT_PROHIBITION_LINE_ROOTS: &[&str] = &["docs/plan/", "docs/decisions/"];
+
+/// Lines that state the prohibition itself, in the decision records that must
+/// name the banned model to forbid it. Matched on exact trimmed text, so editing
+/// one of these lines fails the lint and forces the edit through review, and a
+/// *new* banned line in the same file still fails.
+///
+/// Per line rather than per file on purpose: `ARCHITECTURE.md`, `GLOSSARY.md`
+/// and the 2026-08-02 pivot ADR are the documents the ruling names as the drift
+/// vector, so blinding them wholesale would be the worst place to do it.
 ///
 /// This list only shrinks. A line that leaves its document is a stale entry and
 /// [`exempt_prohibition_lines_are_all_live`] fails until it is deleted here.
@@ -120,6 +145,33 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
     (
         "docs/plan/changes/importable-python-library.md",
         "(A \"dev-mode GIL-hold watchdog\" clause was removed here 2026-08-04: it measured",
+    ),
+    // The 2026-08-02 pivot ADR, whose placement clauses the ruling retracts in
+    // place. Its `~~…~~` spans cover the retracted claims; these six lines are
+    // the retraction prose that follows each span close.
+    (
+        "docs/decisions/importable-python-library.md",
+        "placement; in-process hosting of a Python processor is banned. The distribution decision —",
+    ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "> from the app's venv. In-process hosting of a Python processor is banned outright — not a",
+    ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "> latency, is the optimised axis — the relevant ratio is 0.161ms against the 16.67ms frame",
+    ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "> budget (~1%, zero drops), not against 0.085ms — and the pair itself was never validly",
+    ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "> shared-GIL contention cannot appear). These numbers are never again cited for any",
+    ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "the other way and killed in-process hosting instead. The surviving insight is this entry's",
     ),
 ];
 
@@ -216,6 +268,7 @@ pub struct LintViolation {
 pub struct InProcessPlacementScanReport {
     pub violations: Vec<LintViolation>,
     pub files_scanned: usize,
+    pub files_scanned_per_root: Vec<(&'static str, usize)>,
     pub allow_filed: Vec<PathBuf>,
     pub exempt_lines_hit: usize,
 }
@@ -223,6 +276,7 @@ pub struct InProcessPlacementScanReport {
 pub fn run(workspace_root: &Path) -> Result<()> {
     ensure_forbidden_tree_absent(workspace_root)?;
     let report = lint_workspace(workspace_root)?;
+    ensure_exempt_prohibition_lines_are_in_decision_records()?;
     ensure_allow_file_set_is_pinned(workspace_root, &report)?;
     crate::ensure_source_walking_gate_read_source(
         "check-no-in-process-placement",
@@ -230,6 +284,7 @@ pub fn run(workspace_root: &Path) -> Result<()> {
         report.files_scanned,
         "in-process placement vocabulary re-enter the tree",
     )?;
+    ensure_every_scan_root_contributed(&report)?;
 
     if report.violations.is_empty() {
         println!(
@@ -258,6 +313,21 @@ pub fn run(workspace_root: &Path) -> Result<()> {
         "in-process placement lint failed: {} violation(s)",
         report.violations.len()
     );
+}
+
+/// The per-line hatch must never reach source a session can edit, so the roots
+/// are enforced by the gate rather than only by its tests.
+fn ensure_exempt_prohibition_lines_are_in_decision_records() -> Result<()> {
+    for (rel, _) in EXEMPT_PROHIBITION_LINES {
+        anyhow::ensure!(
+            EXEMPT_PROHIBITION_LINE_ROOTS
+                .iter()
+                .any(|root| rel.starts_with(root)),
+            "{rel} is not a decision record ({EXEMPT_PROHIBITION_LINE_ROOTS:?}) — a per-line \
+             exemption there would be a hole in source a session can edit"
+        );
+    }
+    Ok(())
 }
 
 /// A pragma pasted onto a fifth file would silently exempt it, so the set is
@@ -308,9 +378,62 @@ pub fn lint_workspace(workspace_root: &Path) -> Result<InProcessPlacementScanRep
         if !dir.exists() {
             continue;
         }
+        let before = report.files_scanned;
         scan_dir(workspace_root, &dir, &mut report)?;
+        report.files_scanned_per_root.push((parent, report.files_scanned - before));
     }
+    scan_workspace_root_markdown(workspace_root, &mut report)?;
     Ok(report)
+}
+
+/// `README.md` and `CLAUDE.md` sit at the workspace root, outside every scan
+/// parent. `CLAUDE.md` in particular is read as instruction by every session,
+/// which is the exact surface the ruling blames for the original drift.
+fn scan_workspace_root_markdown(
+    workspace_root: &Path,
+    report: &mut InProcessPlacementScanReport,
+) -> Result<()> {
+    let entries = match fs::read_dir(workspace_root) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(()),
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        if is_skipped_file_name(&path) {
+            continue;
+        }
+        scan_file(workspace_root, &path, "md", report)?;
+    }
+    Ok(())
+}
+
+fn is_skipped_file_name(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| SKIP_FILE_NAMES.contains(&name))
+}
+
+/// A total `files_scanned > 0` check is satisfied by `runtime/` alone, so losing
+/// `docs/` — the root this gate deliberately added — would leave it green. Every
+/// declared root must exist and must have contributed at least one file.
+fn ensure_every_scan_root_contributed(report: &InProcessPlacementScanReport) -> Result<()> {
+    for parent in SCAN_PARENTS {
+        let scanned = report
+            .files_scanned_per_root
+            .iter()
+            .find(|(root, _)| root == parent)
+            .map(|(_, count)| *count)
+            .unwrap_or(0);
+        anyhow::ensure!(
+            scanned > 0,
+            "check-no-in-process-placement scanned 0 files under {parent}/ — the root moved out \
+             from under the gate, which would let banned placement vocabulary re-enter it unnoticed"
+        );
+    }
+    Ok(())
 }
 
 fn scan_dir(workspace_root: &Path, dir: &Path, report: &mut InProcessPlacementScanReport) -> Result<()> {
@@ -866,12 +989,40 @@ mod tests {
     }
 
     #[test]
-    fn every_exempt_prohibition_line_is_under_the_plan_directory() {
-        for (rel, _) in EXEMPT_PROHIBITION_LINES {
-            assert!(
-                rel.starts_with("docs/plan/"),
-                "{rel} is editable by a source session — give it the allow-file pragma instead"
-            );
-        }
+    fn every_exempt_prohibition_line_is_in_a_decision_record() {
+        ensure_exempt_prohibition_lines_are_in_decision_records().unwrap();
+    }
+
+    #[test]
+    fn every_scan_root_contributes_files_in_the_real_tree() {
+        let report = lint_workspace(&workspace()).unwrap();
+        ensure_every_scan_root_contributed(&report).unwrap();
+    }
+
+    #[test]
+    fn a_scan_root_that_moved_out_from_under_the_gate_fails_the_run() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "runtime/foo/src/lib.rs", "pub fn ok() {}\n");
+        let report = lint_workspace(tmp.path()).unwrap();
+        let err = ensure_every_scan_root_contributed(&report)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("scanned 0 files under"), "got {err}");
+    }
+
+    #[test]
+    fn scans_workspace_root_markdown_but_not_the_changelog() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "CLAUDE.md", "In-process hosting is the fast path.\n");
+        write(tmp.path(), "README.md", "In-process hosting is supported.\n");
+        write(tmp.path(), "CHANGELOG.md", "* **python:** in-process authoring\n");
+        let violations = lint(tmp.path());
+        assert_eq!(violations.len(), 2, "got {violations:?}");
+        assert!(
+            violations
+                .iter()
+                .all(|v| !v.file.ends_with("CHANGELOG.md")),
+            "got {violations:?}"
+        );
     }
 }

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -51,11 +51,10 @@
 // patterns and so must contain them literally.
 
 use anyhow::{Context, Result};
+use std::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
-
-use crate::ensure_source_walking_gate_read_source;
 
 const SCAN_PARENTS: &[&str] = &[
     "runtime", "sdk", "adapters", "tools", "packages", "examples", "xtask", "docs",
@@ -83,7 +82,7 @@ const ALLOW_FILE_PRAGMA: &str = "check-no-in-process-placement:allow-file";
 /// banned vocabulary at length to retract and ban it. Pinned so a fifth
 /// exemption is a deliberate, reviewed edit rather than a comment someone
 /// pasted to get CI green.
-pub const EXPECTED_ALLOW_FILE_PATHS: &[&str] = &[
+const EXPECTED_ALLOW_FILE_PATHS: &[&str] = &[
     "docs/decisions/helper-process-placement-only.md",
     "docs/decisions/importable-python-library.md",
     "docs/plan/changes/archive/2026-08-07-in-process-hosting-ripout.md",
@@ -97,7 +96,7 @@ pub const EXPECTED_ALLOW_FILE_PATHS: &[&str] = &[
 ///
 /// This list only shrinks. A line that leaves its document is a stale entry and
 /// [`exempt_prohibition_lines_are_all_live`] fails until it is deleted here.
-pub const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
+const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
     (
         "docs/plan/ARCHITECTURE.md",
         "In-process hosting of a Python processor does not exist — not as a default, a",
@@ -125,11 +124,18 @@ pub const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
 ];
 
 /// A banned shape. `all_of` terms must every one appear on the line;
-/// `any_of` — when non-empty — needs one hit. All matching is
-/// ASCII-case-insensitive on a lowercased copy of the line.
+/// `any_of` and `also_requires_any_of` — when non-empty — each need one hit.
+/// All matching is ASCII-case-insensitive on a lowercased copy of the line.
 struct BannedShape {
     all_of: &'static [&'static str],
     any_of: &'static [&'static str],
+    also_requires_any_of: &'static [&'static str],
+    guidance: &'static str,
+}
+
+/// What matched, and what to tell the author about it.
+struct BannedShapeMatch {
+    matched: Cow<'static, str>,
     guidance: &'static str,
 }
 
@@ -147,41 +153,49 @@ const BANNED_SHAPES: &[BannedShape] = &[
     BannedShape {
         all_of: &["interpreter", "processor"],
         any_of: &["shared interpreter", "one interpreter", "same interpreter"],
+        also_requires_any_of: &[],
         guidance: CO_TENANCY_GUIDANCE,
     },
     BannedShape {
         all_of: &["gil", "contention"],
         any_of: &[],
+        also_requires_any_of: &[],
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
         all_of: &["gil", "stall", "processor"],
         any_of: &[],
+        also_requires_any_of: &[],
         guidance: CO_TENANCY_GUIDANCE,
     },
     BannedShape {
         all_of: &["gil", "every other"],
         any_of: &[],
+        also_requires_any_of: &[],
         guidance: CO_TENANCY_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["gil-hold", "gil hold", "slow-callback", "slow callback", "stall-attribution", "stall attribution"],
+        also_requires_any_of: WATCHDOG_NOUNS,
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
         all_of: &["both placements viable"],
         any_of: &[],
+        also_requires_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["in-process placement", "in-process hosting", "in-process authoring"],
+        also_requires_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["0.085ms", "0.085 ms", "0.161ms", "0.161 ms", "0.089ms", "0.089 ms", "0.180ms", "0.180 ms"],
+        also_requires_any_of: &[],
         guidance: RETRACTED_NUMBERS_GUIDANCE,
     },
 ];
@@ -189,10 +203,6 @@ const BANNED_SHAPES: &[BannedShape] = &[
 /// The watchdog family needs its diagnostic name *and* a monitor noun, or
 /// every `GIL-holding thread` doc comment trips it.
 const WATCHDOG_NOUNS: &[&str] = &["watchdog", "monitor", "detector"];
-
-/// Index of the watchdog-family shape in [`BANNED_SHAPES`], which alone carries
-/// the [`WATCHDOG_NOUNS`] requirement.
-const WATCHDOG_SHAPE_INDEX: usize = 4;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct LintViolation {
@@ -203,7 +213,7 @@ pub struct LintViolation {
 }
 
 #[derive(Debug, Default)]
-pub struct LintOutcome {
+pub struct InProcessPlacementScanReport {
     pub violations: Vec<LintViolation>,
     pub files_scanned: usize,
     pub allow_filed: Vec<PathBuf>,
@@ -212,29 +222,30 @@ pub struct LintOutcome {
 
 pub fn run(workspace_root: &Path) -> Result<()> {
     ensure_forbidden_tree_absent(workspace_root)?;
-    let outcome = lint_workspace(workspace_root)?;
-    ensure_source_walking_gate_read_source(
+    let report = lint_workspace(workspace_root)?;
+    ensure_allow_file_set_is_pinned(workspace_root, &report)?;
+    crate::ensure_source_walking_gate_read_source(
         "check-no-in-process-placement",
-        &format!("{}/", SCAN_PARENTS.join("/, ")),
-        outcome.files_scanned,
+        &format!("{SCAN_PARENTS:?}"),
+        report.files_scanned,
         "in-process placement vocabulary re-enter the tree",
     )?;
 
-    if outcome.violations.is_empty() {
+    if report.violations.is_empty() {
         println!(
             "✓ check-no-in-process-placement: {} files scanned, {} allow-file'd, {} exempt prohibition line(s) matched",
-            outcome.files_scanned,
-            outcome.allow_filed.len(),
-            outcome.exempt_lines_hit,
+            report.files_scanned,
+            report.allow_filed.len(),
+            report.exempt_lines_hit,
         );
         return Ok(());
     }
 
     eprintln!(
         "✗ check-no-in-process-placement: {} violation(s)",
-        outcome.violations.len()
+        report.violations.len()
     );
-    for v in &outcome.violations {
+    for v in &report.violations {
         eprintln!(
             "  {}:{}: banned placement vocabulary `{}` — {}. See docs/decisions/helper-process-placement-only.md",
             v.file.display(),
@@ -245,8 +256,36 @@ pub fn run(workspace_root: &Path) -> Result<()> {
     }
     anyhow::bail!(
         "in-process placement lint failed: {} violation(s)",
-        outcome.violations.len()
+        report.violations.len()
     );
+}
+
+/// A pragma pasted onto a fifth file would silently exempt it, so the set is
+/// pinned here rather than only in the tests — the gate refuses a tree whose
+/// allow-file set is not exactly [`EXPECTED_ALLOW_FILE_PATHS`].
+fn ensure_allow_file_set_is_pinned(
+    workspace_root: &Path,
+    report: &InProcessPlacementScanReport,
+) -> Result<()> {
+    let mut found: Vec<String> = report
+        .allow_filed
+        .iter()
+        .map(|path| {
+            path.strip_prefix(workspace_root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/")
+        })
+        .collect();
+    found.sort();
+    let mut expected: Vec<String> = EXPECTED_ALLOW_FILE_PATHS.iter().map(|p| p.to_string()).collect();
+    expected.sort();
+    anyhow::ensure!(
+        found == expected,
+        "the `{ALLOW_FILE_PRAGMA}` set is {found:?}, pinned as {expected:?} — every member must be \
+         a document that quotes the banned vocabulary in order to retract it"
+    );
+    Ok(())
 }
 
 /// The retracted spike tree must stay deleted: a green vocabulary scan over a
@@ -262,19 +301,19 @@ fn ensure_forbidden_tree_absent(workspace_root: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn lint_workspace(workspace_root: &Path) -> Result<LintOutcome> {
-    let mut outcome = LintOutcome::default();
+pub fn lint_workspace(workspace_root: &Path) -> Result<InProcessPlacementScanReport> {
+    let mut report = InProcessPlacementScanReport::default();
     for parent in SCAN_PARENTS {
         let dir = workspace_root.join(parent);
         if !dir.exists() {
             continue;
         }
-        scan_dir(workspace_root, &dir, &mut outcome)?;
+        scan_dir(workspace_root, &dir, &mut report)?;
     }
-    Ok(outcome)
+    Ok(report)
 }
 
-fn scan_dir(workspace_root: &Path, dir: &Path, outcome: &mut LintOutcome) -> Result<()> {
+fn scan_dir(workspace_root: &Path, dir: &Path, report: &mut InProcessPlacementScanReport) -> Result<()> {
     for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
         let path = entry.path();
         if !path.is_file() {
@@ -288,7 +327,7 @@ fn scan_dir(workspace_root: &Path, dir: &Path, outcome: &mut LintOutcome) -> Res
         if !SCAN_EXTENSIONS.contains(&extension) {
             continue;
         }
-        scan_file(workspace_root, path, extension, outcome)?;
+        scan_file(workspace_root, path, extension, report)?;
     }
     Ok(())
 }
@@ -297,13 +336,13 @@ fn scan_file(
     workspace_root: &Path,
     path: &Path,
     extension: &str,
-    outcome: &mut LintOutcome,
+    report: &mut InProcessPlacementScanReport,
 ) -> Result<()> {
     let body =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-    outcome.files_scanned += 1;
+    report.files_scanned += 1;
     if body.contains(ALLOW_FILE_PRAGMA) {
-        outcome.allow_filed.push(path.to_path_buf());
+        report.allow_filed.push(path.to_path_buf());
         return Ok(());
     }
 
@@ -314,32 +353,32 @@ fn scan_file(
         .replace('\\', "/");
 
     // Supersession spans are a markdown convention; a stray `~~` in Rust or YAML
-    // is not one, so only markdown gets the state machine and the odd-count refusal.
+    // is not one, so only markdown gets the state machine and the unclosed-span refusal.
     let is_markdown = extension == "md";
     if is_markdown {
         ensure_supersession_spans_balanced(path, &body)?;
     }
 
-    let mut inside_span = false;
+    let mut spans = SupersessionSpanState::default();
     for (idx, line) in body.lines().enumerate() {
         let scanned = if is_markdown {
-            strip_supersession_spans(line, &mut inside_span)
+            spans.outside_spans(line)
         } else {
-            line.to_string()
+            Cow::Borrowed(line)
         };
         if scanned.trim().is_empty() {
             continue;
         }
         if is_exempt_prohibition_line(&relative, line) {
-            outcome.exempt_lines_hit += 1;
+            report.exempt_lines_hit += 1;
             continue;
         }
-        if let Some((matched, guidance)) = first_banned_shape(&scanned) {
-            outcome.violations.push(LintViolation {
+        if let Some(hit) = first_banned_shape(&scanned) {
+            report.violations.push(LintViolation {
                 file: path.to_path_buf(),
                 line: idx + 1,
-                matched,
-                guidance,
+                matched: hit.matched.into_owned(),
+                guidance: hit.guidance,
             });
         }
     }
@@ -355,65 +394,90 @@ fn is_exempt_prohibition_line(relative_path: &str, line: &str) -> bool {
 /// An unterminated `~~` would silently swallow the whole rest of the file, so a
 /// file whose spans do not close is refused rather than scanned.
 fn ensure_supersession_spans_balanced(path: &Path, body: &str) -> Result<()> {
-    let markers = body.matches("~~").count();
+    let mut spans = SupersessionSpanState::default();
+    for line in body.lines() {
+        spans.outside_spans(line);
+    }
     anyhow::ensure!(
-        markers.is_multiple_of(2),
-        "{}: {} `~~` marker(s) — an unterminated supersession span would hide every line after it \
+        !spans.inside_span,
+        "{}: unterminated supersession span — the unclosed `~~` would hide every line after it \
          from check-no-in-process-placement. Close the span.",
         path.display(),
-        markers
     );
     Ok(())
 }
 
-/// Return the portion of `line` outside `~~…~~`, carrying span state across
-/// lines. Handles a span opening on one line and closing on a later one, and
-/// two complete spans on a single line.
-fn strip_supersession_spans(line: &str, inside_span: &mut bool) -> String {
-    let mut outside = String::new();
-    let mut rest = line;
-    loop {
-        match rest.find("~~") {
-            Some(pos) => {
-                if !*inside_span {
-                    outside.push_str(&rest[..pos]);
+/// Markdown span tracking across a file's lines: a `~~…~~` supersession span
+/// that opens on one line and closes on a later one, and a `~~~` fenced code
+/// block, whose fence delimiters are not span markers.
+#[derive(Default)]
+struct SupersessionSpanState {
+    inside_span: bool,
+    inside_code_fence: bool,
+}
+
+impl SupersessionSpanState {
+    /// The portion of `line` outside any supersession span. Fence delimiters
+    /// and the lines they enclose are returned whole — fenced code is still
+    /// scanned for banned vocabulary, it just cannot open or close a span.
+    fn outside_spans<'a>(&mut self, line: &'a str) -> Cow<'a, str> {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            self.inside_code_fence = !self.inside_code_fence;
+            return Cow::Borrowed(line);
+        }
+        if self.inside_code_fence || (!self.inside_span && !line.contains("~~")) {
+            return Cow::Borrowed(line);
+        }
+
+        let mut outside = String::new();
+        let mut rest = line;
+        loop {
+            match rest.find("~~") {
+                Some(pos) => {
+                    if !self.inside_span {
+                        outside.push_str(&rest[..pos]);
+                    }
+                    self.inside_span = !self.inside_span;
+                    rest = &rest[pos + 2..];
                 }
-                *inside_span = !*inside_span;
-                rest = &rest[pos + 2..];
-            }
-            None => {
-                if !*inside_span {
-                    outside.push_str(rest);
+                None => {
+                    if !self.inside_span {
+                        outside.push_str(rest);
+                    }
+                    return Cow::Owned(outside);
                 }
-                return outside;
             }
         }
     }
 }
 
-fn first_banned_shape(line: &str) -> Option<(String, &'static str)> {
+fn first_banned_shape(line: &str) -> Option<BannedShapeMatch> {
     let haystack = line.to_ascii_lowercase();
-    for (index, shape) in BANNED_SHAPES.iter().enumerate() {
-        if index == WATCHDOG_SHAPE_INDEX
-            && !WATCHDOG_NOUNS.iter().any(|noun| haystack.contains(noun))
-        {
-            continue;
-        }
+    for shape in BANNED_SHAPES {
         if !shape.all_of.iter().all(|term| haystack.contains(term)) {
             continue;
         }
-        let any_hit = if shape.any_of.is_empty() {
-            None
+        if !shape.also_requires_any_of.is_empty()
+            && !shape
+                .also_requires_any_of
+                .iter()
+                .any(|term| haystack.contains(term))
+        {
+            continue;
+        }
+        let matched = if shape.any_of.is_empty() {
+            Cow::Owned(shape.all_of.join(" + "))
         } else {
-            match shape.any_of.iter().find(|term| haystack.contains(**term)) {
-                Some(term) => Some(*term),
+            match shape.any_of.iter().copied().find(|t| haystack.contains(t)) {
+                Some(term) => Cow::Borrowed(term),
                 None => continue,
             }
         };
-        let matched = any_hit
-            .map(str::to_string)
-            .unwrap_or_else(|| shape.all_of.join(" + "));
-        return Some((matched, shape.guidance));
+        return Some(BannedShapeMatch {
+            matched,
+            guidance: shape.guidance,
+        });
     }
     None
 }
@@ -628,6 +692,30 @@ mod tests {
         assert!(lint(tmp.path()).is_empty());
     }
 
+    /// `~~~` is a legal code fence, not half a supersession span — counting
+    /// `~~` body-wide would refuse the file for an unclosed span that isn't there.
+    #[test]
+    fn a_tilde_code_fence_is_not_a_span_marker() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "~~~rust\nlet x = 1;\n~~~\nHelper-process placement is the only placement.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn fenced_code_is_still_scanned() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "```rust\n// In-process hosting is the fast path.\n```\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
     #[test]
     fn refuses_a_file_with_an_unterminated_span() {
         let tmp = TempDir::new().unwrap();
@@ -648,9 +736,9 @@ mod tests {
             "docs/decisions/a.md",
             "<!-- check-no-in-process-placement:allow-file -->\nIn-process hosting is banned.\n",
         );
-        let outcome = lint_workspace(tmp.path()).unwrap();
-        assert!(outcome.violations.is_empty());
-        assert_eq!(outcome.allow_filed.len(), 1);
+        let report = lint_workspace(tmp.path()).unwrap();
+        assert!(report.violations.is_empty());
+        assert_eq!(report.allow_filed.len(), 1);
     }
 
     #[test]
@@ -662,10 +750,10 @@ mod tests {
             path,
             &format!("{text}\n  In-process hosting is the fast path.\n"),
         );
-        let outcome = lint_workspace(tmp.path()).unwrap();
-        assert_eq!(outcome.exempt_lines_hit, 1);
-        assert_eq!(outcome.violations.len(), 1, "got {:?}", outcome.violations);
-        assert_eq!(outcome.violations[0].line, 2);
+        let report = lint_workspace(tmp.path()).unwrap();
+        assert_eq!(report.exempt_lines_hit, 1);
+        assert_eq!(report.violations.len(), 1, "got {:?}", report.violations);
+        assert_eq!(report.violations[0].line, 2);
     }
 
     /// Exact-text matching is the point: an edited prohibition line loses its
@@ -697,11 +785,11 @@ mod tests {
     #[test]
     fn refuses_a_run_that_read_no_source() {
         let tmp = TempDir::new().unwrap();
-        let outcome = lint_workspace(tmp.path()).unwrap();
-        let err = ensure_source_walking_gate_read_source(
+        let report = lint_workspace(tmp.path()).unwrap();
+        let err = crate::ensure_source_walking_gate_read_source(
             "check-no-in-process-placement",
             "the scan roots",
-            outcome.files_scanned,
+            report.files_scanned,
             "in-process placement vocabulary re-enter the tree",
         )
         .unwrap_err()
@@ -729,40 +817,36 @@ mod tests {
     }
 
     #[test]
-    fn the_workspace_is_clean() {
-        let outcome = lint_workspace(&workspace()).unwrap();
+    fn the_real_workspace_has_no_banned_placement_vocabulary() {
+        let report = lint_workspace(&workspace()).unwrap();
         assert!(
-            outcome.violations.is_empty(),
+            report.violations.is_empty(),
             "got {:?}",
-            outcome.violations
+            report.violations
         );
     }
 
     #[test]
     fn the_allow_file_set_is_exactly_the_expected_documents() {
         let root = workspace();
-        let mut found: Vec<String> = lint_workspace(&root)
-            .unwrap()
-            .allow_filed
-            .iter()
-            .map(|p| {
-                p.strip_prefix(&root)
-                    .unwrap_or(p)
-                    .to_string_lossy()
-                    .replace('\\', "/")
-            })
-            .collect();
-        found.sort();
-        let mut expected: Vec<String> = EXPECTED_ALLOW_FILE_PATHS
-            .iter()
-            .map(|p| p.to_string())
-            .collect();
-        expected.sort();
-        assert_eq!(
-            found, expected,
-            "the allow-file set changed — every member must be a document that quotes the banned \
-             vocabulary in order to retract it"
+        let report = lint_workspace(&root).unwrap();
+        ensure_allow_file_set_is_pinned(&root, &report).unwrap();
+        assert_eq!(report.allow_filed.len(), EXPECTED_ALLOW_FILE_PATHS.len());
+    }
+
+    #[test]
+    fn a_fifth_allow_file_pragma_fails_the_gate() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "// check-no-in-process-placement:allow-file\n//! In-process hosting is the fast path.\n",
         );
+        let report = lint_workspace(tmp.path()).unwrap();
+        let err = ensure_allow_file_set_is_pinned(tmp.path(), &report)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("runtime/foo/src/lib.rs"), "got {err}");
     }
 
     /// The list only shrinks: a stale entry means the prohibition it exempted is

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -43,19 +43,29 @@
 //! - This is vocabulary, not behaviour. A watchdog renamed to avoid these
 //!   patterns passes. The behavioural proof that the parent never hosts a
 //!   processor class is `sdk/streamlib-python-wheel/tests/test_helper_placement.py`.
-//! - **The pattern set is still a subset of the rule's STOP-WORK vocabulary,
-//!   not the whole of it.** `.claude/rules/placement.md` names shapes this gate
-//!   does not match — `share a GIL`, `own interpreter` beside a processor, the
-//!   runtime described as "one process" or "one big process", in-process called
-//!   "lowest latency", a per-callback duration monitor naming another processor,
-//!   and co-hosting described as shortening an escalate hop. A green run means
-//!   these patterns are absent, never that the rule is satisfied — the reviewers
-//!   are the coverage for the rest.
+//! - **The pattern set is a subset of the rule's STOP-WORK vocabulary, not the
+//!   whole of it**, and the list below is not exhaustive either. Probed misses:
+//!   `share a GIL`, the runtime described as "one process" or "one big process",
+//!   in-process called "lowest latency", a per-callback duration monitor naming
+//!   another processor, co-hosting described as shortening an escalate hop,
+//!   registering the class "in the parent process", a per-processor "placement
+//!   decision" or "placement choice", and any paraphrase of the retracted
+//!   numbers — "roughly half the subprocess latency", "0.6% of a frame budget"
+//!   — which no literal list catches. A green run means these patterns are
+//!   absent, never that the rule is satisfied; the reviewers are the coverage
+//!   for the rest.
+//! - **Matching is per line, and this repo's prose hard-wraps.** A banned
+//!   sentence that wraps between two of its terms passes, and so does a denial
+//!   that wraps away from what it denies — which is why
+//!   [`EXEMPT_PROHIBITION_LINES`] carries wrapped halves of prohibitions that
+//!   read as claims on their own. A two-line window was tried and reverted: it
+//!   caught three wrapped violations and invented four false positives on the
+//!   rule's protected boundary, which is the trade the rule explicitly forbids.
 //! - `.claude/` and `.github/` are not scanned. The rules and reviewer
 //!   definitions quote the banned shapes to forbid them and change through their
 //!   own dedicated PRs; `.github/` is CI configuration, and this gate's own
 //!   workflow is named after what it bans.
-//! - The repo-root `CHANGELOG.md` is not scanned: it is release-please-generated
+//! - `CHANGELOG.md` is not scanned at any depth: it is release-please-generated
 //!   history of what shipped, not a claim about what the runtime is. `README.md`
 //!   and `CLAUDE.md` are.
 
@@ -86,10 +96,14 @@ const SKIP_PATH_FRAGMENTS: &[&str] = &[
 
 /// Release-please-generated history of what shipped, including the release that
 /// shipped the model this gate now bans. History is not a claim about what the
-/// runtime is, and it is not ours to rewrite.
+/// runtime is, and it is not ours to rewrite. Skipped at every depth — the
+/// per-crate changelogs a future release config emits are the same artifact.
 const SKIP_FILE_NAMES: &[&str] = &["CHANGELOG.md"];
 
-const SCAN_EXTENSIONS: &[&str] = &["rs", "md", "py", "pyi", "ts", "toml", "yaml", "yml"];
+/// `mmd` is here because `ARCHITECTURE.md` declares the plan to be the document
+/// *plus* its diagrams, moving together — half the plan being unscanned would
+/// leave the ruling's named drift vector half-covered.
+const SCAN_EXTENSIONS: &[&str] = &["rs", "md", "mmd", "py", "pyi", "ts", "toml", "yaml", "yml"];
 
 /// Marker comment that exempts an entire file. See the module doc — the set is
 /// pinned by [`EXPECTED_ALLOW_FILE_PATHS`] and every member is a retraction.
@@ -145,6 +159,12 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
         "docs/plan/changes/importable-python-library.md",
         "(A \"dev-mode GIL-hold watchdog\" clause was removed here 2026-08-04: it measured",
     ),
+    // "…never a co-tenancy test, since no two Python / processors share an
+    // interpreter" — the denial wrapped away from what it denies.
+    (
+        "docs/plan/changes/importable-python-library.md",
+        "processors share an interpreter. Generated `.pyi` stubs ship in the wheel (IDE",
+    ),
     // The 2026-08-02 pivot ADR, whose placement clauses the ruling retracts in
     // place. Its `~~…~~` spans cover the retracted claims; these six lines are
     // the retraction prose that follows each span close.
@@ -186,13 +206,14 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
     ),
 ];
 
-/// A banned shape. `all_of` terms must every one appear on the line;
-/// `any_of` and `also_requires_any_of` — when non-empty — each need one hit.
-/// All matching is ASCII-case-insensitive on a lowercased copy of the line.
+/// A banned shape. `all_of` terms must every one appear; `any_of` and
+/// `also_requires_any_of` — when non-empty — each need one hit; a hit on
+/// `unless_any_of` clears the shape. All matching is ASCII-case-insensitive.
 struct BannedShape {
     all_of: &'static [&'static str],
     any_of: &'static [&'static str],
     also_requires_any_of: &'static [&'static str],
+    unless_any_of: &'static [&'static str],
     guidance: &'static str,
 }
 
@@ -209,59 +230,99 @@ const PLACEMENT_GUIDANCE: &str =
 const RETRACTED_NUMBERS_GUIDANCE: &str = "the #1702 spike's latency numbers are retracted as placement evidence — the two arms ran different CPython builds and were never re-measured";
 
 /// The paired-term rules exist because the bare words are legitimate: the
-/// engine has an EPOLLHUP watchdog, `rt.run()` documents a GIL-release
-/// contract about its own interpreter's threads, and `both placements` appears
-/// in the very sentences that retire it.
+/// engine has an EPOLLHUP watchdog, `rt.run()` documents a GIL-release contract
+/// about a processor's own threads, and `both placements` appears in the very
+/// sentences that retire it. `unless_any_of` carries the rule's "these are NOT
+/// the ban" boundary — a helper's own interpreter, and a processor's own
+/// threads, are the shipped model, not a violation of it.
 const BANNED_SHAPES: &[BannedShape] = &[
     BannedShape {
-        all_of: &["interpreter", "processor"],
-        any_of: &["shared interpreter", "one interpreter", "same interpreter"],
+        all_of: &["processor"],
+        any_of: &[
+            "shared interpreter",
+            "one interpreter",
+            "same interpreter",
+            "single interpreter",
+            "share an interpreter",
+            "shares an interpreter",
+            "sharing an interpreter",
+            "app's interpreter",
+            "parent's interpreter",
+            "parent interpreter",
+        ],
         also_requires_any_of: &[],
+        unless_any_of: CO_TENANCY_BOUNDARY,
         guidance: CO_TENANCY_GUIDANCE,
     },
     BannedShape {
-        all_of: &["gil", "contention"],
-        any_of: &[],
+        all_of: &[],
+        any_of: &[
+            "gil contention",
+            "gil-contention",
+            "contend for the gil",
+            "contending for the gil",
+            "contend for one",
+        ],
         also_requires_any_of: &[],
+        unless_any_of: &[],
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
-        all_of: &["gil", "stall", "processor"],
-        any_of: &[],
-        also_requires_any_of: &[],
-        guidance: CO_TENANCY_GUIDANCE,
-    },
-    BannedShape {
-        all_of: &["gil", "every other"],
-        any_of: &[],
-        also_requires_any_of: &[],
+        all_of: &["gil"],
+        any_of: &["stall", "block", "starve", "degrade"],
+        also_requires_any_of: &["other processor", "another processor", "other python processor"],
+        unless_any_of: &[],
         guidance: CO_TENANCY_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["gil-hold", "gil hold", "slow-callback", "slow callback", "stall-attribution", "stall attribution"],
         also_requires_any_of: WATCHDOG_NOUNS,
+        unless_any_of: &[],
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: RETIRED_PLACEMENT_TERMS,
         also_requires_any_of: &[],
+        unless_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
-        any_of: &["in-process placement", "in-process hosting", "in-process authoring"],
+        any_of: &[
+            "in-process placement",
+            "in-process hosting",
+            "in-process authoring",
+            "in process placement",
+            "in process hosting",
+            "in process authoring",
+        ],
         also_requires_any_of: &[],
+        unless_any_of: &[],
+        guidance: PLACEMENT_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["in-process", "python processor"],
+        any_of: &[],
+        also_requires_any_of: &[],
+        unless_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["0.085ms", "0.085 ms", "0.161ms", "0.161 ms", "0.089ms", "0.089 ms", "0.180ms", "0.180 ms"],
         also_requires_any_of: &[],
+        unless_any_of: &[],
         guidance: RETRACTED_NUMBERS_GUIDANCE,
     },
 ];
+
+/// The rule's protected boundary for the co-tenancy shape. A helper's or
+/// child's own interpreter is the shipped model; `its own interpreter` is what
+/// every Python processor has.
+const CO_TENANCY_BOUNDARY: &[&str] =
+    &["helper", "child", "own interpreter", "its own", "their own", "no two"];
 
 /// The watchdog family needs its diagnostic name *and* a monitor noun, or
 /// every `GIL-holding thread` doc comment trips it.
@@ -273,6 +334,7 @@ const WATCHDOG_NOUNS: &[&str] = &["watchdog", "monitor", "detector"];
 /// the narrower `both placements viable` would have read straight past it.
 const RETIRED_PLACEMENT_TERMS: &[&str] = &[
     "both placements",
+    "two placements",
     "either placement",
     "placement policy",
     "placement heuristic",
@@ -469,6 +531,9 @@ fn scan_dir(workspace_root: &Path, dir: &Path, report: &mut InProcessPlacementSc
         if SKIP_PATH_FRAGMENTS.iter().any(|frag| path_str.contains(frag)) {
             continue;
         }
+        if is_skipped_file_name(path) {
+            continue;
+        }
         let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
         if !SCAN_EXTENSIONS.contains(&extension) {
             continue;
@@ -602,6 +667,9 @@ fn first_banned_shape(line: &str) -> Option<BannedShapeMatch> {
     let haystack = line.to_ascii_lowercase();
     for shape in BANNED_SHAPES {
         if !shape.all_of.iter().all(|term| haystack.contains(term)) {
+            continue;
+        }
+        if shape.unless_any_of.iter().any(|term| haystack.contains(term)) {
             continue;
         }
         if !shape.also_requires_any_of.is_empty()
@@ -743,6 +811,136 @@ mod tests {
 
     /// The sentence the ADR blames for the #1711 incident, which the narrower
     /// `both placements viable` pattern would have read straight past.
+    #[test]
+    fn flags_hosting_a_processor_in_the_apps_interpreter() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Hosting a Python processor in the app's interpreter is the fast path.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn flags_the_interpreter_sharing_synonyms() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "All Python processors execute in a single interpreter.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "Processors share an interpreter with the app.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/c.md",
+            "The processor class runs in the parent interpreter.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 3);
+    }
+
+    /// A helper's own interpreter is the shipped model, not a violation of it —
+    /// the rule's "these are NOT the ban" boundary, which a bare
+    /// `same interpreter` + `processor` rule flagged.
+    #[test]
+    fn allows_a_helper_running_the_class_in_its_own_interpreter() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "The helper imports the wheel into the same interpreter that runs the processor class.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "Every Python processor gets its own interpreter in its own child process.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn flags_a_gil_block_attributed_to_other_processors() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "A callback holding the GIL blocks all other Python processors.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// The GIL-release contract names the processor's own threads. Requiring
+    /// `gil` + `stall` + `processor` alone flagged it; the ban is a stall
+    /// attributed to *another* processor.
+    #[test]
+    fn allows_a_stall_of_the_processors_own_threads() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sdk/foo/src/a.rs",
+            "//! Holding the GIL would stall the processor's own worker threads.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    /// `gil` + `contention` anywhere on a line flagged legitimate prose about
+    /// one processor's own threads; the diagnostic is named by adjacency.
+    #[test]
+    fn allows_contention_that_is_not_gil_contention() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sdk/foo/src/a.rs",
+            "//! Release the GIL in native calls to reduce contention among a processor's own threads.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn flags_in_process_beside_a_python_processor() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Python processors run in-process when latency matters.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn flags_unhyphenated_in_process_hosting() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "docs/architecture/a.md", "In process hosting is back.\n");
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// The plan is the document plus its diagrams, moving together.
+    #[test]
+    fn scans_mermaid_plan_diagrams() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/plan/diagrams/system.mmd",
+            "  A[App] --> B[In-process hosting]\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn skips_a_per_crate_changelog_too() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sdk/streamlib-python-wheel/CHANGELOG.md",
+            "* **python:** in-process authoring\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
     #[test]
     fn flags_the_retired_placement_terms_bare() {
         let tmp = TempDir::new().unwrap();

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -43,15 +43,14 @@
 //! - This is vocabulary, not behaviour. A watchdog renamed to avoid these
 //!   patterns passes. The behavioural proof that the parent never hosts a
 //!   processor class is `sdk/streamlib-python-wheel/tests/test_helper_placement.py`.
-//! - **The pattern set is a chosen subset of the rule's STOP-WORK vocabulary,
+//! - **The pattern set is still a subset of the rule's STOP-WORK vocabulary,
 //!   not the whole of it.** `.claude/rules/placement.md` names shapes this gate
 //!   does not match — `share a GIL`, `own interpreter` beside a processor, the
-//!   runtime described as "one process", `either placement`, `placement
-//!   heuristics`, in-process called "lowest latency", a per-callback duration
-//!   monitor naming another processor, and bare `both placements`. The subset is
-//!   what the commissioning change file specified; widening it is a plan edit,
-//!   not a gate edit. A green run means these patterns are absent, never that
-//!   the rule is satisfied — the reviewers are the coverage for the rest.
+//!   runtime described as "one process" or "one big process", in-process called
+//!   "lowest latency", a per-callback duration monitor naming another processor,
+//!   and co-hosting described as shortening an escalate hop. A green run means
+//!   these patterns are absent, never that the rule is satisfied — the reviewers
+//!   are the coverage for the rest.
 //! - `.claude/` and `.github/` are not scanned. The rules and reviewer
 //!   definitions quote the banned shapes to forbid them and change through their
 //!   own dedicated PRs; `.github/` is CI configuration, and this gate's own
@@ -173,6 +172,18 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
         "docs/decisions/importable-python-library.md",
         "the other way and killed in-process hosting instead. The surviving insight is this entry's",
     ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "- **Both placements, engine-chosen** — rejected 2026-08-04",
+    ),
+    (
+        "docs/plan/GLOSSARY.md",
+        "\"transparent move\".",
+    ),
+    (
+        "docs/plan/GLOSSARY.md",
+        "**Placement policy**, **Placement heuristic**, **Transparent move** — there is one",
+    ),
 ];
 
 /// A banned shape. `all_of` terms must every one appear on the line;
@@ -233,8 +244,8 @@ const BANNED_SHAPES: &[BannedShape] = &[
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
-        all_of: &["both placements viable"],
-        any_of: &[],
+        all_of: &[],
+        any_of: RETIRED_PLACEMENT_TERMS,
         also_requires_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
@@ -255,6 +266,18 @@ const BANNED_SHAPES: &[BannedShape] = &[
 /// The watchdog family needs its diagnostic name *and* a monitor noun, or
 /// every `GIL-holding thread` doc comment trips it.
 const WATCHDOG_NOUNS: &[&str] = &["watchdog", "monitor", "detector"];
+
+/// The glossary's retired-terms list for the 2026-08-04 ruling — there is one
+/// placement, so each of these names nothing. Banned bare: `both placements
+/// are first-class` is the sentence the ADR blames for the #1711 incident, and
+/// the narrower `both placements viable` would have read straight past it.
+const RETIRED_PLACEMENT_TERMS: &[&str] = &[
+    "both placements",
+    "either placement",
+    "placement policy",
+    "placement heuristic",
+    "transparent move",
+];
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct LintViolation {
@@ -718,22 +741,37 @@ mod tests {
         assert!(lint(tmp.path()).is_empty());
     }
 
+    /// The sentence the ADR blames for the #1711 incident, which the narrower
+    /// `both placements viable` pattern would have read straight past.
     #[test]
-    fn flags_both_placements_viable_but_not_the_bare_phrase() {
+    fn flags_the_retired_placement_terms_bare() {
         let tmp = TempDir::new().unwrap();
         write(
             tmp.path(),
-            "docs/architecture/foo.md",
-            "The measured gap makes both placements viable.\n",
+            "docs/architecture/a.md",
+            "Both placements are first-class.\n",
         );
         write(
             tmp.path(),
-            "docs/architecture/bar.md",
-            "Rejected alternative: both placements, engine-chosen.\n",
+            "docs/architecture/b.md",
+            "Either placement is acceptable for a Python processor.\n",
         );
-        let violations = lint(tmp.path());
-        assert_eq!(violations.len(), 1, "got {violations:?}");
-        assert_eq!(violations[0].matched, "both placements viable");
+        write(
+            tmp.path(),
+            "docs/architecture/c.md",
+            "The engine applies placement heuristics per processor.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/d.md",
+            "Placement policy is an engine concern.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/e.md",
+            "A transparent move between placements.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 5);
     }
 
     #[test]

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -1,0 +1,793 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! CI lint enforcing the helper-process-placement-only ruling (owner 2026-08-04).
+//!
+//! Every Python processor runs in its own child process with its own
+//! interpreter and its own GIL; hosting one in the app's interpreter is banned
+//! outright, and so is any diagnostic whose premise is that processors share a
+//! GIL or an interpreter. See `docs/decisions/helper-process-placement-only.md`
+//! and `.claude/rules/placement.md`.
+//!
+//! Two deliberate inversions of the `check_no_reverse_dns` shape this lint is
+//! otherwise modeled on:
+//!
+//! - **Prose is in scope, not out of it.** This lint is line-based over `.md`
+//!   files and over Rust doc comments and line comments. The shipped violation
+//!   announced itself in a `//!` line ("One interpreter runs every Python
+//!   processor") that three review rounds read past; an AST walk over string
+//!   literals is blind to exactly that. Do not "fix" this lint by moving it to
+//!   `syn`.
+//! - **`docs/` is a scan root**, and `spikes/` must stay absent — the
+//!   `streamlib-pyembed-spike` tree published the retracted latency numbers.
+//!
+//! Two escape hatches, both narrow:
+//!
+//! - [`ALLOW_FILE_PRAGMA`] exempts a whole file. Reserved for the documents that
+//!   have to quote the banned vocabulary at length in order to retract and ban
+//!   it; [`EXPECTED_ALLOW_FILE_PATHS`] pins the set.
+//! - [`EXEMPT_PROHIBITION_LINES`] exempts individual lines that state the
+//!   prohibition itself in `docs/plan/**` — files a source session cannot edit,
+//!   since plan edits are gated to the plan skills. Exempting those files whole
+//!   would blind the lint at the one place the ADR blames for the original
+//!   drift, so the exemption is per line and matched on exact text: a new banned
+//!   line in `ARCHITECTURE.md` still fails.
+//!
+//! Markdown supersession spans (`~~…~~`) are skipped, because the docs policy
+//! requires a retraction to quote what it retracts.
+//!
+//! Honest limits, so nobody reads a green run as more than it is:
+//!
+//! - This is vocabulary, not behaviour. A watchdog renamed to avoid these
+//!   patterns passes. The behavioural proof that the parent never hosts a
+//!   processor class is `sdk/streamlib-python-wheel/tests/test_helper_placement.py`.
+//! - `.claude/` is not scanned — the rules and reviewer definitions quote the
+//!   banned shapes to forbid them, and they change through their own dedicated
+//!   PRs.
+//! - The repo-root `CHANGELOG.md` is not scanned: it is release-please-generated
+//!   history of what shipped, not a claim about what the runtime is.
+
+// check-no-in-process-placement:allow-file — this file defines the banned
+// patterns and so must contain them literally.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+use crate::ensure_source_walking_gate_read_source;
+
+const SCAN_PARENTS: &[&str] = &[
+    "runtime", "sdk", "adapters", "tools", "packages", "examples", "xtask", "docs",
+];
+
+/// The retracted spike tree. Its README was the last place in the tree where a
+/// grep returned "in-process beats the baseline" as a live claim.
+const FORBIDDEN_TREE: &str = "spikes";
+
+const SKIP_PATH_FRAGMENTS: &[&str] = &[
+    "/target/",
+    "/_generated_/",
+    "/node_modules/",
+    "/.git/",
+    "/.venv/",
+];
+
+const SCAN_EXTENSIONS: &[&str] = &["rs", "md", "py", "pyi", "ts", "toml", "yaml", "yml"];
+
+/// Marker comment that exempts an entire file. See the module doc — the set is
+/// pinned by [`EXPECTED_ALLOW_FILE_PATHS`] and every member is a retraction.
+const ALLOW_FILE_PRAGMA: &str = "check-no-in-process-placement:allow-file";
+
+/// Every file allowed to carry the pragma, each because it must quote the
+/// banned vocabulary at length to retract and ban it. Pinned so a fifth
+/// exemption is a deliberate, reviewed edit rather than a comment someone
+/// pasted to get CI green.
+pub const EXPECTED_ALLOW_FILE_PATHS: &[&str] = &[
+    "docs/decisions/helper-process-placement-only.md",
+    "docs/decisions/importable-python-library.md",
+    "docs/plan/changes/archive/2026-08-07-in-process-hosting-ripout.md",
+    "xtask/src/check_no_in_process_placement.rs",
+];
+
+/// Lines that state the prohibition, in plan documents a source session cannot
+/// edit. Matched on exact trimmed text, so editing one of these lines fails the
+/// lint and forces the edit through review, and a *new* banned line in the same
+/// file still fails.
+///
+/// This list only shrinks. A line that leaves its document is a stale entry and
+/// [`exempt_prohibition_lines_are_all_live`] fails until it is deleted here.
+pub const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
+    (
+        "docs/plan/ARCHITECTURE.md",
+        "In-process hosting of a Python processor does not exist — not as a default, a",
+    ),
+    (
+        "docs/plan/GLOSSARY.md",
+        "in-process hosting of a Python processor does not exist. Native built-ins running in",
+    ),
+    (
+        "docs/plan/GLOSSARY.md",
+        "\"in-process placement\", \"both placements\", \"placement policy\", \"placement heuristic\",",
+    ),
+    (
+        "docs/plan/GLOSSARY.md",
+        "`docs/decisions/helper-process-placement-only.md`): **In-process placement**,",
+    ),
+    (
+        "docs/plan/changes/importable-python-library.md",
+        "\"In-process Python authoring\" — in-process hosting of a Python processor is banned,",
+    ),
+    (
+        "docs/plan/changes/importable-python-library.md",
+        "(A \"dev-mode GIL-hold watchdog\" clause was removed here 2026-08-04: it measured",
+    ),
+];
+
+/// A banned shape. `all_of` terms must every one appear on the line;
+/// `any_of` — when non-empty — needs one hit. All matching is
+/// ASCII-case-insensitive on a lowercased copy of the line.
+struct BannedShape {
+    all_of: &'static [&'static str],
+    any_of: &'static [&'static str],
+    guidance: &'static str,
+}
+
+const CO_TENANCY_GUIDANCE: &str = "processors never share an interpreter or a GIL — every Python processor runs in its own helper process";
+const DIAGNOSTIC_GUIDANCE: &str = "a diagnostic premised on shared-GIL contention measures something that cannot happen under helper-process placement";
+const PLACEMENT_GUIDANCE: &str =
+    "there is one placement; say `app-process` for the legitimate in-that-process senses";
+const RETRACTED_NUMBERS_GUIDANCE: &str = "the #1702 spike's latency numbers are retracted as placement evidence — the two arms ran different CPython builds and were never re-measured";
+
+/// The paired-term rules exist because the bare words are legitimate: the
+/// engine has an EPOLLHUP watchdog, `rt.run()` documents a GIL-release
+/// contract about its own interpreter's threads, and `both placements` appears
+/// in the very sentences that retire it.
+const BANNED_SHAPES: &[BannedShape] = &[
+    BannedShape {
+        all_of: &["interpreter", "processor"],
+        any_of: &["shared interpreter", "one interpreter", "same interpreter"],
+        guidance: CO_TENANCY_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["gil", "contention"],
+        any_of: &[],
+        guidance: DIAGNOSTIC_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["gil", "stall", "processor"],
+        any_of: &[],
+        guidance: CO_TENANCY_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["gil", "every other"],
+        any_of: &[],
+        guidance: CO_TENANCY_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &[],
+        any_of: &["gil-hold", "gil hold", "slow-callback", "slow callback", "stall-attribution", "stall attribution"],
+        guidance: DIAGNOSTIC_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["both placements viable"],
+        any_of: &[],
+        guidance: PLACEMENT_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &[],
+        any_of: &["in-process placement", "in-process hosting", "in-process authoring"],
+        guidance: PLACEMENT_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &[],
+        any_of: &["0.085ms", "0.085 ms", "0.161ms", "0.161 ms", "0.089ms", "0.089 ms", "0.180ms", "0.180 ms"],
+        guidance: RETRACTED_NUMBERS_GUIDANCE,
+    },
+];
+
+/// The watchdog family needs its diagnostic name *and* a monitor noun, or
+/// every `GIL-holding thread` doc comment trips it.
+const WATCHDOG_NOUNS: &[&str] = &["watchdog", "monitor", "detector"];
+
+/// Index of the watchdog-family shape in [`BANNED_SHAPES`], which alone carries
+/// the [`WATCHDOG_NOUNS`] requirement.
+const WATCHDOG_SHAPE_INDEX: usize = 4;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct LintViolation {
+    pub file: PathBuf,
+    pub line: usize,
+    pub matched: String,
+    pub guidance: &'static str,
+}
+
+#[derive(Debug, Default)]
+pub struct LintOutcome {
+    pub violations: Vec<LintViolation>,
+    pub files_scanned: usize,
+    pub allow_filed: Vec<PathBuf>,
+    pub exempt_lines_hit: usize,
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    ensure_forbidden_tree_absent(workspace_root)?;
+    let outcome = lint_workspace(workspace_root)?;
+    ensure_source_walking_gate_read_source(
+        "check-no-in-process-placement",
+        &format!("{}/", SCAN_PARENTS.join("/, ")),
+        outcome.files_scanned,
+        "in-process placement vocabulary re-enter the tree",
+    )?;
+
+    if outcome.violations.is_empty() {
+        println!(
+            "✓ check-no-in-process-placement: {} files scanned, {} allow-file'd, {} exempt prohibition line(s) matched",
+            outcome.files_scanned,
+            outcome.allow_filed.len(),
+            outcome.exempt_lines_hit,
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "✗ check-no-in-process-placement: {} violation(s)",
+        outcome.violations.len()
+    );
+    for v in &outcome.violations {
+        eprintln!(
+            "  {}:{}: banned placement vocabulary `{}` — {}. See docs/decisions/helper-process-placement-only.md",
+            v.file.display(),
+            v.line,
+            v.matched,
+            v.guidance,
+        );
+    }
+    anyhow::bail!(
+        "in-process placement lint failed: {} violation(s)",
+        outcome.violations.len()
+    );
+}
+
+/// The retracted spike tree must stay deleted: a green vocabulary scan over a
+/// resurrected `spikes/` would still leave its published tables in the tree.
+fn ensure_forbidden_tree_absent(workspace_root: &Path) -> Result<()> {
+    let tree = workspace_root.join(FORBIDDEN_TREE);
+    anyhow::ensure!(
+        !tree.exists(),
+        "{}/ is back in the tree — it published the retracted #1702 latency numbers and was \
+         deleted with the in-process-hosting rip-out. See docs/decisions/helper-process-placement-only.md",
+        FORBIDDEN_TREE
+    );
+    Ok(())
+}
+
+pub fn lint_workspace(workspace_root: &Path) -> Result<LintOutcome> {
+    let mut outcome = LintOutcome::default();
+    for parent in SCAN_PARENTS {
+        let dir = workspace_root.join(parent);
+        if !dir.exists() {
+            continue;
+        }
+        scan_dir(workspace_root, &dir, &mut outcome)?;
+    }
+    Ok(outcome)
+}
+
+fn scan_dir(workspace_root: &Path, dir: &Path, outcome: &mut LintOutcome) -> Result<()> {
+    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let path_str = path.to_string_lossy();
+        if SKIP_PATH_FRAGMENTS.iter().any(|frag| path_str.contains(frag)) {
+            continue;
+        }
+        let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        if !SCAN_EXTENSIONS.contains(&extension) {
+            continue;
+        }
+        scan_file(workspace_root, path, extension, outcome)?;
+    }
+    Ok(())
+}
+
+fn scan_file(
+    workspace_root: &Path,
+    path: &Path,
+    extension: &str,
+    outcome: &mut LintOutcome,
+) -> Result<()> {
+    let body =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    outcome.files_scanned += 1;
+    if body.contains(ALLOW_FILE_PRAGMA) {
+        outcome.allow_filed.push(path.to_path_buf());
+        return Ok(());
+    }
+
+    let relative = path
+        .strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    // Supersession spans are a markdown convention; a stray `~~` in Rust or YAML
+    // is not one, so only markdown gets the state machine and the odd-count refusal.
+    let is_markdown = extension == "md";
+    if is_markdown {
+        ensure_supersession_spans_balanced(path, &body)?;
+    }
+
+    let mut inside_span = false;
+    for (idx, line) in body.lines().enumerate() {
+        let scanned = if is_markdown {
+            strip_supersession_spans(line, &mut inside_span)
+        } else {
+            line.to_string()
+        };
+        if scanned.trim().is_empty() {
+            continue;
+        }
+        if is_exempt_prohibition_line(&relative, line) {
+            outcome.exempt_lines_hit += 1;
+            continue;
+        }
+        if let Some((matched, guidance)) = first_banned_shape(&scanned) {
+            outcome.violations.push(LintViolation {
+                file: path.to_path_buf(),
+                line: idx + 1,
+                matched,
+                guidance,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn is_exempt_prohibition_line(relative_path: &str, line: &str) -> bool {
+    EXEMPT_PROHIBITION_LINES
+        .iter()
+        .any(|(path, text)| *path == relative_path && line.trim() == *text)
+}
+
+/// An unterminated `~~` would silently swallow the whole rest of the file, so a
+/// file whose spans do not close is refused rather than scanned.
+fn ensure_supersession_spans_balanced(path: &Path, body: &str) -> Result<()> {
+    let markers = body.matches("~~").count();
+    anyhow::ensure!(
+        markers.is_multiple_of(2),
+        "{}: {} `~~` marker(s) — an unterminated supersession span would hide every line after it \
+         from check-no-in-process-placement. Close the span.",
+        path.display(),
+        markers
+    );
+    Ok(())
+}
+
+/// Return the portion of `line` outside `~~…~~`, carrying span state across
+/// lines. Handles a span opening on one line and closing on a later one, and
+/// two complete spans on a single line.
+fn strip_supersession_spans(line: &str, inside_span: &mut bool) -> String {
+    let mut outside = String::new();
+    let mut rest = line;
+    loop {
+        match rest.find("~~") {
+            Some(pos) => {
+                if !*inside_span {
+                    outside.push_str(&rest[..pos]);
+                }
+                *inside_span = !*inside_span;
+                rest = &rest[pos + 2..];
+            }
+            None => {
+                if !*inside_span {
+                    outside.push_str(rest);
+                }
+                return outside;
+            }
+        }
+    }
+}
+
+fn first_banned_shape(line: &str) -> Option<(String, &'static str)> {
+    let haystack = line.to_ascii_lowercase();
+    for (index, shape) in BANNED_SHAPES.iter().enumerate() {
+        if index == WATCHDOG_SHAPE_INDEX
+            && !WATCHDOG_NOUNS.iter().any(|noun| haystack.contains(noun))
+        {
+            continue;
+        }
+        if !shape.all_of.iter().all(|term| haystack.contains(term)) {
+            continue;
+        }
+        let any_hit = if shape.any_of.is_empty() {
+            None
+        } else {
+            match shape.any_of.iter().find(|term| haystack.contains(**term)) {
+                Some(term) => Some(*term),
+                None => continue,
+            }
+        };
+        let matched = any_hit
+            .map(str::to_string)
+            .unwrap_or_else(|| shape.all_of.join(" + "));
+        return Some((matched, shape.guidance));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    fn lint(dir: &Path) -> Vec<LintViolation> {
+        lint_workspace(dir).unwrap().violations
+    }
+
+    /// Every banned shape, red on the violating phrasing and green on the
+    /// legitimate near-miss that motivated its pairing.
+    #[test]
+    fn flags_shared_interpreter_claims_about_processors() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "//! One interpreter runs every Python processor.\npub fn ok() {}\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn allows_one_interpreter_prose_that_names_no_processor() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sdk/foo/pyproject.toml",
+            "# one interpreter's stale `.pyc` files inside an abi3 wheel.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn flags_gil_contention() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "/// Reports GIL contention across the graph.\npub fn ok() {}\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn flags_a_gil_stall_attributed_to_a_processor() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "//! Holding the GIL stalls every other Python processor.\npub fn ok() {}\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// The GIL-release contract is about the child's own interpreter's threads —
+    /// the explicit boundary the ruling preserves, and the live doc comment in
+    /// `python_processor_link_data_access.rs`.
+    #[test]
+    fn allows_the_gil_release_contract_about_its_own_threads() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sdk/foo/src/data_access.rs",
+            "//! Holding the GIL across that call would stall the interpreter's other threads.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn flags_the_watchdog_family() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "/// The dev-mode GIL-hold watchdog.\npub fn ok() {}\n",
+        );
+        write(
+            tmp.path(),
+            "runtime/bar/src/lib.rs",
+            "/// A slow-callback monitor for the graph.\npub fn ok() {}\n",
+        );
+        write(
+            tmp.path(),
+            "runtime/baz/src/lib.rs",
+            "/// Stall-attribution detector.\npub fn ok() {}\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 3);
+    }
+
+    /// Bare `watchdog` is the engine's own EPOLLHUP surface-share reaper, and a
+    /// `GIL-holding thread` is ordinary description. Neither is the ban.
+    #[test]
+    fn allows_a_watchdog_that_is_not_a_gil_diagnostic() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "/// EPOLLHUP watchdog: releases surfaces after a subprocess disconnect.\n\
+             /// Safe for any GIL-holding thread reading the handle.\npub fn ok() {}\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn flags_both_placements_viable_but_not_the_bare_phrase() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/foo.md",
+            "The measured gap makes both placements viable.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/bar.md",
+            "Rejected alternative: both placements, engine-chosen.\n",
+        );
+        let violations = lint(tmp.path());
+        assert_eq!(violations.len(), 1, "got {violations:?}");
+        assert_eq!(violations[0].matched, "both placements viable");
+    }
+
+    #[test]
+    fn flags_in_process_placement_hosting_and_authoring() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "docs/architecture/a.md", "In-process placement.\n");
+        write(tmp.path(), "docs/architecture/b.md", "In-process hosting.\n");
+        write(tmp.path(), "docs/architecture/c.md", "In-process authoring.\n");
+        assert_eq!(lint(tmp.path()).len(), 3);
+    }
+
+    /// In-process *Rust* is a different concern wearing the same two words.
+    #[test]
+    fn allows_in_process_rust() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "/// Mints an in-process `FullAccess` context for the adapter fast path.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn flags_the_retracted_spike_literals() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/perf.md",
+            "p50 0.085ms in-process vs 0.161 ms subprocess; warm 0.089ms / 0.180ms.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    /// The literals are ms-anchored on purpose — bare decimals collide with
+    /// every tolerance constant in the tree.
+    #[test]
+    fn allows_bare_decimals_that_are_not_the_retracted_numbers() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/src/lib.rs",
+            "const PSNR_TOLERANCE: f64 = 0.085;\nconst DRIFT: f64 = 0.161;\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn skips_a_supersession_span_that_spans_lines() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "> ~~the measured gap makes both placements viable, so placement is\n\
+             > demoted to engine policy~~ — Superseded 2026-08-04. There is one placement.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn scans_the_retraction_prose_that_follows_a_closed_span() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "> ~~old claim~~ — Superseded: in-process hosting is banned outright.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn skips_two_spans_on_one_line() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "~~in-process hosting~~ and ~~both placements viable~~ are both retracted.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn refuses_a_file_with_an_unterminated_span() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "~~an opened span that never closes\nin-process hosting sails through.\n",
+        );
+        let err = lint_workspace(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("unterminated supersession span"), "got {err}");
+    }
+
+    #[test]
+    fn skips_a_file_carrying_the_allow_pragma() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/decisions/a.md",
+            "<!-- check-no-in-process-placement:allow-file -->\nIn-process hosting is banned.\n",
+        );
+        let outcome = lint_workspace(tmp.path()).unwrap();
+        assert!(outcome.violations.is_empty());
+        assert_eq!(outcome.allow_filed.len(), 1);
+    }
+
+    #[test]
+    fn exempts_a_prohibition_line_but_not_its_neighbours() {
+        let tmp = TempDir::new().unwrap();
+        let (path, text) = EXEMPT_PROHIBITION_LINES[0];
+        write(
+            tmp.path(),
+            path,
+            &format!("{text}\n  In-process hosting is the fast path.\n"),
+        );
+        let outcome = lint_workspace(tmp.path()).unwrap();
+        assert_eq!(outcome.exempt_lines_hit, 1);
+        assert_eq!(outcome.violations.len(), 1, "got {:?}", outcome.violations);
+        assert_eq!(outcome.violations[0].line, 2);
+    }
+
+    /// Exact-text matching is the point: an edited prohibition line loses its
+    /// exemption and goes back through review.
+    #[test]
+    fn an_edited_prohibition_line_loses_its_exemption() {
+        let tmp = TempDir::new().unwrap();
+        let (path, text) = EXEMPT_PROHIBITION_LINES[0];
+        write(tmp.path(), path, &format!("{text} (mostly)\n"));
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn skips_target_and_generated_dirs() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "runtime/foo/target/debug/build.rs",
+            "//! In-process hosting.\n",
+        );
+        write(
+            tmp.path(),
+            "runtime/foo/_generated_/mod.rs",
+            "//! In-process hosting.\n",
+        );
+        assert!(lint(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn refuses_a_run_that_read_no_source() {
+        let tmp = TempDir::new().unwrap();
+        let outcome = lint_workspace(tmp.path()).unwrap();
+        let err = ensure_source_walking_gate_read_source(
+            "check-no-in-process-placement",
+            "the scan roots",
+            outcome.files_scanned,
+            "in-process placement vocabulary re-enter the tree",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("scanned 0 files"), "got {err}");
+    }
+
+    #[test]
+    fn refuses_a_resurrected_spike_tree() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "spikes/streamlib-pyembed-spike/README.md", "\n");
+        let err = ensure_forbidden_tree_absent(tmp.path())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("retracted"), "got {err}");
+    }
+
+    // --- assertions against the real tree ---
+
+    fn workspace() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .to_path_buf()
+    }
+
+    #[test]
+    fn the_workspace_is_clean() {
+        let outcome = lint_workspace(&workspace()).unwrap();
+        assert!(
+            outcome.violations.is_empty(),
+            "got {:?}",
+            outcome.violations
+        );
+    }
+
+    #[test]
+    fn the_allow_file_set_is_exactly_the_expected_documents() {
+        let root = workspace();
+        let mut found: Vec<String> = lint_workspace(&root)
+            .unwrap()
+            .allow_filed
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&root)
+                    .unwrap_or(p)
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        found.sort();
+        let mut expected: Vec<String> = EXPECTED_ALLOW_FILE_PATHS
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        expected.sort();
+        assert_eq!(
+            found, expected,
+            "the allow-file set changed — every member must be a document that quotes the banned \
+             vocabulary in order to retract it"
+        );
+    }
+
+    /// The list only shrinks: a stale entry means the prohibition it exempted is
+    /// gone from the document, so the entry goes too.
+    #[test]
+    fn exempt_prohibition_lines_are_all_live() {
+        let root = workspace();
+        for (rel, text) in EXEMPT_PROHIBITION_LINES {
+            let body = fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|e| panic!("{rel}: {e}"));
+            assert!(
+                body.lines().any(|line| line.trim() == *text),
+                "{rel} no longer contains the exempted prohibition line `{text}` — delete the \
+                 stale EXEMPT_PROHIBITION_LINES entry"
+            );
+        }
+    }
+
+    #[test]
+    fn every_exempt_prohibition_line_is_under_the_plan_directory() {
+        for (rel, _) in EXEMPT_PROHIBITION_LINES {
+            assert!(
+                rel.starts_with("docs/plan/"),
+                "{rel} is editable by a source session — give it the allow-file pragma instead"
+            );
+        }
+    }
+}

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -45,22 +45,22 @@
 //!   processor class is `sdk/streamlib-python-wheel/tests/test_helper_placement.py`.
 //! - **The pattern set is a subset of the rule's STOP-WORK vocabulary, not the
 //!   whole of it**, and the list below is not exhaustive either. Probed misses:
-//!   `share a GIL`, the runtime described as "one process" or "one big process",
-//!   in-process called "lowest latency", a per-callback duration monitor naming
-//!   another processor, co-hosting described as shortening an escalate hop,
-//!   registering the class "in the parent process", a per-processor "placement
-//!   decision" or "placement choice", and any paraphrase of the retracted
-//!   numbers — "roughly half the subprocess latency", "0.6% of a frame budget"
-//!   — which no literal list catches. A green run means these patterns are
-//!   absent, never that the rule is satisfied; the reviewers are the coverage
-//!   for the rest.
-//! - **Matching is per line, and this repo's prose hard-wraps.** A banned
-//!   sentence that wraps between two of its terms passes, and so does a denial
-//!   that wraps away from what it denies — which is why
-//!   [`EXEMPT_PROHIBITION_LINES`] carries wrapped halves of prohibitions that
-//!   read as claims on their own. A two-line window was tried and reverted: it
-//!   caught three wrapped violations and invented four false positives on the
-//!   rule's protected boundary, which is the trade the rule explicitly forbids.
+//!   the runtime described as "one process" or "one big process" (the same two
+//!   words state the correct model — one process *per* processor), registering
+//!   the class "in the parent process", a per-callback duration monitor naming
+//!   another processor, a per-processor "placement decision" or "placement
+//!   choice", and any paraphrase of the retracted numbers — "roughly half the
+//!   subprocess latency", "0.6% of a frame budget" — which no literal list
+//!   catches. A green run means these patterns are absent, never that the rule
+//!   is satisfied; the reviewers are the coverage for the rest.
+//! - **A banned phrase split by a line wrap is caught; a paired-term rule whose
+//!   terms land on different lines is not.** [`wrapped_banned_phrase`] explains
+//!   why the second half is deliberate rather than missing.
+//! - The contention shape is anchored to the word `GIL`, so a non-adjacent
+//!   phrasing — "reduces contention between processors", "the lock is contended
+//!   by both" — does not reach it. Bare `contention` flagged a processor's own
+//!   threads and bare `contended` flagged the surface adapter's lock prose;
+//!   anchoring is what keeps the shape from crying wolf.
 //! - `.claude/` and `.github/` are not scanned. The rules and reviewer
 //!   definitions quote the banned shapes to forbid them and change through their
 //!   own dedicated PRs; `.github/` is CI configuration, and this gate's own
@@ -140,6 +140,10 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
         "In-process hosting of a Python processor does not exist — not as a default, a",
     ),
     (
+        "docs/plan/ARCHITECTURE.md",
+        "co-tenancy remedy: no two Python processors share an interpreter.",
+    ),
+    (
         "docs/plan/GLOSSARY.md",
         "in-process hosting of a Python processor does not exist. Native built-ins running in",
     ),
@@ -158,6 +162,16 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
     (
         "docs/plan/changes/importable-python-library.md",
         "(A \"dev-mode GIL-hold watchdog\" clause was removed here 2026-08-04: it measured",
+    ),
+    // Wrapped halves: the phrase splits across the line break, so the line the
+    // violation reports on carries only the tail of a prohibition.
+    (
+        "docs/plan/changes/processor-class-identity.md",
+        "hosting of a Python processor is banned, so a `__main__`-defined class has no legal",
+    ),
+    (
+        "docs/decisions/importable-python-library.md",
+        "interpreter — it is the performance bar, never a placement precedent). Dogfooding",
     ),
     // "…never a co-tenancy test, since no two Python / processors share an
     // interpreter" — the denial wrapped away from what it denies.
@@ -207,13 +221,19 @@ const EXEMPT_PROHIBITION_LINES: &[(&str, &str)] = &[
 ];
 
 /// A banned shape. `all_of` terms must every one appear; `any_of` and
-/// `also_requires_any_of` — when non-empty — each need one hit; a hit on
-/// `unless_any_of` clears the shape. All matching is ASCII-case-insensitive.
+/// `also_requires_any_of` — when non-empty — each need one hit. All matching is
+/// case-insensitive over a [`normalize`]d line.
+///
+/// There is deliberately no negative term. A "unless the line also says
+/// `helper`" clause was tried and removed: it cleared the whole shape on a
+/// substring hit anywhere on the line, so `When no helper is available the
+/// app's interpreter hosts the processor class` — the ADR's named `not a
+/// fallback` shape — passed green. A prohibition that needs quarter is a line
+/// in [`EXEMPT_PROHIBITION_LINES`], which names the file and the exact text.
 struct BannedShape {
     all_of: &'static [&'static str],
     any_of: &'static [&'static str],
     also_requires_any_of: &'static [&'static str],
-    unless_any_of: &'static [&'static str],
     guidance: &'static str,
 }
 
@@ -251,8 +271,25 @@ const BANNED_SHAPES: &[BannedShape] = &[
             "parent interpreter",
         ],
         also_requires_any_of: &[],
-        unless_any_of: CO_TENANCY_BOUNDARY,
         guidance: CO_TENANCY_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["processor"],
+        any_of: &["share a gil", "shares a gil", "sharing a gil", "share the gil", "share one gil", "shared gil"],
+        also_requires_any_of: &[],
+        guidance: CO_TENANCY_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["processor"],
+        any_of: &["co-host", "cohost"],
+        also_requires_any_of: &[],
+        guidance: PLACEMENT_GUIDANCE,
+    },
+    BannedShape {
+        all_of: &["in-process", "lowest latency"],
+        any_of: &[],
+        also_requires_any_of: &[],
+        guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
@@ -261,31 +298,28 @@ const BANNED_SHAPES: &[BannedShape] = &[
             "gil-contention",
             "contend for the gil",
             "contending for the gil",
-            "contend for one",
+            "gil is contended",
+            "contended gil",
         ],
         also_requires_any_of: &[],
-        unless_any_of: &[],
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
         all_of: &["gil"],
         any_of: &["stall", "block", "starve", "degrade"],
         also_requires_any_of: &["other processor", "another processor", "other python processor"],
-        unless_any_of: &[],
         guidance: CO_TENANCY_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["gil-hold", "gil hold", "slow-callback", "slow callback", "stall-attribution", "stall attribution"],
         also_requires_any_of: WATCHDOG_NOUNS,
-        unless_any_of: &[],
         guidance: DIAGNOSTIC_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: RETIRED_PLACEMENT_TERMS,
         also_requires_any_of: &[],
-        unless_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
@@ -299,30 +333,22 @@ const BANNED_SHAPES: &[BannedShape] = &[
             "in process authoring",
         ],
         also_requires_any_of: &[],
-        unless_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &["in-process", "python processor"],
         any_of: &[],
         also_requires_any_of: &[],
-        unless_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
     BannedShape {
         all_of: &[],
         any_of: &["0.085ms", "0.085 ms", "0.161ms", "0.161 ms", "0.089ms", "0.089 ms", "0.180ms", "0.180 ms"],
         also_requires_any_of: &[],
-        unless_any_of: &[],
         guidance: RETRACTED_NUMBERS_GUIDANCE,
     },
 ];
 
-/// The rule's protected boundary for the co-tenancy shape. A helper's or
-/// child's own interpreter is the shipped model; `its own interpreter` is what
-/// every Python processor has.
-const CO_TENANCY_BOUNDARY: &[&str] =
-    &["helper", "child", "own interpreter", "its own", "their own", "no two"];
 
 /// The watchdog family needs its diagnostic name *and* a monitor noun, or
 /// every `GIL-holding thread` doc comment trips it.
@@ -571,6 +597,7 @@ fn scan_file(
     }
 
     let mut spans = SupersessionSpanState::default();
+    let mut previous = String::new();
     for (idx, line) in body.lines().enumerate() {
         let scanned = if is_markdown {
             spans.outside_spans(line)
@@ -578,13 +605,17 @@ fn scan_file(
             Cow::Borrowed(line)
         };
         if scanned.trim().is_empty() {
+            previous.clear();
             continue;
         }
         if is_exempt_prohibition_line(&relative, line) {
             report.exempt_lines_hit += 1;
+            previous.clear();
             continue;
         }
-        if let Some(hit) = first_banned_shape(&scanned) {
+        let hit = first_banned_shape(&scanned)
+            .or_else(|| wrapped_banned_phrase(&previous, &scanned));
+        if let Some(hit) = hit {
             report.violations.push(LintViolation {
                 file: path.to_path_buf(),
                 line: idx + 1,
@@ -592,6 +623,7 @@ fn scan_file(
                 guidance: hit.guidance,
             });
         }
+        previous = scanned.into_owned();
     }
     Ok(())
 }
@@ -663,37 +695,82 @@ impl SupersessionSpanState {
     }
 }
 
+/// Fold the prose spellings that differ from the pattern literals only by a
+/// character an editor substituted: the hyphen family (a non-breaking hyphen in
+/// `in‑process` is invisible in a diff) and the curly apostrophe in
+/// `app's interpreter`.
+fn normalize(line: &str) -> String {
+    line.chars()
+        .map(|c| match c {
+            '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' => '-',
+            '\u{2018}' | '\u{2019}' => '\'',
+            other => other.to_ascii_lowercase(),
+        })
+        .collect()
+}
+
 fn first_banned_shape(line: &str) -> Option<BannedShapeMatch> {
-    let haystack = line.to_ascii_lowercase();
-    for shape in BANNED_SHAPES {
-        if !shape.all_of.iter().all(|term| haystack.contains(term)) {
-            continue;
+    let haystack = normalize(line);
+    BANNED_SHAPES
+        .iter()
+        .find_map(|shape| shape.match_in(&haystack))
+}
+
+/// The wrap case: a banned *phrase* split across a line break. This repo's
+/// prose hard-wraps, so `in-process` / `hosting` and `one shared` /
+/// `interpreter` happen with no intent to evade.
+///
+/// Deliberately narrower than joining the two lines and re-running everything.
+/// A whole-window scan also pairs terms that merely landed on adjacent lines,
+/// and adjacent prose lines routinely share a word — that trade cost four false
+/// positives on the rule's protected boundary, which is exactly what
+/// `.claude/rules/placement.md` says must not happen. A multi-word term absent
+/// from both lines but present across the seam is the real phrase, every time.
+fn wrapped_banned_phrase(previous: &str, current: &str) -> Option<BannedShapeMatch> {
+    if previous.is_empty() {
+        return None;
+    }
+    let before = normalize(previous);
+    let after = normalize(current);
+    let seam = format!("{before} {after}");
+    BANNED_SHAPES.iter().find_map(|shape| {
+        let splits_the_seam = shape
+            .all_of
+            .iter()
+            .chain(shape.any_of.iter())
+            .filter(|term| term.contains(' '))
+            .any(|term| seam.contains(term) && !before.contains(term) && !after.contains(term));
+        if !splits_the_seam {
+            return None;
         }
-        if shape.unless_any_of.iter().any(|term| haystack.contains(term)) {
-            continue;
+        shape.match_in(&seam)
+    })
+}
+
+impl BannedShape {
+    /// `haystack` must already be [`normalize`]d.
+    fn match_in(&self, haystack: &str) -> Option<BannedShapeMatch> {
+        if !self.all_of.iter().all(|term| haystack.contains(term)) {
+            return None;
         }
-        if !shape.also_requires_any_of.is_empty()
-            && !shape
+        if !self.also_requires_any_of.is_empty()
+            && !self
                 .also_requires_any_of
                 .iter()
                 .any(|term| haystack.contains(term))
         {
-            continue;
+            return None;
         }
-        let matched = if shape.any_of.is_empty() {
-            Cow::Owned(shape.all_of.join(" + "))
+        let matched = if self.any_of.is_empty() {
+            Cow::Owned(self.all_of.join(" + "))
         } else {
-            match shape.any_of.iter().copied().find(|t| haystack.contains(t)) {
-                Some(term) => Cow::Borrowed(term),
-                None => continue,
-            }
+            Cow::Borrowed(self.any_of.iter().copied().find(|t| haystack.contains(t))?)
         };
-        return Some(BannedShapeMatch {
+        Some(BannedShapeMatch {
             matched,
-            guidance: shape.guidance,
-        });
+            guidance: self.guidance,
+        })
     }
-    None
 }
 
 #[cfg(test)]
@@ -843,23 +920,40 @@ mod tests {
         assert_eq!(lint(tmp.path()).len(), 3);
     }
 
-    /// A helper's own interpreter is the shipped model, not a violation of it —
-    /// the rule's "these are NOT the ban" boundary, which a bare
-    /// `same interpreter` + `processor` rule flagged.
+    /// Each processor having *its own* interpreter is the shipped model, and it
+    /// matches no pattern — the co-tenancy shape names sharing, not ownership.
+    /// No negative term is needed, and none exists.
     #[test]
-    fn allows_a_helper_running_the_class_in_its_own_interpreter() {
+    fn allows_a_processor_owning_its_interpreter() {
         let tmp = TempDir::new().unwrap();
         write(
             tmp.path(),
             "docs/architecture/a.md",
-            "The helper imports the wheel into the same interpreter that runs the processor class.\n",
-        );
-        write(
-            tmp.path(),
-            "docs/architecture/b.md",
             "Every Python processor gets its own interpreter in its own child process.\n",
         );
-        assert!(lint(tmp.path()).is_empty());
+        assert!(lint(tmp.path()).is_empty(), "{:?}", lint(tmp.path()));
+    }
+
+    /// Naming the helper, the child, or a processor's own anything must not buy
+    /// a sentence clemency. An `unless_any_of` boundary let all seven of these
+    /// through — including the ADR's named "not a fallback" shape — for the sake
+    /// of one plan line that `EXEMPT_PROHIBITION_LINES` now carries by name.
+    #[test]
+    fn boundary_words_do_not_excuse_a_co_tenancy_claim() {
+        let sentences = [
+            "When no helper is available the app's interpreter hosts the processor class.",
+            "The helper pool runs several Python processors in one interpreter.",
+            "Two Python processors share an interpreter inside the child process.",
+            "The processor class is imported into the parent interpreter whenever the helper spawn fails.",
+            "A processor may run in the same interpreter as the app if it declares its own low-latency mode.",
+            "No two processors share an interpreter unless the helper opts them in.",
+            "Several processors share one interpreter and their own GIL is shared between them.",
+        ];
+        for (index, sentence) in sentences.iter().enumerate() {
+            let tmp = TempDir::new().unwrap();
+            write(tmp.path(), "docs/architecture/a.md", &format!("{sentence}\n"));
+            assert_eq!(lint(tmp.path()).len(), 1, "sentence {index} passed: {sentence}");
+        }
     }
 
     #[test]
@@ -939,6 +1033,88 @@ mod tests {
             "* **python:** in-process authoring\n",
         );
         assert!(lint(tmp.path()).is_empty());
+    }
+
+    /// This repo's prose hard-wraps; a banned phrase splitting across the break
+    /// is the phrase, not a coincidence.
+    #[test]
+    fn flags_a_banned_phrase_split_by_a_line_wrap() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "A change that reintroduces in-process\nhosting is a regression.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "Holoscan acquires the GIL in one shared\ninterpreter for every processor.\n",
+        );
+        let violations = lint(tmp.path());
+        assert_eq!(violations.len(), 2, "got {violations:?}");
+        assert!(violations.iter().all(|v| v.line == 2), "got {violations:?}");
+    }
+
+    /// The reason the wrap check is phrase-only: adjacent prose lines routinely
+    /// share a word, and pairing across the break flagged the rule's protected
+    /// boundary — here, a true sentence about what the app's interpreter never
+    /// loaded.
+    #[test]
+    fn does_not_pair_terms_that_merely_landed_on_adjacent_lines() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "sdk/foo/tests/a.py",
+            "# Only a parent can see that the app's interpreter never loaded a second copy\n             # of the processor's module.\n",
+        );
+        assert!(lint(tmp.path()).is_empty(), "{:?}", lint(tmp.path()));
+    }
+
+    /// An editor's non-breaking hyphen and curly apostrophe are invisible in a
+    /// diff and would otherwise walk straight past the pattern literals.
+    #[test]
+    fn flags_prose_spelled_with_unicode_punctuation() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "docs/architecture/a.md", "In\u{2011}process hosting is back.\n");
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "Hosting a Python processor in the app\u{2019}s interpreter is the fast path.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 2);
+    }
+
+    #[test]
+    fn flags_processors_sharing_a_gil() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Two Python processors share a GIL, so one can block the other.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn flags_co_hosting_a_processor() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "The processor is co-hosted in the parent to shorten the escalate hop.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn flags_in_process_called_lowest_latency() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Running in-process is the lowest latency option.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 1);
     }
 
     #[test]

--- a/xtask/src/check_no_in_process_placement.rs
+++ b/xtask/src/check_no_in_process_placement.rs
@@ -49,10 +49,21 @@
 //!   words state the correct model — one process *per* processor), registering
 //!   the class "in the parent process", a per-callback duration monitor naming
 //!   another processor, a per-processor "placement decision" or "placement
-//!   choice", and any paraphrase of the retracted numbers — "roughly half the
-//!   subprocess latency", "0.6% of a frame budget" — which no literal list
-//!   catches. A green run means these patterns are absent, never that the rule
-//!   is satisfied; the reviewers are the coverage for the rest.
+//!   choice", `in-process` beside a Python processor (tried as a shape and
+//!   removed — it fires on the boundary, where built-ins and in-process Rust
+//!   are discussed alongside processors), and any paraphrase of the retracted
+//!   numbers — "roughly half the subprocess latency", "0.6% of a frame budget"
+//!   — which no literal list catches. A green run means these patterns are
+//!   absent, never that the rule is satisfied; the reviewers are the coverage
+//!   for the rest.
+//! - **Matching is by fixed substring, so one interposed adjective defeats a
+//!   determiner form.** `same interpreter` is caught; `same Python interpreter`
+//!   is not, and neither are `one CPython interpreter`, `app's embedded
+//!   interpreter`, or `app's own interpreter`. Closing that family properly
+//!   needs token-proximity matching rather than substring matching — a
+//!   different matcher than this gate was commissioned with, and one whose
+//!   false-positive cost against `one interpreter per processor` (the correct
+//!   model, stated in the banned shape's own words) has not been measured.
 //! - **A banned phrase split by a line wrap is caught; a paired-term rule whose
 //!   terms land on different lines is not.** [`wrapped_banned_phrase`] explains
 //!   why the second half is deliberate rather than missing.
@@ -266,6 +277,11 @@ const BANNED_SHAPES: &[BannedShape] = &[
             "share an interpreter",
             "shares an interpreter",
             "sharing an interpreter",
+            "share the interpreter",
+            "shares the interpreter",
+            "sharing the interpreter",
+            "share interpreters",
+            "shares interpreters",
             "app's interpreter",
             "parent's interpreter",
             "parent interpreter",
@@ -275,7 +291,16 @@ const BANNED_SHAPES: &[BannedShape] = &[
     },
     BannedShape {
         all_of: &["processor"],
-        any_of: &["share a gil", "shares a gil", "sharing a gil", "share the gil", "share one gil", "shared gil"],
+        any_of: &[
+            "share a gil",
+            "shares a gil",
+            "sharing a gil",
+            "share the gil",
+            "share one gil",
+            "shared gil",
+            "share a python gil",
+            "share the python gil",
+        ],
         also_requires_any_of: &[],
         guidance: CO_TENANCY_GUIDANCE,
     },
@@ -332,12 +357,6 @@ const BANNED_SHAPES: &[BannedShape] = &[
             "in process hosting",
             "in process authoring",
         ],
-        also_requires_any_of: &[],
-        guidance: PLACEMENT_GUIDANCE,
-    },
-    BannedShape {
-        all_of: &["in-process", "python processor"],
-        any_of: &[],
         also_requires_any_of: &[],
         guidance: PLACEMENT_GUIDANCE,
     },
@@ -720,12 +739,16 @@ fn first_banned_shape(line: &str) -> Option<BannedShapeMatch> {
 /// prose hard-wraps, so `in-process` / `hosting` and `one shared` /
 /// `interpreter` happen with no intent to evade.
 ///
-/// Deliberately narrower than joining the two lines and re-running everything.
-/// A whole-window scan also pairs terms that merely landed on adjacent lines,
-/// and adjacent prose lines routinely share a word — that trade cost four false
-/// positives on the rule's protected boundary, which is exactly what
-/// `.claude/rules/placement.md` says must not happen. A multi-word term absent
-/// from both lines but present across the seam is the real phrase, every time.
+/// Narrower than joining every pair of lines and re-running everything: the
+/// seam is evaluated only when a multi-word term is itself split by the break,
+/// which is strong evidence of the real phrase. A bare whole-window scan pairs
+/// terms that merely landed on adjacent lines, and adjacent prose lines
+/// routinely share a word — that cost four false positives on the rule's
+/// protected boundary, which `.claude/rules/placement.md` says must not happen.
+///
+/// Note what this still is: once a term straddles, the shape's *remaining*
+/// terms are matched over the joined window, so they may come from either line.
+/// The straddle is the admission ticket, not a per-term constraint.
 fn wrapped_banned_phrase(previous: &str, current: &str) -> Option<BannedShapeMatch> {
     if previous.is_empty() {
         return None;
@@ -994,13 +1017,57 @@ mod tests {
         assert!(lint(tmp.path()).is_empty());
     }
 
+    /// `in-process` beside `python processor` was tried as a shape and removed:
+    /// it fires on the rule's protected boundary, where native built-ins and
+    /// in-process Rust are discussed alongside Python processors — including in
+    /// the sentences that state the ban. Disclosed as a miss instead.
     #[test]
-    fn flags_in_process_beside_a_python_processor() {
+    fn allows_the_boundary_discussing_in_process_rust_beside_a_processor() {
         let tmp = TempDir::new().unwrap();
         write(
             tmp.path(),
             "docs/architecture/a.md",
-            "Python processors run in-process when latency matters.\n",
+            "The RHI mints an in-process FullAccess context; the Python processor reaches it \
+             only through the escalate hop.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "Native built-ins run in-process; a Python processor never does.\n",
+        );
+        assert!(lint(tmp.path()).is_empty(), "{:?}", lint(tmp.path()));
+    }
+
+    #[test]
+    fn flags_the_interpreter_sharing_determiners() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Two Python processors share the interpreter.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/b.md",
+            "The processors share interpreters.\n",
+        );
+        write(
+            tmp.path(),
+            "docs/architecture/c.md",
+            "Two Python processors share a Python GIL.\n",
+        );
+        assert_eq!(lint(tmp.path()).len(), 3);
+    }
+
+    /// A straddling term admits the seam, and the shape's other terms are then
+    /// matched across both lines. Locked so the behaviour is deliberate.
+    #[test]
+    fn a_straddling_phrase_pairs_the_shapes_other_terms_across_the_seam() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            "docs/architecture/a.md",
+            "Every Python processor is served by one shared\ninterpreter.\n",
         );
         assert_eq!(lint(tmp.path()).len(), 1);
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ pub mod check_cdylib_reach;
 pub mod check_consumer_rhi_repr;
 pub mod check_device_wait_idle;
 pub mod check_no_escalate_in_lifecycle;
+pub mod check_no_in_process_placement;
 pub mod check_no_inventory_submit;
 pub mod check_no_reverse_dns;
 pub mod check_no_streamlib_metadata;
@@ -138,6 +139,15 @@ enum Commands {
     /// `tests/`, `*_test{s}.rs`), and Rust comments are allowed. See
     /// `docs/architecture/schema-identity-and-packaging.md`.
     CheckNoReverseDns,
+
+    /// CI gate for the helper-process-placement-only ruling (owner
+    /// 2026-08-04). Fails on the vocabulary of the banned model anywhere in
+    /// the engine tree or `docs/`; the banned patterns and the two escape
+    /// hatches are enumerated in
+    /// [`check_no_in_process_placement`]. Markdown and Rust doc comments are
+    /// scanned on purpose — the shipped violation announced itself in a `//!`
+    /// line. See `docs/decisions/helper-process-placement-only.md`.
+    CheckNoInProcessPlacement,
 
     /// CI gate for #793's all-dynamic registration rule. Fails on any
     /// `inventory::submit!(FactoryRegistration { ... })` in live code —
@@ -329,6 +339,9 @@ fn main() -> Result<()> {
         Commands::CheckSchemaVersions => check_schema_versions::run(&workspace_root()?)?,
         Commands::CheckNoStreamlibMetadata => check_no_streamlib_metadata::run(&workspace_root()?)?,
         Commands::CheckNoReverseDns => check_no_reverse_dns::run(&workspace_root()?)?,
+        Commands::CheckNoInProcessPlacement => {
+            check_no_in_process_placement::run(&workspace_root()?)?
+        }
         Commands::CheckNoInventorySubmit => check_no_inventory_submit::run(&workspace_root()?)?,
         Commands::CheckProcessorSpecNew => check_processor_spec_new::run(&workspace_root()?)?,
         Commands::CheckProcessorSourceReachability => {


### PR DESCRIPTION
## Summary

`cargo xtask check-no-in-process-placement` + its CI workflow — the vocabulary half of the
enforcement the helper-placement pivot commissioned. Modeled on `check_no_reverse_dns.rs` with
the two deliberate inversions the ticket names: it **scans markdown and Rust doc comments on
purpose** (the shipped #1711 violation announced itself in a `//!` line, which an AST walk over
string literals cannot see), and it adds `docs/` to the scan roots plus an assertion that the
retracted `spikes/` tree stays deleted.

Part of the pattern set is **sourced from the projects the ADR cites rather than invented here**
(owner steer). dora-rs — the process-per-node model StreamLib adopts wholesale — ships the banned
shape under its own name: an *operator*, as against a *node*, "linked into a runtime process"
sharing "a single address space". CPython's PEP 684 calls the pre-3.12 behaviour a *shared* or
*process-wide GIL* and names the alternative the ADR rejects, a *subinterpreter* with a
*per-interpreter GIL*. `global interpreter lock` spelled out contains no `gil` substring and was
bypassing every shape keyed on the acronym.

Two escape hatches, both enforced by the gate itself rather than only by its tests:
`check-no-in-process-placement:allow-file` on **3** documents that must quote the vocabulary at
length to retract it, and **19** exact-text `EXEMPT_PROHIBITION_LINES` for prohibition statements
in `docs/plan/**` and `docs/decisions/**`. Per line rather than per file on purpose —
`ARCHITECTURE.md`, `GLOSSARY.md` and the 2026-08-02 pivot ADR are the documents the ruling names
as the drift vector, so blinding them wholesale would be the worst possible place to do it.

Two prose fixes outside the gate, both required for a green run:
`emit_app_process_python_log_record` still documented itself as emitting "from an in-process
Python processor" though #1714 had already renamed it, and #1754's helper-placement test docstring
described the ban in the banned words.

## Closes

Closes #1744

## Exit criteria

- [x] `xtask/src/check_no_in_process_placement.rs` + `.github/workflows/check-no-in-process-placement.yml` on the established gate shape, with markdown/doc-comment scanning and `docs/` + `spikes/`-absence stated in the module doc so nobody "fixes" it
- [x] Paired-term rules, the watchdog family, the retired placement terms, the `in-process` nouns, and the ms-anchored retracted literals
- [x] `~~…~~` supersession spans skipped via a per-file state machine (multi-line spans, two spans per line, `~~~` code fences), refusing a file whose spans do not close
- [x] Allow-file pragma set pinned and asserted against the real tree
- [x] Annotated exemption list, shrink-only, count printed on success
- [x] `ensure_source_walking_gate_read_source` wired, plus per-root liveness
- [x] Fixture tests: each pattern red **and** each legitimate near-miss green

## Test plan

- `cargo test --locked -p xtask` → **293 passed, 0 failed** (49 in this module: fixture tests plus four real-tree assertions — workspace clean, allow-file set exact, every scan root contributes, every exemption still live)
- `cargo run --locked -q -p xtask -- check-no-in-process-placement` → `✓ 1515 files scanned, 3 allow-file'd, 19 exempt prohibition line(s) matched`
- Injected a real violation (`// One interpreter runs every Python processor.`) into `runtime/streamlib-engine/src/lib.rs` → exit 1 with correct file:line and guidance; green on restore
- Full xtask gate battery, `lint-logging`, `check-boundaries`, and the CI unit-test tier all pass
- Reviewed over three `review-pr` rounds, one `rust-craftsmanship-reviewer` round, and an adversarial completeness sweep. One **blocker** was found and fixed: an `unless_any_of` boundary I added to silence a false positive behaved as a whole-line kill switch, letting seven co-tenancy sentences pass green — including the ADR's named "not a fallback" shape. The mechanism is deleted, not narrowed; all seven are now red fixtures.

## Notes for owner

**1. A decided rename was never executed, and it is the single biggest thing weakening this gate.**
The ADR closes: *""In-process" is retired as a word for the surviving app-process senses — the
glossary now says **app-process** — so the banned term stays unambiguous and greppable."* The tree
today is **399 `in-process` vs 6 `app-process`** (112 in `streamlib-engine`, 37 in
`docs/architecture`, 30 in `docs/plan`) — Vulkan contexts, statically-linked API servers, texture
caches, all legitimate app-process senses still wearing the banned word. I therefore had to **drop**
the strongest single pattern (`in-process` beside a Python processor): it fires on *"native
built-ins run in-process; a Python processor never does"*, which is the correct model and which
`.claude/rules/placement.md` explicitly protects. Mechanical, already decided, unlocks a materially
stronger gate. Not filed — it does not block M39.

**2. The archived change file now disagrees with the shipped gate.**
`docs/plan/changes/archive/2026-08-07-in-process-hosting-ripout.md` clause (5) says ban
`both placements viable`, *"never bare `both placements` — live legitimate use exists"*. There was
no live legitimate use; all five occurrences were already covered. Owner ruled 2026-08-07 that
`.claude/rules/placement.md` governs, so the gate bans the GLOSSARY's retired-terms list bare —
which is what forces **5 of the 19** exemptions. Wants a `/ship-change` correction to that clause.

**3. `placement.md`'s STOP-WORK list mixes two kinds of item.** Mechanizable vocabulary
(`in-process placement`, `gil-hold watchdog`) sits in the same list as judgment calls (prose calling
the runtime "one process"; anything "whose premise is" co-tenancy). Reading as one homogeneous list
invites exactly the mistake I made — building a gate that looks like it covers the list. Separating
the halves would cost no strictness. Offered, not done; it would go through `/propose-rule`.
Specifically **not** recommending any change to *"whose premise is"* — that clause is why #1711 is
catchable at all, since that watchdog used no banned word in its name.

**4. Two pre-existing docstrings from #1754** carry retrospective in-process prose that passes the
gate (`test_capability_contexts.py:136`, `test_graph_building.py:49`). Not from this diff, not
blocking; they would be swept by note 1's rename.

**5. Honest limits are stated in the module doc, not implied by omission** — vocabulary not
behaviour; a subset of the rule's STOP-WORK list (the runtime called "one process" is unreachable,
since the same two words state the correct model); fixed-substring matching, so one interposed
adjective defeats a determiner form; `.claude/`, `.github/` and `CHANGELOG.md` unscanned. `.txt` /
`.rst` / `.json` are also outside `SCAN_EXTENSIONS` and clean today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated placement-policy check covering source code, documentation, diagrams, and configuration.
  * Added a command-line check that reports prohibited terminology and related references with actionable guidance.
  * Added comprehensive validation for exclusions, generated files, coverage, and real-workspace safeguards.

* **Documentation**
  * Clarified logging and test documentation to reflect current terminology and runtime behavior.

* **CI**
  * Added automated checks for pushes and pull requests targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->