### PR TITLE
test(cli): prove the MVP minute with every processor in its own interpreter

### DIFF
--- a/sdk/streamlib-python-wheel/tests/first_frame_reporter.py
+++ b/sdk/streamlib-python-wheel/tests/first_frame_reporter.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""A processor that announces the process it is running in.
+
+Copied into an app directory beside its entry file, which is the import shape a
+helper child resolves off `PYTHONPATH` when the processor does not live in a
+package. It reports on its first frame rather than at startup: a child that
+spawned but never received traffic has not made the pipeline live.
+"""
+
+import os
+
+from streamlib import input, log, processor  # noqa: A004 — streamlib's port decorator
+
+
+@processor
+class ReportsItsProcessOnFirstFrame:
+    """Announces its own process the first time a frame reaches it."""
+
+    def __init__(self) -> None:
+        self.announced = False
+
+    @input(delivery_profile="latest")
+    def video_from_upstream(self) -> None: ...
+
+    def process(self, ctx) -> None:
+        if self.announced or ctx.inputs.read("video_from_upstream") is None:
+            return
+        self.announced = True
+        log.info(f"MARKER:LIVE {os.getpid()}")

--- a/sdk/streamlib-python-wheel/tests/test_cli.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli.py
@@ -200,6 +200,37 @@ def test_a_syntax_error_prints_the_apps_traceback_and_builds_no_engine(tmp_path:
     )
 
 
+def test_a_bad_save_in_the_effect_module_names_that_module_not_the_entry_file(
+    tmp_path: Path,
+):
+    """The bad save the scaffold actually invites.
+
+    `app.py` holds wiring the user rarely touches; the file they edit is the
+    processor module, which reaches the launcher only as an import from the
+    entry file. So the traceback has to walk through `app.py` and land in the
+    module — naming only the entry file would point at the wrong file.
+    """
+    app_directory = tmp_path / "demo"
+    cli.scaffold_new_app(app_directory, use_test_pattern_source=True)
+    (app_directory / "processors" / "inverting_effect.py").write_text(
+        "def process(self ctx:\n    this does not parse\n"
+    )
+
+    finished = run_cli("dev", "--dir", str(app_directory))
+
+    assert finished.returncode == 1, f"stderr was:\n{finished.stderr}"
+    assert "SyntaxError" in finished.stderr, (
+        f"the user's own error must be the headline; stderr was:\n{finished.stderr}"
+    )
+    assert "inverting_effect.py" in finished.stderr, (
+        f"the traceback must name the module the user edited; stderr was:\n"
+        f"{finished.stderr}"
+    )
+    assert "Initializing GPU context" not in finished.stdout + finished.stderr, (
+        "a module that cannot be imported must not cost an engine boot"
+    )
+
+
 def test_a_raise_at_import_time_surfaces_as_the_apps_traceback(tmp_path: Path):
     write_app(tmp_path, "app.py", "raise ValueError('bad wiring')\n")
 

--- a/sdk/streamlib-python-wheel/tests/test_cli.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from app_under_test import ENGINE_STARTING_LOG_LINE
 
 from streamlib import Runtime, cli
 
@@ -226,7 +227,7 @@ def test_a_bad_save_in_the_effect_module_names_that_module_not_the_entry_file(
         f"the traceback must name the module the user edited; stderr was:\n"
         f"{finished.stderr}"
     )
-    assert "Initializing GPU context" not in finished.stdout + finished.stderr, (
+    assert ENGINE_STARTING_LOG_LINE not in finished.stdout + finished.stderr, (
         "a module that cannot be imported must not cost an engine boot"
     )
 

--- a/sdk/streamlib-python-wheel/tests/test_cli_launch.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli_launch.py
@@ -38,10 +38,11 @@ NODE_READY_TIMEOUT_SECONDS = 90.0
 CLEAN_EXIT_TIMEOUT_SECONDS = 60.0
 # Long enough that a per-frame failure or slowdown cannot hide inside it — and
 # long enough to outlast a warm-up. A window that ends before steady state
-# proves less than its length suggests: #1764 is a per-frame defect that takes
-# ~280 delivered frames to appear at all, which the 6s this ran at could not
-# have seen however many times it was run.
+# proves less than its length suggests: #1764 is a per-frame defect that needs
+# ~280 delivered frames, nine seconds of them, before it appears at all.
 SCAFFOLD_OBSERVATION_WINDOW_SECONDS = 12.0
+# The save has to land on a node that is already running, not one still booting.
+SECONDS_OF_LIVE_VIDEO_BEFORE_THE_BAD_SAVE_LANDS = SCAFFOLD_OBSERVATION_WINDOW_SECONDS / 2
 # Measured through the window below, effect in its own interpreter: 360 frames
 # in 12.0s — 30fps, the source's full rate, so the helper hop (escalate acquire
 # + surface-share checkout per frame) costs the demo no frames at all. The
@@ -58,56 +59,41 @@ def setup(rt):
     rt.add(TestPatternSource, config={"width": 320, "height": 180})
 '''
 
-# Enough helpers that a serialized spawn, or a per-child stall, separates from
-# a parallel one by more than measurement noise.
+# Enough helpers that a serialized spawn separates from a parallel one by far
+# more than measurement noise: six sequential interpreter startups cost six
+# times one, while six parallel ones cost about as much as one.
 HELPER_PLACED_PROCESSOR_COUNT = 6
-# The MVP sentence gives a minute for install, scaffold and run. Booting is the
-# only part of that this test can measure, so the budget is the half of the
-# minute the other parts do not need — a ceiling the measurement must fit
-# inside, not the measurement itself. Measured on the rig: 6 helpers go live
-# 0.80s after launch, 16 in 1.03s, so spawn is parallel and the margin is wide
-# on purpose. What this fails on is a regression that makes it serial.
+# The MVP sentence gives a minute for install, scaffold and run, and booting is
+# the only part of that this test can measure — so the budget is the half of
+# the minute the other parts do not need. It is a ceiling, and on its own a
+# generous one: measured on the rig, one helper goes live 0.65s after launch,
+# six in 0.60s and sixteen in 0.71s, so even a fully serialized spawn of six
+# would slip under it. The ceiling is why the assertion below charges the fleet
+# against a measured single helper as well.
 MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE = 30.0
 
-FIRST_FRAME_REPORTER_MODULE = '''\
-import os
+FIRST_FRAME_REPORTER_MODULE = Path(__file__).parent / "first_frame_reporter.py"
 
-from streamlib import input, log, processor  # noqa: A004
-
-
-@processor
-class ReportsItsProcessOnFirstFrame:
-    """Announces its own process the first time a frame reaches it."""
-
-    def __init__(self) -> None:
-        self.announced = False
-
-    @input(delivery_profile="latest")
-    def video_from_upstream(self) -> None: ...
-
-    def process(self, ctx) -> None:
-        if self.announced or ctx.inputs.read("video_from_upstream") is None:
-            return
-        self.announced = True
-        log.info(f"MARKER:LIVE {os.getpid()}")
-'''
-
-# The reporter module sits beside the entry file rather than in a package: that
+# The reporter is copied beside the entry file rather than into a package: that
 # is the other import shape the child's `PYTHONPATH` has to resolve, and the
 # scaffold suite already covers the packaged one.
-APP_WITH_A_FLEET_OF_HELPER_PLACED_PROCESSORS = f'''\
+APP_WITH_HELPER_PLACED_PROCESSORS_TEMPLATE = '''\
 from first_frame_reporter import ReportsItsProcessOnFirstFrame
 from streamlib import TestPatternSource
 
 
 def setup(rt):
-    source = rt.add(TestPatternSource, config={{"width": 320, "height": 180}})
-    for _ in range({HELPER_PLACED_PROCESSOR_COUNT}):
+    source = rt.add(TestPatternSource, config={"width": 320, "height": 180})
+    for _ in range(%d):
         reporter = rt.add(ReportsItsProcessOnFirstFrame)
         rt.connect(source.output("video"), reporter.input("video_from_upstream"))
 '''
 
 LIVE_HELPER_MARKER = re.compile(r"MARKER:LIVE (\d+)")
+DISPLAY_WINDOW_FRAME_COUNT = re.compile(r"DisplayWindow: stopped \((\d+) frames\)")
+
+# Enough tail to carry a traceback and the lines around it.
+RECENT_OUTPUT_CHARACTERS = 4000
 
 
 def free_port() -> int:
@@ -158,11 +144,30 @@ class LaunchedNode:
         assert self.output_file is not None, "this node was launched without capture"
         return self.output_file.read_text(errors="replace")
 
-    def await_output_satisfying(
-        self, satisfied: "Callable[[str], bool]", what: str, timeout: float
+    def recent_output(self) -> str:
+        """The tail of the capture, plus where to read the rest.
+
+        Whole captures stopped being printable: a window long enough to outlast
+        a warm-up is also long enough for #1764 to put most of a megabyte of
+        iceoryx2 warnings between a failure and the line that explains it.
+        """
+        captured = self.captured_output()
+        if len(captured) <= RECENT_OUTPUT_CHARACTERS:
+            return captured
+        return (
+            f"[first {len(captured) - RECENT_OUTPUT_CHARACTERS} characters elided — "
+            f"the whole capture is at {self.output_file}]\n"
+            f"{captured[-RECENT_OUTPUT_CHARACTERS:]}"
+        )
+
+    def await_captured_output_satisfying(
+        self,
+        captured_output_satisfies: "Callable[[str], bool]",
+        awaited_description: str,
+        timeout: float,
     ) -> float:
-        """Wait until the captured output satisfies `satisfied`, and return the
-        seconds since launch that took.
+        """Wait for the capture to satisfy the predicate; return the seconds
+        since launch that took.
 
         Polled off the capture file rather than read off a pipe: the launcher
         writes to a file precisely because nothing drains the child while it
@@ -171,22 +176,22 @@ class LaunchedNode:
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if satisfied(self.captured_output()):
+            if captured_output_satisfies(self.captured_output()):
                 return time.monotonic() - self.launched_at
             if self.process.poll() is not None:
                 raise AssertionError(
-                    f"the node exited before {what}; output was:\n"
-                    f"{self.captured_output()}"
+                    f"the node exited before {awaited_description}; output ended:\n"
+                    f"{self.recent_output()}"
                 )
             time.sleep(0.1)
         raise AssertionError(
-            f"timed out after {timeout}s waiting for {what}; output was:\n"
-            f"{self.captured_output()}"
+            f"timed out after {timeout}s waiting for {awaited_description}; "
+            f"output ended:\n{self.recent_output()}"
         )
 
-    def await_output_containing(self, awaited: str, timeout: float) -> float:
-        return self.await_output_satisfying(
-            lambda output: awaited in output, f"`{awaited}`", timeout
+    def await_captured_output_containing(self, awaited: str, timeout: float) -> float:
+        return self.await_captured_output_satisfying(
+            lambda captured: awaited in captured, f"`{awaited}`", timeout
         )
 
     def interrupt(self) -> None:
@@ -353,16 +358,55 @@ def test_the_scaffolded_app_reaches_a_running_graph(
     node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS)
     output = node.captured_output()
 
+    assert_the_window_showed_live_video(node, "the app `streamlib new` writes")
+
+
+def assert_the_window_showed_live_video(node: LaunchedNode, what_ran: str) -> None:
+    """Require an interrupted node to have shown live video, not a slideshow.
+
+    The window reports what it actually put on screen, which is the honest
+    measure — an effect can be correct and still leave the demo at roughly 4
+    frames a second, which is what editing the write-combined mapping in place
+    through a strided view produced.
+    """
+    output = node.captured_output()
     assert "process() failed" not in output, (
-        f"the scaffolded effect raised on a live frame; output was:\n{output}"
+        f"{what_ran}: the effect raised on a live frame; output ended:\n"
+        f"{node.recent_output()}"
     )
-    # The window reports what it actually put on screen, which is the honest
-    # measure of "live video" — the in-place effect managed roughly 4 a second.
-    frames_shown = re.search(r"DisplayWindow: stopped \((\d+) frames\)", output)
-    assert frames_shown, f"the window never reported a frame count; output was:\n{output}"
+    frames_shown = DISPLAY_WINDOW_FRAME_COUNT.search(output)
+    assert frames_shown, (
+        f"{what_ran}: the window never reported a frame count; output ended:\n"
+        f"{node.recent_output()}"
+    )
     assert int(frames_shown.group(1)) >= MINIMUM_FRAMES_FOR_LIVE_VIDEO, (
-        f"the app `streamlib new` writes showed only {frames_shown.group(1)} frames in "
+        f"{what_ran} showed only {frames_shown.group(1)} frames in "
         f"{SCAFFOLD_OBSERVATION_WINDOW_SECONDS}s — that is a slideshow, not live video"
+    )
+
+
+def write_app_with_helper_placed_processors(
+    app_directory: Path, helper_count: int
+) -> None:
+    """An app wiring `helper_count` copies of the reporter to one native source."""
+    app_directory.mkdir(parents=True, exist_ok=True)
+    (app_directory / "app.py").write_text(
+        APP_WITH_HELPER_PLACED_PROCESSORS_TEMPLATE % helper_count
+    )
+    shutil.copy(FIRST_FRAME_REPORTER_MODULE, app_directory / FIRST_FRAME_REPORTER_MODULE.name)
+
+
+def seconds_until_every_helper_reports(node: LaunchedNode, helper_count: int) -> float:
+    """Seconds from launch until `helper_count` distinct processes each saw a frame.
+
+    Waited for on a bound far above the budget rather than on the budget
+    itself: a wait that expires exactly at the ceiling can only ever report a
+    timeout, and what a blown budget should say is how long it actually took.
+    """
+    return node.await_captured_output_satisfying(
+        lambda captured: len(set(LIVE_HELPER_MARKER.findall(captured))) >= helper_count,
+        f"all {helper_count} helpers to report a frame",
+        NODE_READY_TIMEOUT_SECONDS,
     )
 
 
@@ -372,40 +416,56 @@ def test_every_helper_interpreter_goes_live_inside_the_startup_budget(
     """The N-child-interpreter startup budget the MVP minute has to pay.
 
     Every Python processor is its own child interpreter, so a graph's boot cost
-    now grows with its processor count. What this pins is that the growth is
-    parallel rather than serial, and that it is the *pipeline* that went live —
-    each helper reports only once a frame has actually reached it, so a child
-    that started but never received traffic does not count.
+    now grows with its processor count — and the sentence gives that growth a
+    minute to disappear into. Two things carry that here. The budget is a flat
+    ceiling on the whole fleet. Charging the fleet against a single helper
+    measured on the same machine is what makes the ceiling discriminating: a
+    spawn that lost its parallelism costs one interpreter's startup per child,
+    which a fixed ceiling this generous would never catch.
 
-    The distinct-pid assertion is the placement half: N processors must be N
-    processes, so a spawn path that quietly reused one would fail here instead
-    of passing on the timing alone.
+    Both halves are about live traffic, not liveness — a helper reports only
+    once a frame has reached it, so a child that started and received nothing
+    does not count. The distinct-pid assertion is the placement half: N
+    processors must be N processes.
     """
-    app_directory = tmp_path / "app"
-    app_directory.mkdir()
-    (app_directory / "app.py").write_text(APP_WITH_A_FLEET_OF_HELPER_PLACED_PROCESSORS)
-    (app_directory / "first_frame_reporter.py").write_text(FIRST_FRAME_REPORTER_MODULE)
+    one_helper_app = tmp_path / "one-helper"
+    write_app_with_helper_placed_processors(one_helper_app, 1)
+    baseline_node = launch_node("dev", one_helper_app, free_port(), capture_output=True)
+    seconds_for_one_helper = seconds_until_every_helper_reports(baseline_node, 1)
+    baseline_node.interrupt()
+    assert baseline_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0
 
-    node = launch_node("dev", app_directory, free_port(), capture_output=True)
-    seconds_to_live = node.await_output_satisfying(
-        lambda output: len(set(LIVE_HELPER_MARKER.findall(output)))
-        >= HELPER_PLACED_PROCESSOR_COUNT,
-        f"all {HELPER_PLACED_PROCESSOR_COUNT} helpers to report a frame",
-        MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE,
+    fleet_app = tmp_path / "fleet"
+    write_app_with_helper_placed_processors(fleet_app, HELPER_PLACED_PROCESSOR_COUNT)
+    fleet_node = launch_node("dev", fleet_app, free_port(), capture_output=True)
+    seconds_for_every_helper = seconds_until_every_helper_reports(
+        fleet_node, HELPER_PLACED_PROCESSOR_COUNT
     )
 
-    reporting_pids = set(LIVE_HELPER_MARKER.findall(node.captured_output()))
+    reporting_pids = set(LIVE_HELPER_MARKER.findall(fleet_node.captured_output()))
     assert len(reporting_pids) == HELPER_PLACED_PROCESSOR_COUNT, (
         f"{HELPER_PLACED_PROCESSOR_COUNT} processors reported from "
         f"{len(reporting_pids)} processes — every Python processor gets its own"
     )
-    assert str(node.process.pid) not in reporting_pids, (
+    assert str(fleet_node.process.pid) not in reporting_pids, (
         "a processor reported from the app's own process"
     )
-    assert seconds_to_live < MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE
+    assert seconds_for_every_helper < MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE, (
+        f"{HELPER_PLACED_PROCESSOR_COUNT} helper interpreters took "
+        f"{seconds_for_every_helper:.2f}s to reach live traffic — the minute does "
+        f"not absorb that"
+    )
+    # Half, not the whole: parallel spawn costs about what one helper costs, so
+    # the line sits far below a serial spawn and far above the measurement.
+    serialized_spawn_would_cost = seconds_for_one_helper * HELPER_PLACED_PROCESSOR_COUNT
+    assert seconds_for_every_helper < serialized_spawn_would_cost / 2, (
+        f"{HELPER_PLACED_PROCESSOR_COUNT} helpers took {seconds_for_every_helper:.2f}s "
+        f"against {seconds_for_one_helper:.2f}s for one — that is the shape of a spawn "
+        f"path that starts its children one after another"
+    )
 
-    node.interrupt()
-    assert node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0, (
+    fleet_node.interrupt()
+    assert fleet_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0, (
         f"a graph of {HELPER_PLACED_PROCESSOR_COUNT} helpers must still tear down cleanly"
     )
 
@@ -418,26 +478,29 @@ def edit_the_scaffolded_effect(app_directory: Path) -> None:
     proving something about a module `new` no longer writes.
     """
     effect_module = app_directory / "processors" / "inverting_effect.py"
-    scaffolded = effect_module.read_text()
-    edited = (
-        scaffolded.replace("    input,\n", "    input,\n    log,\n")
-        .replace(
+    edited = effect_module.read_text()
+    for anchor, replacement in (
+        ("    input,\n", "    input,\n    log,\n"),
+        (
             '    @input(delivery_profile="latest")',
             '    announced = False\n\n    @input(delivery_profile="latest")',
-        )
-        .replace(
+        ),
+        (
             '        ctx.outputs.write("video_to_downstream", bag)',
             "        if not self.announced:\n"
             "            self.announced = True\n"
             '            log.info("MARKER:EDITED_EFFECT")\n'
             '        ctx.outputs.write("video_to_downstream", bag)',
+        ),
+    ):
+        # Named one at a time, and required to be unique: a scaffold that grew
+        # a second copy of an anchor would take the edit twice, and a scaffold
+        # that dropped one would otherwise fail somewhere downstream of here.
+        assert edited.count(anchor) == 1, (
+            f"the scaffolded effect module carries {edited.count(anchor)} copies of "
+            f"the anchor {anchor!r} this edit needs exactly one of"
         )
-    )
-    assert (
-        "    log,\n" in edited
-        and "announced = False" in edited
-        and "MARKER:EDITED_EFFECT" in edited
-    ), "the scaffolded effect module no longer carries the anchors this edit needs"
+        edited = edited.replace(anchor, replacement, 1)
     effect_module.write_text(edited)
 
 
@@ -462,30 +525,27 @@ def test_the_edit_loop_survives_a_bad_save_and_shows_a_good_one(
     surviving_node = launch_node("dev", app_directory, free_port(), capture_output=True)
     await_sole_registry_entry(isolated_runtime_directory, NODE_READY_TIMEOUT_SECONDS)
 
-    time.sleep(SCAFFOLD_OBSERVATION_WINDOW_SECONDS / 2)
+    time.sleep(SECONDS_OF_LIVE_VIDEO_BEFORE_THE_BAD_SAVE_LANDS)
     effect_module.write_text("def process(self ctx:\n    this does not parse\n")
-    time.sleep(SCAFFOLD_OBSERVATION_WINDOW_SECONDS / 2)
+    time.sleep(
+        SCAFFOLD_OBSERVATION_WINDOW_SECONDS - SECONDS_OF_LIVE_VIDEO_BEFORE_THE_BAD_SAVE_LANDS
+    )
 
     surviving_node.interrupt()
     assert surviving_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0, (
         "a bad save must not take the running node down"
     )
-    survived_output = surviving_node.captured_output()
-    assert "process() failed" not in survived_output, (
-        f"the running effect must not have noticed the save; output was:\n{survived_output}"
-    )
-    frames_shown = re.search(r"DisplayWindow: stopped \((\d+) frames\)", survived_output)
-    assert frames_shown, f"the window never reported a frame count:\n{survived_output}"
-    assert int(frames_shown.group(1)) >= MINIMUM_FRAMES_FOR_LIVE_VIDEO, (
-        f"the pipeline delivered only {frames_shown.group(1)} frames across a save "
-        f"that never touched it"
+    assert_the_window_showed_live_video(
+        surviving_node, "the pipeline running when the bad save landed"
     )
 
     effect_module.write_text(last_good_effect_source)
     edit_the_scaffolded_effect(app_directory)
 
     edited_node = launch_node("dev", app_directory, free_port(), capture_output=True)
-    edited_node.await_output_containing("MARKER:EDITED_EFFECT", NODE_READY_TIMEOUT_SECONDS)
+    edited_node.await_captured_output_containing(
+        "MARKER:EDITED_EFFECT", NODE_READY_TIMEOUT_SECONDS
+    )
 
     edited_node.interrupt()
     assert edited_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0

--- a/sdk/streamlib-python-wheel/tests/test_cli_launch.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli_launch.py
@@ -59,17 +59,20 @@ def setup(rt):
     rt.add(TestPatternSource, config={"width": 320, "height": 180})
 '''
 
-# Enough helpers that a serialized spawn separates from a parallel one by far
-# more than measurement noise: six sequential interpreter startups cost six
-# times one, while six parallel ones cost about as much as one.
+# A fleet rather than a pair, and few enough that the rig pays for it in
+# seconds.
 HELPER_PLACED_PROCESSOR_COUNT = 6
 # The MVP sentence gives a minute for install, scaffold and run, and booting is
 # the only part of that this test can measure — so the budget is the half of
-# the minute the other parts do not need. It is a ceiling, and on its own a
-# generous one: measured on the rig, one helper goes live 0.65s after launch,
-# six in 0.60s and sixteen in 0.71s, so even a fully serialized spawn of six
-# would slip under it. The ceiling is why the assertion below charges the fleet
-# against a measured single helper as well.
+# the minute the other parts do not need.
+#
+# It is a ceiling and nothing subtler. An app boot is ~520ms of GPU context
+# init and a child interpreter adds ~56ms at the margin, so six helpers reach
+# live traffic 0.6s after launch and even starting them one after another
+# would land near 1s. What this catches is a helper that stopped starting, or
+# a per-child cost that grew by an order of magnitude — not the difference
+# between a parallel spawn and a serial one, which lives inside the noise at
+# this count. The distinct-pid assertions are what pin placement.
 MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE = 30.0
 
 FIRST_FRAME_REPORTER_MODULE = Path(__file__).parent / "first_frame_reporter.py"
@@ -356,7 +359,6 @@ def test_the_scaffolded_app_reaches_a_running_graph(
     time.sleep(SCAFFOLD_OBSERVATION_WINDOW_SECONDS)
     node.interrupt()
     node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS)
-    output = node.captured_output()
 
     assert_the_window_showed_live_video(node, "the app `streamlib new` writes")
 
@@ -416,25 +418,16 @@ def test_every_helper_interpreter_goes_live_inside_the_startup_budget(
     """The N-child-interpreter startup budget the MVP minute has to pay.
 
     Every Python processor is its own child interpreter, so a graph's boot cost
-    now grows with its processor count — and the sentence gives that growth a
-    minute to disappear into. Two things carry that here. The budget is a flat
-    ceiling on the whole fleet. Charging the fleet against a single helper
-    measured on the same machine is what makes the ceiling discriminating: a
-    spawn that lost its parallelism costs one interpreter's startup per child,
-    which a fixed ceiling this generous would never catch.
+    now grows with its processor count, and the sentence gives that growth a
+    minute to disappear into. The budget is a flat ceiling on the whole fleet —
+    see the constant for what a ceiling this generous can and cannot catch.
 
-    Both halves are about live traffic, not liveness — a helper reports only
-    once a frame has reached it, so a child that started and received nothing
-    does not count. The distinct-pid assertion is the placement half: N
-    processors must be N processes.
+    What it measures is live traffic, not liveness: a helper reports only once
+    a frame has reached it, so a child that started and received nothing does
+    not count. The distinct-pid assertions are the placement half — N
+    processors must be N processes, so a spawn path that quietly reused one
+    fails here rather than passing on the timing alone.
     """
-    one_helper_app = tmp_path / "one-helper"
-    write_app_with_helper_placed_processors(one_helper_app, 1)
-    baseline_node = launch_node("dev", one_helper_app, free_port(), capture_output=True)
-    seconds_for_one_helper = seconds_until_every_helper_reports(baseline_node, 1)
-    baseline_node.interrupt()
-    assert baseline_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0
-
     fleet_app = tmp_path / "fleet"
     write_app_with_helper_placed_processors(fleet_app, HELPER_PLACED_PROCESSOR_COUNT)
     fleet_node = launch_node("dev", fleet_app, free_port(), capture_output=True)
@@ -455,15 +448,6 @@ def test_every_helper_interpreter_goes_live_inside_the_startup_budget(
         f"{seconds_for_every_helper:.2f}s to reach live traffic — the minute does "
         f"not absorb that"
     )
-    # Half, not the whole: parallel spawn costs about what one helper costs, so
-    # the line sits far below a serial spawn and far above the measurement.
-    serialized_spawn_would_cost = seconds_for_one_helper * HELPER_PLACED_PROCESSOR_COUNT
-    assert seconds_for_every_helper < serialized_spawn_would_cost / 2, (
-        f"{HELPER_PLACED_PROCESSOR_COUNT} helpers took {seconds_for_every_helper:.2f}s "
-        f"against {seconds_for_one_helper:.2f}s for one — that is the shape of a spawn "
-        f"path that starts its children one after another"
-    )
-
     fleet_node.interrupt()
     assert fleet_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0, (
         f"a graph of {HELPER_PLACED_PROCESSOR_COUNT} helpers must still tear down cleanly"

--- a/sdk/streamlib-python-wheel/tests/test_cli_launch.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli_launch.py
@@ -7,6 +7,11 @@ What these lock is that a Python-launched app is a first-class node: its
 `setup(rt)` built the graph, it published a node-registry entry the observation
 verbs discover, and a clean interrupt takes the entry away again. Booting
 initializes a GPU context, so the whole module needs a device.
+
+The MVP minute is measured here too, with every processor in its own child
+interpreter: what `new` writes runs frame after frame, a graph of helpers goes
+live inside the startup budget their interpreters cost, and the edit loop —
+which is re-running `dev` — survives a bad save and shows a good one.
 """
 
 import json
@@ -20,6 +25,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -30,15 +36,19 @@ pytestmark = pytest.mark.requires_gpu
 # Boot is process start + engine init + GPU context + socket bind.
 NODE_READY_TIMEOUT_SECONDS = 90.0
 CLEAN_EXIT_TIMEOUT_SECONDS = 60.0
-# Many frames at any watchable rate — long enough that a per-frame failure or a
-# per-frame slowdown cannot hide inside it.
-SCAFFOLD_OBSERVATION_WINDOW_SECONDS = 6.0
-# The source runs at 30fps, so a healthy effect delivers ~180 frames in the
-# window. The floor sits far below that and far above the ~25 a pathologically
-# slow per-frame edit manages, so it fails on a regression and not on a slow
-# machine. Held at re-baselining against the real cross-process pixel path
-# (escalate acquire + surface-share checkout per frame), which clears it.
-MINIMUM_FRAMES_FOR_LIVE_VIDEO = 60
+# Long enough that a per-frame failure or slowdown cannot hide inside it — and
+# long enough to outlast a warm-up. A window that ends before steady state
+# proves less than its length suggests: #1764 is a per-frame defect that takes
+# ~280 delivered frames to appear at all, which the 6s this ran at could not
+# have seen however many times it was run.
+SCAFFOLD_OBSERVATION_WINDOW_SECONDS = 12.0
+# Measured through the window below, effect in its own interpreter: 360 frames
+# in 12.0s — 30fps, the source's full rate, so the helper hop (escalate acquire
+# + surface-share checkout per frame) costs the demo no frames at all. The
+# floor keeps a third of that, which is still well above the ~4fps a
+# pathologically slow per-frame edit manages, so it fails on a regression and
+# not on a slow machine.
+MINIMUM_FRAMES_FOR_LIVE_VIDEO = 120
 
 APP_WITH_ONE_NATIVE_SOURCE = '''\
 from streamlib import TestPatternSource
@@ -47,6 +57,57 @@ from streamlib import TestPatternSource
 def setup(rt):
     rt.add(TestPatternSource, config={"width": 320, "height": 180})
 '''
+
+# Enough helpers that a serialized spawn, or a per-child stall, separates from
+# a parallel one by more than measurement noise.
+HELPER_PLACED_PROCESSOR_COUNT = 6
+# The MVP sentence gives a minute for install, scaffold and run. Booting is the
+# only part of that this test can measure, so the budget is the half of the
+# minute the other parts do not need — a ceiling the measurement must fit
+# inside, not the measurement itself. Measured on the rig: 6 helpers go live
+# 0.80s after launch, 16 in 1.03s, so spawn is parallel and the margin is wide
+# on purpose. What this fails on is a regression that makes it serial.
+MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE = 30.0
+
+FIRST_FRAME_REPORTER_MODULE = '''\
+import os
+
+from streamlib import input, log, processor  # noqa: A004
+
+
+@processor
+class ReportsItsProcessOnFirstFrame:
+    """Announces its own process the first time a frame reaches it."""
+
+    def __init__(self) -> None:
+        self.announced = False
+
+    @input(delivery_profile="latest")
+    def video_from_upstream(self) -> None: ...
+
+    def process(self, ctx) -> None:
+        if self.announced or ctx.inputs.read("video_from_upstream") is None:
+            return
+        self.announced = True
+        log.info(f"MARKER:LIVE {os.getpid()}")
+'''
+
+# The reporter module sits beside the entry file rather than in a package: that
+# is the other import shape the child's `PYTHONPATH` has to resolve, and the
+# scaffold suite already covers the packaged one.
+APP_WITH_A_FLEET_OF_HELPER_PLACED_PROCESSORS = f'''\
+from first_frame_reporter import ReportsItsProcessOnFirstFrame
+from streamlib import TestPatternSource
+
+
+def setup(rt):
+    source = rt.add(TestPatternSource, config={{"width": 320, "height": 180}})
+    for _ in range({HELPER_PLACED_PROCESSOR_COUNT}):
+        reporter = rt.add(ReportsItsProcessOnFirstFrame)
+        rt.connect(source.output("video"), reporter.input("video_from_upstream"))
+'''
+
+LIVE_HELPER_MARKER = re.compile(r"MARKER:LIVE (\d+)")
 
 
 def free_port() -> int:
@@ -90,11 +151,43 @@ class LaunchedNode:
     ) -> None:
         self.process = process
         self.output_file = output_file
+        self.launched_at = time.monotonic()
 
     def captured_output(self) -> str:
         """Everything the child wrote, for a test that asserts on its report."""
         assert self.output_file is not None, "this node was launched without capture"
         return self.output_file.read_text(errors="replace")
+
+    def await_output_satisfying(
+        self, satisfied: "Callable[[str], bool]", what: str, timeout: float
+    ) -> float:
+        """Wait until the captured output satisfies `satisfied`, and return the
+        seconds since launch that took.
+
+        Polled off the capture file rather than read off a pipe: the launcher
+        writes to a file precisely because nothing drains the child while it
+        runs, and a reader that stopped draining would wedge the node the test
+        is waiting on.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if satisfied(self.captured_output()):
+                return time.monotonic() - self.launched_at
+            if self.process.poll() is not None:
+                raise AssertionError(
+                    f"the node exited before {what}; output was:\n"
+                    f"{self.captured_output()}"
+                )
+            time.sleep(0.1)
+        raise AssertionError(
+            f"timed out after {timeout}s waiting for {what}; output was:\n"
+            f"{self.captured_output()}"
+        )
+
+    def await_output_containing(self, awaited: str, timeout: float) -> float:
+        return self.await_output_satisfying(
+            lambda output: awaited in output, f"`{awaited}`", timeout
+        )
 
     def interrupt(self) -> None:
         self.process.send_signal(signal.SIGINT)
@@ -271,6 +364,131 @@ def test_the_scaffolded_app_reaches_a_running_graph(
         f"the app `streamlib new` writes showed only {frames_shown.group(1)} frames in "
         f"{SCAFFOLD_OBSERVATION_WINDOW_SECONDS}s — that is a slideshow, not live video"
     )
+
+
+def test_every_helper_interpreter_goes_live_inside_the_startup_budget(
+    tmp_path: Path, isolated_runtime_directory: Path, launch_node
+):
+    """The N-child-interpreter startup budget the MVP minute has to pay.
+
+    Every Python processor is its own child interpreter, so a graph's boot cost
+    now grows with its processor count. What this pins is that the growth is
+    parallel rather than serial, and that it is the *pipeline* that went live —
+    each helper reports only once a frame has actually reached it, so a child
+    that started but never received traffic does not count.
+
+    The distinct-pid assertion is the placement half: N processors must be N
+    processes, so a spawn path that quietly reused one would fail here instead
+    of passing on the timing alone.
+    """
+    app_directory = tmp_path / "app"
+    app_directory.mkdir()
+    (app_directory / "app.py").write_text(APP_WITH_A_FLEET_OF_HELPER_PLACED_PROCESSORS)
+    (app_directory / "first_frame_reporter.py").write_text(FIRST_FRAME_REPORTER_MODULE)
+
+    node = launch_node("dev", app_directory, free_port(), capture_output=True)
+    seconds_to_live = node.await_output_satisfying(
+        lambda output: len(set(LIVE_HELPER_MARKER.findall(output)))
+        >= HELPER_PLACED_PROCESSOR_COUNT,
+        f"all {HELPER_PLACED_PROCESSOR_COUNT} helpers to report a frame",
+        MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE,
+    )
+
+    reporting_pids = set(LIVE_HELPER_MARKER.findall(node.captured_output()))
+    assert len(reporting_pids) == HELPER_PLACED_PROCESSOR_COUNT, (
+        f"{HELPER_PLACED_PROCESSOR_COUNT} processors reported from "
+        f"{len(reporting_pids)} processes — every Python processor gets its own"
+    )
+    assert str(node.process.pid) not in reporting_pids, (
+        "a processor reported from the app's own process"
+    )
+    assert seconds_to_live < MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE
+
+    node.interrupt()
+    assert node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0, (
+        f"a graph of {HELPER_PLACED_PROCESSOR_COUNT} helpers must still tear down cleanly"
+    )
+
+
+def edit_the_scaffolded_effect(app_directory: Path) -> None:
+    """Make the edit the demo asks for, in the file `new` wrote.
+
+    Applied to the scaffold's own source rather than overwriting it with a
+    copy: a copy would keep passing after the scaffold changed underneath it,
+    proving something about a module `new` no longer writes.
+    """
+    effect_module = app_directory / "processors" / "inverting_effect.py"
+    scaffolded = effect_module.read_text()
+    edited = (
+        scaffolded.replace("    input,\n", "    input,\n    log,\n")
+        .replace(
+            '    @input(delivery_profile="latest")',
+            '    announced = False\n\n    @input(delivery_profile="latest")',
+        )
+        .replace(
+            '        ctx.outputs.write("video_to_downstream", bag)',
+            "        if not self.announced:\n"
+            "            self.announced = True\n"
+            '            log.info("MARKER:EDITED_EFFECT")\n'
+            '        ctx.outputs.write("video_to_downstream", bag)',
+        )
+    )
+    assert (
+        "    log,\n" in edited
+        and "announced = False" in edited
+        and "MARKER:EDITED_EFFECT" in edited
+    ), "the scaffolded effect module no longer carries the anchors this edit needs"
+    effect_module.write_text(edited)
+
+
+def test_the_edit_loop_survives_a_bad_save_and_shows_a_good_one(
+    tmp_path: Path, isolated_runtime_directory: Path, launch_node
+):
+    """The MVP edit loop, which is re-running `dev`.
+
+    A save is a file write, and the node running when it lands has already
+    imported what it needs — in the app process and in every helper. So a
+    broken save must cost the running pipeline nothing, and a good one must
+    show up on the next run. Both halves are asserted against the same app in
+    sequence because the first is only meaningful if the second follows: a
+    pipeline that survives a bad save by ignoring the file entirely would pass
+    the first alone.
+    """
+    app_directory = tmp_path / "app"
+    cli.scaffold_new_app(app_directory, use_test_pattern_source=True)
+    effect_module = app_directory / "processors" / "inverting_effect.py"
+    last_good_effect_source = effect_module.read_text()
+
+    surviving_node = launch_node("dev", app_directory, free_port(), capture_output=True)
+    await_sole_registry_entry(isolated_runtime_directory, NODE_READY_TIMEOUT_SECONDS)
+
+    time.sleep(SCAFFOLD_OBSERVATION_WINDOW_SECONDS / 2)
+    effect_module.write_text("def process(self ctx:\n    this does not parse\n")
+    time.sleep(SCAFFOLD_OBSERVATION_WINDOW_SECONDS / 2)
+
+    surviving_node.interrupt()
+    assert surviving_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0, (
+        "a bad save must not take the running node down"
+    )
+    survived_output = surviving_node.captured_output()
+    assert "process() failed" not in survived_output, (
+        f"the running effect must not have noticed the save; output was:\n{survived_output}"
+    )
+    frames_shown = re.search(r"DisplayWindow: stopped \((\d+) frames\)", survived_output)
+    assert frames_shown, f"the window never reported a frame count:\n{survived_output}"
+    assert int(frames_shown.group(1)) >= MINIMUM_FRAMES_FOR_LIVE_VIDEO, (
+        f"the pipeline delivered only {frames_shown.group(1)} frames across a save "
+        f"that never touched it"
+    )
+
+    effect_module.write_text(last_good_effect_source)
+    edit_the_scaffolded_effect(app_directory)
+
+    edited_node = launch_node("dev", app_directory, free_port(), capture_output=True)
+    edited_node.await_output_containing("MARKER:EDITED_EFFECT", NODE_READY_TIMEOUT_SECONDS)
+
+    edited_node.interrupt()
+    assert edited_node.await_exit(CLEAN_EXIT_TIMEOUT_SECONDS) == 0
 
 
 def test_a_bad_config_is_reported_without_a_launcher_traceback(


### PR DESCRIPTION
## Summary

#1711's remainder turned out to be proof, not construction. The split scaffold shipped with
#1739 (`app.py` plus `processors/inverting_effect.py`) and the helper spawn with #1714 — so
`streamlib new && streamlib dev` already runs the effect in its own child interpreter. What was
missing was evidence: the frame floor guarding the demo carried an *assertion* that
re-baselining against the cross-process pixel path "clears it", the startup cost helper
placement adds was unmeasured, and the edit loop the milestone is named for was untested against
the file a user actually edits.

Four claims now hold their own evidence, all measured on the rig.

**The demo runs at full rate.** 360 frames in 12.0s — 30fps, the source's rate exactly — so the
escalate acquire and surface-share checkout each frame cost the demo nothing. The floor moves to
a third of the measurement (60 → 120) and the comment cites the number instead of promising it.

**The observation window outlasts a warm-up.** Six seconds could not have seen a per-frame defect
that needs ~280 delivered frames before it appears, however many times it ran. #1764 is exactly
that defect, and it lived under this gate undisturbed.

**The N-child-interpreter startup budget is a ceiling, and says so.** Six helpers reach live
traffic 0.6s after launch. Two drafts of this test claimed the ceiling would catch a spawn that
lost its parallelism, and neither could — see the note below; the shipped version states what a
generous ceiling actually catches and leaves the parallelism question to the distinct-pid
assertions and to future work.

**The edit loop survives a bad save and shows a good one.** A save lands on a node that already
imported everything it needs, in the app process and in every helper — so a broken one costs the
running pipeline nothing, and a good one shows up on the next run. The bad save that matters is
in the processor module, not the entry file, and its traceback has to name the file the user
edited.

No source changed. Two commits, both tests.

## Closes

Closes #1711

## Exit criteria

- [x] `streamlib new` scaffolds `app.py` + the effect in its own importable module — shipped
      #1739, locked by the pre-existing `test_the_scaffolded_processor_lives_outside_the_entry_file`
- [x] A `__main__`-defined processor is a wiring error at `rt.add` naming the fix — shipped #1754
- [x] The MVP minute re-proven with the effect in a child interpreter, at the source's full frame
      rate
- [x] `MINIMUM_FRAMES_FOR_LIVE_VIDEO` re-baselined against measured IPC cost
- [x] The N-child-interpreter startup budget owned here — a ceiling on the fleet's time to live
      traffic, plus the distinct-pid assertions that pin placement
- [x] Bad-save resilience: the running pipeline is untouched, the relaunch names the module
- [x] Bind posture unchanged — shipped #1739

## Test plan

Run on the rig (RTX 3090, driver 595.84, `DISPLAY=:1`), debug build via `maturin develop`:

```
cd sdk/streamlib-python-wheel
.venv/bin/python -m pytest tests/test_cli_launch.py tests/test_cli.py
```

38 passed — 8 rig-only in `test_cli_launch.py`, 30 in `test_cli.py`.

Both new assertions were mutation-checked rather than trusted to be green:

| mutation | result |
|---|---|
| `MINIMUM_FRAMES_FOR_LIVE_VIDEO` → 100000 | fails, reporting the real count: `showed only 360 frames in 12.0s` |
| fleet wired with one fewer helper than expected | fails: `timed out … waiting for all 7 helpers to report a frame` |
| `MAXIMUM_SECONDS_FOR_EVERY_HELPER_TO_GO_LIVE` → 0.001 | fails with the measured duration: `6 helper interpreters took 0.80s` |

Gate battery: 32 passed, 0 failed. `check-no-in-process-placement` clean (55 fixture tests green),
`mypy.stubtest` clean, `pyright` 0 errors, 112 non-GPU wheel tests pass.

One intermittent failure appeared in the battery and is **not** from this diff:
`stopping_an_already_stopped_runtime_is_a_no_op` in `runtime/streamlib-engine/src/core/runtime/runtime.rs`
failed 1 run in 4 — the parallel-run flake this suite already has.

## Notes for owner

**#1764 filed, deliberately not fixed here.** The scaffolded demo prints 2.4 MB of iceoryx2
warnings in 20 seconds — one per frame from 9.4s onward, each a ~4KB Rust `Debug` dump of the
whole `Notifier`. It is engine-layer and Python-independent: a `TestPatternSource → DisplayWindow`
graph with no Python in it reproduces it at a higher rate (372 warnings, all `rust`-tagged). The
onset is arithmetic — 280 notifications ÷ 30fps = 9.3s, a unix datagram socket filling and staying
full. Video is unaffected; the terminal is a firehose. Fixing it inside a CLI proof ticket would
have been the scope violation, so it is filed against the engine.

It does leave a mark here: the widened 12s window now always runs through the flood, so failure
messages tail the last 4000 characters of a capture and name the file holding the rest. Worth
deciding, once #1764 lands, whether the window shrinks back.

**The startup budget does not catch a serialized spawn, and two attempts to make it say
otherwise were wrong.** Worth knowing, because the fix is real work rather than a wording change.
Draft one asserted a flat 30s ceiling and claimed in a comment that it "fails on a regression
that makes it serial". Draft two charged the fleet against a measured single helper — six must
beat half of `one × 6`. Both were refuted by measurement: a one-helper launch is ~520ms of GPU
context init plus ~56ms of child interpreter, so serializing multiplies the 56ms, not the total.
Six sequential startups land near 1s, not near 4s. Review proved it by building an app whose
children stagger at import — a faithful emulation of a serial spawn — and measuring 0.910s
against the 1.938s threshold: it passes with 2× headroom.

A real parallelism gate needs a helper count where the marginal cost clears run-to-run noise
(~16 children, where a serial signal is ~0.9s), an assertion against a small multiple of the
one-helper baseline, and proof against that staggered emulation rather than an assertion. I did
not do it here — it is beyond what the ticket commissions, and after two unbacked claims the
right move was to stop claiming rather than to try a third time. Say the word if you want it as
a follow-up.

**The ticket body was stale and has been corrected** (strikethroughs preserved). It claimed #1739
"must not merge carrying `Closes #1711` while its scaffold defines the processor in `app.py`" —
#1739 shipped the split scaffold, and #1714 landed as #1754, so nothing was blocked.

**Not fixed, adjacent:** `test_cli.py:198` spells `"Initializing GPU context"` as a bare literal
where `app_under_test.ENGINE_STARTING_LOG_LINE` already names it. The new test beside it uses the
constant; the pre-existing one was left alone rather than swept in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line error reporting when edited processor modules contain syntax errors.
  * The development edit loop now recovers after an invalid save and resumes successfully once corrected.
  * Prevented engine startup when a processor module fails to import.

* **Tests**
  * Expanded coverage for live video startup, processor execution, first-frame handling, and multi-process launch reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->