### PR TITLE
fix(engine): open no link notifier for a destination that never drains one

### DIFF
--- a/runtime/streamlib-engine/benches/output_writer_ffi_hop.rs
+++ b/runtime/streamlib-engine/benches/output_writer_ffi_hop.rs
@@ -135,7 +135,7 @@ fn build_inner_with_connection(tag: &str) -> BenchFixture {
             ceiling_bytes: TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
         },
     );
-    inner.add_channel_notifier("out", "L-bench-ffi-hop", notifier);
+    inner.add_channel_link("out", "L-bench-ffi-hop", Some(notifier));
 
     BenchFixture {
         inner,
@@ -225,7 +225,7 @@ struct FanoutFixture {
 
 /// Build an `OutputWriterInner` whose single "out" channel feeds
 /// `subscriber_count` subscribers, mirroring the compiler op's 1→N wiring: ONE
-/// `set_channel_publisher` + N `add_channel_notifier`, N subscribers on the one
+/// `set_channel_publisher` + N `add_channel_link`, N subscribers on the one
 /// pubsub service.
 fn build_inner_with_fanout(tag: &str, subscriber_count: usize) -> FanoutFixture {
     let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
@@ -275,7 +275,7 @@ fn build_inner_with_fanout(tag: &str, subscriber_count: usize) -> FanoutFixture 
             .unwrap();
         let notifier = notify.notifier_builder().create().unwrap();
         let listener = notify.listener_builder().create().unwrap();
-        inner.add_channel_notifier("out", &format!("L-bench-fanout-{i}"), notifier);
+        inner.add_channel_link("out", &format!("L-bench-fanout-{i}"), Some(notifier));
         listeners.push(listener);
     }
 

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -110,24 +110,22 @@ pub fn open_iceoryx2_service(
     let dest_is_subprocess = is_subprocess_processor(graph, &dest_proc_id);
 
     let channel_service_name = channel_service_name(&source_proc_id, &source_port)?;
-    let notify_service_name = notify_service_name_for(&dest_proc_id);
 
     // A notifier aimed at a destination that never drains its listener fills
     // that listener's queue and then silently stops being delivered for the
     // rest of the run, one iceoryx2 warning per frame (#1764). The notify
     // service exists to wake a waiting destination, so a destination that does
     // not wait gets none of it: no service, no notifier, no listener.
-    let dest_consumes_notifications =
-        destination_consumes_notifications(graph, &dest_proc_id, dest_is_subprocess);
-    let wired_notify_service_name = if dest_consumes_notifications {
-        notify_service_name.as_str()
-    } else {
-        ""
-    };
+    let notify_service_name = destination_consumes_notifications(
+        graph,
+        &dest_proc_id,
+        dest_is_subprocess,
+    )
+    .then(|| notify_service_name_for(&dest_proc_id));
 
     tracing::info!(
         channel = %channel_service_name,
-        notify = %wired_notify_service_name,
+        notify = notify_service_name.as_deref().unwrap_or("<destination drains no listener>"),
         "Opening iceoryx2 channel: {} ({}:{}) -> ({}:{}) [{}] (source_subprocess={}, dest_subprocess={})",
         from_port,
         source_proc_id,
@@ -179,8 +177,9 @@ pub fn open_iceoryx2_service(
         max_queued_messages,
         enable_safe_overflow,
     )?;
-    let notify_service = dest_consumes_notifications
-        .then(|| iceoryx2_node.open_or_create_notify_service(&notify_service_name, max_notifiers))
+    let notify_service = notify_service_name
+        .as_deref()
+        .map(|name| iceoryx2_node.open_or_create_notify_service(name, max_notifiers))
         .transpose()?;
 
     // Source side: install the single channel publisher (first link out of this
@@ -191,7 +190,7 @@ pub fn open_iceoryx2_service(
             &source_proc_id,
             &source_port,
             &channel_service_name,
-            wired_notify_service_name,
+            notify_service_name.as_deref().unwrap_or(""),
             &output_schema,
             expected_payload,
             channel_ceiling_bytes,
@@ -227,7 +226,7 @@ pub fn open_iceoryx2_service(
             &dest_proc_id,
             &dest_port,
             &channel_service_name,
-            wired_notify_service_name,
+            notify_service_name.as_deref().unwrap_or(""),
             drain_order,
             max_queued_messages,
             max_subscribers,
@@ -707,11 +706,10 @@ fn wire_rust_source(
         );
     }
 
-    output_inner.add_channel_link(source_port, link_id.as_str());
-    if let Some(notify_service) = notify_service {
-        let notifier = notify_service.create_notifier()?;
-        output_inner.add_channel_notifier(source_port, link_id.as_str(), notifier);
-    }
+    let notifier = notify_service
+        .map(|notify_service| notify_service.create_notifier())
+        .transpose()?;
+    output_inner.add_channel_link(source_port, link_id.as_str(), notifier);
     Ok(())
 }
 
@@ -747,13 +745,12 @@ fn wire_rust_dest(
         dest_port
     );
 
-    match notify_service {
-        Some(notify_service) if !input_inner.has_listener() => {
+    if let Some(notify_service) = notify_service {
+        if !input_inner.has_listener() {
             let listener = notify_service.create_listener()?;
             input_inner.set_listener(listener);
             tracing::debug!("Created listener for destination on its notify service");
         }
-        _ => {}
     }
     Ok(())
 }
@@ -762,6 +759,10 @@ fn wire_rust_dest(
 /// out of process, so it opens its own channel publisher + destination notifier
 /// from the envelope. One entry per link — the far side installs the single
 /// publisher once (keyed by source port) and appends a notifier per entry.
+///
+/// An empty `notify_service_name` is the wire's way of saying the destination
+/// drains no listener, so the far side opens no notifier for this link. Every
+/// SDK reads it that way.
 #[allow(clippy::too_many_arguments)]
 fn wire_subprocess_source(
     graph: &mut Graph,
@@ -1089,23 +1090,39 @@ mod tests {
         (instance, output_inner, input_inner)
     }
 
-    /// A notify service usable by both sides of one link.
-    fn open_test_notify_service(tag: &str) -> crate::iceoryx2::Iceoryx2NotifyService {
-        crate::iceoryx2::Iceoryx2Node::new()
-            .expect("an iceoryx2 node must open")
-            .open_or_create_notify_service(
-                &format!(
-                    "test/notify/{}/{}/{}",
-                    tag,
-                    std::process::id(),
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap()
-                        .as_nanos()
-                ),
-                1,
-            )
-            .expect("the notify service must open")
+    /// A service name no concurrent test — or an earlier run that recycled this
+    /// pid — can collide with on iceoryx2's machine-global `/dev/shm` namespace.
+    /// A collision surfaces as `DoesNotSupportRequestedMinBufferSize` against
+    /// the stale service, not as a clean failure.
+    fn unique_service_name(tag: &str) -> String {
+        format!(
+            "test/wiring/{}/{}/{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    /// The channel and notify services one wired link needs, on one node.
+    fn open_test_link_services(
+        tag: &str,
+        destination_consumes_notifications: bool,
+    ) -> (
+        crate::iceoryx2::Iceoryx2Service,
+        Option<crate::iceoryx2::Iceoryx2NotifyService>,
+    ) {
+        let node = crate::iceoryx2::Iceoryx2Node::new().expect("an iceoryx2 node must open");
+        let channel = node
+            .open_or_create_service(&unique_service_name(&format!("{tag}/channel")), 2, 8, true)
+            .expect("the channel service must open");
+        let notify = destination_consumes_notifications.then(|| {
+            node.open_or_create_notify_service(&unique_service_name(&format!("{tag}/notify")), 1)
+                .expect("the notify service must open")
+        });
+        (channel, notify)
     }
 
     /// The decision behind #1764: only a destination that will actually wait on
@@ -1145,60 +1162,79 @@ mod tests {
         );
     }
 
+    /// Wire one Rust→Rust link end to end the way the compiler op does, with or
+    /// without the notify service, and hand back the two sides' iceoryx2 state.
+    fn wire_one_test_link<Destination>(
+        tag: &str,
+        destination_consumes_notifications: bool,
+    ) -> (
+        Arc<crate::iceoryx2::OutputWriterInner>,
+        Arc<crate::iceoryx2::InputMailboxesInner>,
+    )
+    where
+        Destination: crate::core::GeneratedProcessor + DynGeneratedProcessor + Send + 'static,
+        Destination::Config: Default,
+    {
+        use crate::core::test_support::MockOutputOnlyProcessor;
+
+        let mut graph = Graph::new();
+        let source_id = add_mock_output_only(&mut graph);
+        let (source, source_output, _) =
+            attach_mock_instance::<MockOutputOnlyProcessor::Processor>(&mut graph, &source_id);
+        let source_output = source_output.expect("an output-only mock holds an output writer");
+
+        let dest_id = if destination_consumes_notifications {
+            add_mock_reactive_input_only(&mut graph)
+        } else {
+            add_mock_input_only(&mut graph)
+        };
+        let (dest, _, dest_input) = attach_mock_instance::<Destination>(&mut graph, &dest_id);
+        let dest_input = dest_input.expect("an input-only mock holds input mailboxes");
+
+        let (channel, notify_service) =
+            open_test_link_services(tag, destination_consumes_notifications);
+        let link_id: LinkUniqueId = format!("L-{tag}").as_str().into();
+
+        wire_rust_source(
+            &source,
+            "out1",
+            &link_id,
+            &PortSchemaSpec::Any,
+            &channel,
+            notify_service.as_ref(),
+            ChannelEgressConfig {
+                service_name: unique_service_name(tag),
+                trust_tier: ChannelTrustTier::Trusted,
+                expected_payload_bytes: 4096,
+                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+            },
+        )
+        .expect("the source side wires");
+        wire_rust_dest(
+            &dest,
+            "in1",
+            &link_id,
+            &PortSchemaSpec::Any,
+            crate::iceoryx2::ReadMode::SkipToLatest,
+            8,
+            &channel,
+            notify_service.as_ref(),
+        )
+        .expect("the destination side wires");
+
+        (source_output, dest_input)
+    }
+
     /// The decision reaches the ports: no notify service means the source
     /// installs its channel publisher and no notifier, and the destination
     /// subscribes with no listener. Data wiring is untouched either way — the
     /// frames still flow, which is why #1764 cost terminal output and not video.
     #[test]
     fn a_destination_that_consumes_nothing_is_wired_for_data_only() {
-        use crate::core::test_support::{MockInputOnlyProcessor, MockOutputOnlyProcessor};
+        use crate::core::test_support::MockInputOnlyProcessor;
 
-        let mut graph = Graph::new();
-        let source_id = add_mock_output_only(&mut graph);
-        let dest_id = add_mock_input_only(&mut graph);
-        let (source, source_output, _) =
-            attach_mock_instance::<MockOutputOnlyProcessor::Processor>(&mut graph, &source_id);
-        let source_output = source_output.expect("an output-only mock holds an output writer");
-        let (dest, _, dest_input) =
-            attach_mock_instance::<MockInputOnlyProcessor::Processor>(&mut graph, &dest_id);
-        let dest_input = dest_input.expect("an input-only mock holds input mailboxes");
-
-        let node = crate::iceoryx2::Iceoryx2Node::new().expect("an iceoryx2 node must open");
-        let channel = node
-            .open_or_create_service(
-                &format!("test-notifierless-{}/out1", std::process::id()),
-                2,
-                8,
-                true,
-            )
-            .expect("the channel service must open");
-
-        wire_rust_source(
-            &source,
-            "out1",
-            &"L-no-notify".into(),
-            &PortSchemaSpec::Any,
-            &channel,
-            None,
-            ChannelEgressConfig {
-                service_name: "test-notifierless/out1".to_string(),
-                trust_tier: ChannelTrustTier::Trusted,
-                expected_payload_bytes: 4096,
-                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
-            },
-        )
-        .expect("a data-only source wires without a notify service");
-        wire_rust_dest(
-            &dest,
-            "in1",
-            &"L-no-notify".into(),
-            &PortSchemaSpec::Any,
-            crate::iceoryx2::ReadMode::SkipToLatest,
-            8,
-            &channel,
-            None,
-        )
-        .expect("a data-only destination wires without a notify service");
+        let (source_output, dest_input) =
+            wire_one_test_link::<MockInputOnlyProcessor::Processor>("data-only", false);
 
         assert!(
             source_output.has_channel_publisher("out1"),
@@ -1223,55 +1259,10 @@ mod tests {
     /// the fix removes notifiers only where nobody reads them.
     #[test]
     fn a_destination_that_consumes_notifications_keeps_its_notifier_and_listener() {
-        use crate::core::test_support::{MockOutputOnlyProcessor, MockReactiveInputOnlyProcessor};
+        use crate::core::test_support::MockReactiveInputOnlyProcessor;
 
-        let mut graph = Graph::new();
-        let source_id = add_mock_output_only(&mut graph);
-        let dest_id = add_mock_reactive_input_only(&mut graph);
-        let (source, source_output, _) =
-            attach_mock_instance::<MockOutputOnlyProcessor::Processor>(&mut graph, &source_id);
-        let source_output = source_output.expect("an output-only mock holds an output writer");
-        let (dest, _, dest_input) =
-            attach_mock_instance::<MockReactiveInputOnlyProcessor::Processor>(&mut graph, &dest_id);
-        let dest_input = dest_input.expect("an input-only mock holds input mailboxes");
-
-        let node = crate::iceoryx2::Iceoryx2Node::new().expect("an iceoryx2 node must open");
-        let channel = node
-            .open_or_create_service(
-                &format!("test-notified-{}/out1", std::process::id()),
-                2,
-                8,
-                true,
-            )
-            .expect("the channel service must open");
-        let notify_service = open_test_notify_service("reactive-dest");
-
-        wire_rust_source(
-            &source,
-            "out1",
-            &"L-notify".into(),
-            &PortSchemaSpec::Any,
-            &channel,
-            Some(&notify_service),
-            ChannelEgressConfig {
-                service_name: "test-notified/out1".to_string(),
-                trust_tier: ChannelTrustTier::Trusted,
-                expected_payload_bytes: 4096,
-                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
-            },
-        )
-        .expect("a notified source wires");
-        wire_rust_dest(
-            &dest,
-            "in1",
-            &"L-notify".into(),
-            &PortSchemaSpec::Any,
-            crate::iceoryx2::ReadMode::SkipToLatest,
-            8,
-            &channel,
-            Some(&notify_service),
-        )
-        .expect("a notified destination wires");
+        let (source_output, dest_input) =
+            wire_one_test_link::<MockReactiveInputOnlyProcessor::Processor>("notified", true);
 
         assert_eq!(
             source_output.channel_notifier_count("out1"),

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -112,9 +112,22 @@ pub fn open_iceoryx2_service(
     let channel_service_name = channel_service_name(&source_proc_id, &source_port)?;
     let notify_service_name = notify_service_name_for(&dest_proc_id);
 
+    // A notifier aimed at a destination that never drains its listener fills
+    // that listener's queue and then silently stops being delivered for the
+    // rest of the run, one iceoryx2 warning per frame (#1764). The notify
+    // service exists to wake a waiting destination, so a destination that does
+    // not wait gets none of it: no service, no notifier, no listener.
+    let dest_consumes_notifications =
+        destination_consumes_notifications(graph, &dest_proc_id, dest_is_subprocess);
+    let wired_notify_service_name = if dest_consumes_notifications {
+        notify_service_name.as_str()
+    } else {
+        ""
+    };
+
     tracing::info!(
         channel = %channel_service_name,
-        notify = %notify_service_name,
+        notify = %wired_notify_service_name,
         "Opening iceoryx2 channel: {} ({}:{}) -> ({}:{}) [{}] (source_subprocess={}, dest_subprocess={})",
         from_port,
         source_proc_id,
@@ -166,8 +179,9 @@ pub fn open_iceoryx2_service(
         max_queued_messages,
         enable_safe_overflow,
     )?;
-    let notify_service =
-        iceoryx2_node.open_or_create_notify_service(&notify_service_name, max_notifiers)?;
+    let notify_service = dest_consumes_notifications
+        .then(|| iceoryx2_node.open_or_create_notify_service(&notify_service_name, max_notifiers))
+        .transpose()?;
 
     // Source side: install the single channel publisher (first link out of this
     // port) and append this link's destination notifier.
@@ -177,7 +191,7 @@ pub fn open_iceoryx2_service(
             &source_proc_id,
             &source_port,
             &channel_service_name,
-            &notify_service_name,
+            wired_notify_service_name,
             &output_schema,
             expected_payload,
             channel_ceiling_bytes,
@@ -195,7 +209,7 @@ pub fn open_iceoryx2_service(
             link_id,
             &output_schema,
             &service,
-            &notify_service,
+            notify_service.as_ref(),
             ChannelEgressConfig {
                 service_name: channel_service_name.clone(),
                 trust_tier,
@@ -213,7 +227,7 @@ pub fn open_iceoryx2_service(
             &dest_proc_id,
             &dest_port,
             &channel_service_name,
-            &notify_service_name,
+            wired_notify_service_name,
             drain_order,
             max_queued_messages,
             max_subscribers,
@@ -231,7 +245,7 @@ pub fn open_iceoryx2_service(
             drain_order,
             max_queued_messages,
             &service,
-            &notify_service,
+            notify_service.as_ref(),
         )?;
     }
 
@@ -477,6 +491,39 @@ fn destination_fanin(graph: &mut Graph, dest_proc_id: &ProcessorUniqueId) -> usi
     graph.traversal_mut().v(dest_proc_id).in_e().iter().count()
 }
 
+/// Whether the destination ever drains the listener a notify service exists to
+/// wake — the only condition under which opening one is worth anything.
+///
+/// Reactive is the sole host execution mode that waits on the listener fd.
+/// Continuous and Manual drive themselves and poll their mailboxes, so a
+/// notifier pointed at them fills the listener's queue and then stops being
+/// delivered for the rest of the run, one iceoryx2 warning per frame (#1764).
+/// A destination out of process always drains: its runner selects on the fd
+/// whatever mode the class declares.
+///
+/// The answer is a property of the destination's class, so it is the same for
+/// every inbound link and the incremental `open_or_create` calls agree.
+fn destination_consumes_notifications(
+    graph: &mut Graph,
+    dest_proc_id: &ProcessorUniqueId,
+    dest_is_subprocess: bool,
+) -> bool {
+    if dest_is_subprocess {
+        return true;
+    }
+    // A destination the graph cannot resolve is wired as before; the wiring
+    // path itself reports the missing processor.
+    get_single_processor(graph, dest_proc_id)
+        .map(|dest_processor| {
+            dest_processor
+                .lock()
+                .execution_config()
+                .execution
+                .is_reactive()
+        })
+        .unwrap_or(true)
+}
+
 /// The channel's [`DeliveryProfile`], agreed across every destination the
 /// channel feeds.
 ///
@@ -629,13 +676,16 @@ fn get_single_processor(
 
 /// Install (once) the source's single channel publisher and append this link's
 /// destination notifier onto the Rust source's [`OutputWriterInner`].
+///
+/// `notify_service` is `None` when the destination never drains a listener, and
+/// the link is then wired for data only.
 fn wire_rust_source(
     source_processor: &Arc<Mutex<ProcessorInstance>>,
     source_port: &str,
     link_id: &LinkUniqueId,
     output_schema: &PortSchemaSpec,
     service: &Iceoryx2Service,
-    notify_service: &Iceoryx2NotifyService,
+    notify_service: Option<&Iceoryx2NotifyService>,
     egress_config: ChannelEgressConfig,
 ) -> Result<()> {
     let source_guard = source_processor.lock();
@@ -657,13 +707,18 @@ fn wire_rust_source(
         );
     }
 
-    let notifier = notify_service.create_notifier()?;
-    output_inner.add_channel_notifier(source_port, link_id.as_str(), notifier);
+    if let Some(notify_service) = notify_service {
+        let notifier = notify_service.create_notifier()?;
+        output_inner.add_channel_notifier(source_port, link_id.as_str(), notifier);
+    }
     Ok(())
 }
 
 /// Subscribe the Rust destination to the channel bound to its local input port,
 /// and ensure its single listener exists.
+///
+/// `notify_service` is `None` when this destination never drains a listener, and
+/// no listener is created for it.
 fn wire_rust_dest(
     dest_processor: &Arc<Mutex<ProcessorInstance>>,
     dest_port: &str,
@@ -672,7 +727,7 @@ fn wire_rust_dest(
     drain_order: crate::iceoryx2::ReadMode,
     depth: usize,
     service: &Iceoryx2Service,
-    notify_service: &Iceoryx2NotifyService,
+    notify_service: Option<&Iceoryx2NotifyService>,
 ) -> Result<()> {
     let dest_guard = dest_processor.lock();
     let Some(input_inner) = dest_guard.iceoryx2_input_mailboxes_inner() else {
@@ -691,10 +746,13 @@ fn wire_rust_dest(
         dest_port
     );
 
-    if !input_inner.has_listener() {
-        let listener = notify_service.create_listener()?;
-        input_inner.set_listener(listener);
-        tracing::debug!("Created listener for destination on its notify service");
+    match notify_service {
+        Some(notify_service) if !input_inner.has_listener() => {
+            let listener = notify_service.create_listener()?;
+            input_inner.set_listener(listener);
+            tracing::debug!("Created listener for destination on its notify service");
+        }
+        _ => {}
     }
     Ok(())
 }
@@ -1002,6 +1060,229 @@ mod tests {
         ));
     }
 
+    /// Attach a live instance of `P` to `proc_id`, holding the iceoryx2
+    /// resources its declared ports call for — the state the factory leaves a
+    /// host-run processor in before the wiring op reaches it.
+    fn attach_mock_instance<P>(
+        graph: &mut Graph,
+        proc_id: &str,
+    ) -> (
+        Arc<Mutex<ProcessorInstance>>,
+        Option<Arc<crate::iceoryx2::OutputWriterInner>>,
+        Option<Arc<crate::iceoryx2::InputMailboxesInner>>,
+    )
+    where
+        P: crate::core::GeneratedProcessor + DynGeneratedProcessor + Send + 'static,
+        P::Config: Default,
+    {
+        let mut instance = ProcessorInstance::LegacyDyn(Box::new(
+            P::from_config(Default::default())
+                .expect("the mock constructs from its default config"),
+        ));
+        instance
+            .install_iceoryx2_resources()
+            .expect("the mock accepts its iceoryx2 resources");
+        let output_inner = instance.iceoryx2_output_writer_inner();
+        let input_inner = instance.iceoryx2_input_mailboxes_inner();
+        let instance = attach_processor_instance(graph, proc_id, instance);
+        (instance, output_inner, input_inner)
+    }
+
+    /// A notify service usable by both sides of one link.
+    fn open_test_notify_service(tag: &str) -> crate::iceoryx2::Iceoryx2NotifyService {
+        crate::iceoryx2::Iceoryx2Node::new()
+            .expect("an iceoryx2 node must open")
+            .open_or_create_notify_service(
+                &format!(
+                    "test/notify/{}/{}/{}",
+                    tag,
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos()
+                ),
+                1,
+            )
+            .expect("the notify service must open")
+    }
+
+    /// The decision behind #1764: only a destination that will actually wait on
+    /// its listener is worth opening a notify service for.
+    ///
+    /// Manual and Continuous destinations drive themselves and poll their
+    /// mailboxes — a notifier aimed at one fills its listener and then floods
+    /// the terminal for the rest of the run. Revert this predicate to a
+    /// constant `true` and every `DisplayWindow`-shaped sink is back to that.
+    #[test]
+    fn only_a_reactive_or_out_of_process_destination_consumes_notifications() {
+        use crate::core::test_support::{MockInputOnlyProcessor, MockReactiveInputOnlyProcessor};
+
+        let mut graph = Graph::new();
+
+        let self_driven_id = add_mock_input_only(&mut graph);
+        attach_mock_instance::<MockInputOnlyProcessor::Processor>(&mut graph, &self_driven_id);
+        assert!(
+            !destination_consumes_notifications(&mut graph, &self_driven_id.as_str().into(), false),
+            "a manual destination never drains its listener, so it must get no notifier"
+        );
+
+        let woken_id = add_mock_reactive_input_only(&mut graph);
+        attach_mock_instance::<MockReactiveInputOnlyProcessor::Processor>(&mut graph, &woken_id);
+        assert!(
+            destination_consumes_notifications(&mut graph, &woken_id.as_str().into(), false),
+            "a reactive destination waits on its listener fd and must keep its notifier"
+        );
+
+        // Out of process the runner selects on the fd whatever mode the class
+        // declares, so the host cannot decide this from execution mode alone.
+        let helper_hosted_id = add_mock_input_only(&mut graph);
+        attach_mock_instance::<MockInputOnlyProcessor::Processor>(&mut graph, &helper_hosted_id);
+        assert!(
+            destination_consumes_notifications(&mut graph, &helper_hosted_id.as_str().into(), true),
+            "a subprocess destination drains its own listener and must keep its notifier"
+        );
+    }
+
+    /// The decision reaches the ports: no notify service means the source
+    /// installs its channel publisher and no notifier, and the destination
+    /// subscribes with no listener. Data wiring is untouched either way — the
+    /// frames still flow, which is why #1764 cost terminal output and not video.
+    #[test]
+    fn a_destination_that_consumes_nothing_is_wired_for_data_only() {
+        use crate::core::test_support::{MockInputOnlyProcessor, MockOutputOnlyProcessor};
+
+        let mut graph = Graph::new();
+        let source_id = add_mock_output_only(&mut graph);
+        let dest_id = add_mock_input_only(&mut graph);
+        let (source, source_output, _) =
+            attach_mock_instance::<MockOutputOnlyProcessor::Processor>(&mut graph, &source_id);
+        let source_output = source_output.expect("an output-only mock holds an output writer");
+        let (dest, _, dest_input) =
+            attach_mock_instance::<MockInputOnlyProcessor::Processor>(&mut graph, &dest_id);
+        let dest_input = dest_input.expect("an input-only mock holds input mailboxes");
+
+        let node = crate::iceoryx2::Iceoryx2Node::new().expect("an iceoryx2 node must open");
+        let channel = node
+            .open_or_create_service(
+                &format!("test-notifierless-{}/out1", std::process::id()),
+                2,
+                8,
+                true,
+            )
+            .expect("the channel service must open");
+
+        wire_rust_source(
+            &source,
+            "out1",
+            &"L-no-notify".into(),
+            &PortSchemaSpec::Any,
+            &channel,
+            None,
+            ChannelEgressConfig {
+                service_name: "test-notifierless/out1".to_string(),
+                trust_tier: ChannelTrustTier::Trusted,
+                expected_payload_bytes: 4096,
+                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+            },
+        )
+        .expect("a data-only source wires without a notify service");
+        wire_rust_dest(
+            &dest,
+            "in1",
+            &"L-no-notify".into(),
+            &PortSchemaSpec::Any,
+            crate::iceoryx2::ReadMode::SkipToLatest,
+            8,
+            &channel,
+            None,
+        )
+        .expect("a data-only destination wires without a notify service");
+
+        assert!(
+            source_output.has_channel_publisher("out1"),
+            "the data path must be wired exactly as before"
+        );
+        assert!(
+            dest_input.has_port("in1"),
+            "the destination's mailbox must be wired exactly as before"
+        );
+        assert!(
+            !dest_input.has_listener(),
+            "a destination that never drains must hold no listener at all"
+        );
+        assert_eq!(
+            source_output.channel_notifier_count("out1"),
+            0,
+            "the source must hold no notifier aimed at a destination that never drains"
+        );
+    }
+
+    /// The same seam with a consuming destination still opens both ends —
+    /// the fix removes notifiers only where nobody reads them.
+    #[test]
+    fn a_destination_that_consumes_notifications_keeps_its_notifier_and_listener() {
+        use crate::core::test_support::{MockOutputOnlyProcessor, MockReactiveInputOnlyProcessor};
+
+        let mut graph = Graph::new();
+        let source_id = add_mock_output_only(&mut graph);
+        let dest_id = add_mock_reactive_input_only(&mut graph);
+        let (source, source_output, _) =
+            attach_mock_instance::<MockOutputOnlyProcessor::Processor>(&mut graph, &source_id);
+        let source_output = source_output.expect("an output-only mock holds an output writer");
+        let (dest, _, dest_input) =
+            attach_mock_instance::<MockReactiveInputOnlyProcessor::Processor>(&mut graph, &dest_id);
+        let dest_input = dest_input.expect("an input-only mock holds input mailboxes");
+
+        let node = crate::iceoryx2::Iceoryx2Node::new().expect("an iceoryx2 node must open");
+        let channel = node
+            .open_or_create_service(
+                &format!("test-notified-{}/out1", std::process::id()),
+                2,
+                8,
+                true,
+            )
+            .expect("the channel service must open");
+        let notify_service = open_test_notify_service("reactive-dest");
+
+        wire_rust_source(
+            &source,
+            "out1",
+            &"L-notify".into(),
+            &PortSchemaSpec::Any,
+            &channel,
+            Some(&notify_service),
+            ChannelEgressConfig {
+                service_name: "test-notified/out1".to_string(),
+                trust_tier: ChannelTrustTier::Trusted,
+                expected_payload_bytes: 4096,
+                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+            },
+        )
+        .expect("a notified source wires");
+        wire_rust_dest(
+            &dest,
+            "in1",
+            &"L-notify".into(),
+            &PortSchemaSpec::Any,
+            crate::iceoryx2::ReadMode::SkipToLatest,
+            8,
+            &channel,
+            Some(&notify_service),
+        )
+        .expect("a notified destination wires");
+
+        assert_eq!(
+            source_output.channel_notifier_count("out1"),
+            1,
+            "a reactive destination's link must still carry its notifier"
+        );
+        assert!(
+            dest_input.has_listener(),
+            "a reactive destination must still hold the listener its runner waits on"
+        );
+    }
+
     /// Look up a registered mock processor's structured ident by its
     /// PascalCase short name.
     fn lookup_registered_ident(short: &str) -> SchemaIdent {
@@ -1041,6 +1322,19 @@ mod tests {
             ))
             .first()
             .expect("mock_input_only_processor must be in the registry")
+            .id
+            .to_string()
+    }
+
+    fn add_mock_reactive_input_only(graph: &mut Graph) -> String {
+        graph
+            .traversal_mut()
+            .add_v(ProcessorSpec::new(
+                lookup_registered_ident("TestMockReactiveInputOnlyProcessor"),
+                serde_json::Value::Null,
+            ))
+            .first()
+            .expect("mock_reactive_input_only_processor must be in the registry")
             .id
             .to_string()
     }

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -707,6 +707,7 @@ fn wire_rust_source(
         );
     }
 
+    output_inner.add_channel_link(source_port, link_id.as_str());
     if let Some(notify_service) = notify_service {
         let notifier = notify_service.create_notifier()?;
         output_inner.add_channel_notifier(source_port, link_id.as_str(), notifier);

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -497,11 +497,20 @@ fn destination_fanin(graph: &mut Graph, dest_proc_id: &ProcessorUniqueId) -> usi
 /// Continuous and Manual drive themselves and poll their mailboxes, so a
 /// notifier pointed at them fills the listener's queue and then stops being
 /// delivered for the rest of the run, one iceoryx2 warning per frame (#1764).
-/// A destination out of process always drains: its runner selects on the fd
-/// whatever mode the class declares.
 ///
 /// The answer is a property of the destination's class, so it is the same for
 /// every inbound link and the incremental `open_or_create` calls agree.
+///
+/// A destination out of process is assumed to drain, and that assumption is
+/// only true of a reactive one. Every subprocess host reports `Manual` here —
+/// that is the host thread's own mode, not the child's — and the child's
+/// declared mode reaches no wiring-time surface, so this cannot yet ask. A
+/// helper destination explicitly declared `continuous` or `manual` therefore
+/// still gets a notifier its runner never drains, which is #1764 unfixed for
+/// that one shape. Reaching it takes an author writing a non-reactive
+/// execution mode onto a class that has input ports: Python defaults such a
+/// class to `reactive`, which is what every scaffolded and in-tree helper
+/// processor is.
 fn destination_consumes_notifications(
     graph: &mut Graph,
     dest_proc_id: &ProcessorUniqueId,

--- a/runtime/streamlib-engine/src/core/execution/thread_runner.rs
+++ b/runtime/streamlib-engine/src/core/execution/thread_runner.rs
@@ -249,10 +249,10 @@ fn run_reactive_mode(
                     std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
                 }
             },
-            None => std::thread::sleep(NO_WAITER_FALLBACK_SLEEP),
+            None => sleep_then_drain_listener(processor, NO_WAITER_FALLBACK_SLEEP),
         }
         #[cfg(not(target_os = "linux"))]
-        std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
+        sleep_then_drain_listener(processor, NO_WAITER_FALLBACK_SLEEP);
 
         // Drain-loop dispatch: iceoryx2's Event service coalesces
         // multiple notify()s on the same EventId into one fd-readable
@@ -298,6 +298,24 @@ fn run_reactive_mode(
                 break;
             }
         }
+    }
+}
+
+/// The poll-loop tick a reactive runner falls back to when it has no fd waiter
+/// — every tick off Linux, and on Linux when epoll setup failed.
+///
+/// The listener still exists and every upstream still notifies it, so the drain
+/// is not optional: without it the queue fills and iceoryx2 warns on every
+/// frame for the rest of the run (#1764). Waking on the fd is what this loop
+/// gave up, not owning the listener.
+fn sleep_then_drain_listener(
+    processor: &Arc<Mutex<ProcessorInstance>>,
+    sleep_duration: std::time::Duration,
+) {
+    std::thread::sleep(sleep_duration);
+    let guard = processor.lock();
+    if let Some(inner) = guard.iceoryx2_input_mailboxes_inner() {
+        inner.drain_listener();
     }
 }
 

--- a/runtime/streamlib-engine/src/core/execution/thread_runner.rs
+++ b/runtime/streamlib-engine/src/core/execution/thread_runner.rs
@@ -222,24 +222,24 @@ fn run_reactive_mode(
             was_paused = false;
         }
 
+        // Every path that is not waking on the listener fd still owns that
+        // listener, and upstream still notifies it on every frame — so each
+        // one drains. Skip a drain here and the listener's queue fills, after
+        // which iceoryx2 warns per frame for the rest of the run (#1764).
         if is_paused {
             // While paused we deliberately poll: the pause_gate is an
             // AtomicBool with no fd, so on_resume can't fire from epoll.
             std::thread::sleep(PAUSE_CHECK_INTERVAL);
+            drain_input_listener(processor);
             continue;
         }
 
-        // Block until an upstream notify, a shutdown signal, or (only in
-        // the no-waiter fallback) the next channel-poll tick.
+        // Block until an upstream notify, a shutdown signal, or (in the
+        // no-waiter and epoll-error fallbacks) the next channel-poll tick.
         #[cfg(target_os = "linux")]
         match waiter.as_ref() {
             Some(w) => match w.wait() {
-                ReactiveLoopWakeOutcome::Notified => {
-                    let guard = processor.lock();
-                    if let Some(inner) = guard.iceoryx2_input_mailboxes_inner() {
-                        inner.drain_listener();
-                    }
-                }
+                ReactiveLoopWakeOutcome::Notified => drain_input_listener(processor),
                 ReactiveLoopWakeOutcome::Shutdown => {
                     tracing::info!("[{}] Received shutdown via eventfd", id);
                     break;
@@ -247,12 +247,19 @@ fn run_reactive_mode(
                 ReactiveLoopWakeOutcome::Interrupted => continue,
                 ReactiveLoopWakeOutcome::Error => {
                     std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
+                    drain_input_listener(processor);
                 }
             },
-            None => sleep_then_drain_listener(processor, NO_WAITER_FALLBACK_SLEEP),
+            None => {
+                std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
+                drain_input_listener(processor);
+            }
         }
         #[cfg(not(target_os = "linux"))]
-        sleep_then_drain_listener(processor, NO_WAITER_FALLBACK_SLEEP);
+        {
+            std::thread::sleep(NO_WAITER_FALLBACK_SLEEP);
+            drain_input_listener(processor);
+        }
 
         // Drain-loop dispatch: iceoryx2's Event service coalesces
         // multiple notify()s on the same EventId into one fd-readable
@@ -301,18 +308,11 @@ fn run_reactive_mode(
     }
 }
 
-/// The poll-loop tick a reactive runner falls back to when it has no fd waiter
-/// — every tick off Linux, and on Linux when epoll setup failed.
+/// Clear the pending events on this processor's listener, so its fd goes
+/// not-readable and the queue upstream keeps filling has room again.
 ///
-/// The listener still exists and every upstream still notifies it, so the drain
-/// is not optional: without it the queue fills and iceoryx2 warns on every
-/// frame for the rest of the run (#1764). Waking on the fd is what this loop
-/// gave up, not owning the listener.
-fn sleep_then_drain_listener(
-    processor: &Arc<Mutex<ProcessorInstance>>,
-    sleep_duration: std::time::Duration,
-) {
-    std::thread::sleep(sleep_duration);
+/// No-op for a processor with no input mailboxes (a manual source).
+fn drain_input_listener(processor: &Arc<Mutex<ProcessorInstance>>) {
     let guard = processor.lock();
     if let Some(inner) = guard.iceoryx2_input_mailboxes_inner() {
         inner.drain_listener();
@@ -606,6 +606,64 @@ mod tests {
             n == buf.len() as isize,
             "eventfd write failed: n={n}, err={}",
             std::io::Error::last_os_error()
+        );
+    }
+
+    /// Every reactive tick that is not an fd wake still has to drain, because
+    /// the listener stays subscribed and upstream keeps notifying it. This is
+    /// the primitive those ticks call: a listener saturated to the point of
+    /// undeliverable notifications takes them again straight after.
+    ///
+    /// Fail-without-fix: drop the `drain_input_listener` call from the paused
+    /// branch, the no-waiter arm, or the epoll-error arm and that path is back
+    /// to #1764 — an fd nobody clears, warned about once per frame. Those arms
+    /// are unreachable from the two waiter-backed tests in this module (the
+    /// no-waiter arm is every tick of every reactive processor off Linux), so
+    /// this is what covers them.
+    #[test]
+    fn draining_a_saturated_listener_lets_it_be_notified_again() {
+        use crate::core::test_support::MockInputOnlyProcessor;
+
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let service = node
+            .service_builder(&ServiceName::new(&unique_suffix("saturated-drain")).unwrap())
+            .event()
+            .max_notifiers(1)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap();
+        let notifier = service.notifier_builder().create().unwrap();
+
+        let mut instance = ProcessorInstance::LegacyDyn(Box::new(
+            <MockInputOnlyProcessor::Processor as crate::core::GeneratedProcessor>::from_config(
+                Default::default(),
+            )
+            .expect("the mock constructs from its default config"),
+        ));
+        instance
+            .install_iceoryx2_resources()
+            .expect("the mock accepts its iceoryx2 resources");
+        instance
+            .iceoryx2_input_mailboxes_inner()
+            .expect("an input-only mock holds input mailboxes")
+            .set_listener(service.listener_builder().create().unwrap());
+        let processor = Arc::new(Mutex::new(instance));
+
+        // Well past any plausible queue depth; the ticket measured the onset at
+        // ~280 notifications against the default socket buffer.
+        const SENDS: usize = 8192;
+        let saturated = (0..SENDS).any(|_| notifier.notify().unwrap() == 0);
+        assert!(
+            saturated,
+            "an undrained listener absorbed {SENDS} notifications and still took more"
+        );
+
+        drain_input_listener(&processor);
+
+        assert_eq!(
+            notifier.notify().unwrap(),
+            1,
+            "the listener must take notifications again once the runner drains it"
         );
     }
 

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -496,7 +496,7 @@ impl ProcessorInstance {
     /// Used by the host's connection-wiring path (compiler ops) to
     /// mutate the inner directly via
     /// [`crate::iceoryx2::OutputWriterInner::set_channel_publisher`]
-    /// and [`crate::iceoryx2::OutputWriterInner::add_channel_notifier`]
+    /// and [`crate::iceoryx2::OutputWriterInner::add_channel_link`]
     /// — no plugin ABI hop to the cdylib.
     pub fn iceoryx2_output_writer_inner(&self) -> Option<Arc<crate::iceoryx2::OutputWriterInner>> {
         match self {

--- a/runtime/streamlib-engine/src/core/test_support.rs
+++ b/runtime/streamlib-engine/src/core/test_support.rs
@@ -104,6 +104,26 @@ impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {
     }
 }
 
+/// Mock processor with only input ports, waking on upstream writes rather
+/// than driving itself — the one execution mode that consumes the link
+/// notifications its listener receives.
+#[crate::processor(
+    "@tatolab/streamlib-engine/TestMockReactiveInputOnlyProcessor",
+    execution = reactive,
+    input("in1", any),
+    input("in2", any),
+)]
+pub(crate) struct MockReactiveInputOnlyProcessor;
+
+impl crate::core::ReactiveProcessor for MockReactiveInputOnlyProcessor::Processor {
+    fn process(
+        &mut self,
+        _ctx: &crate::core::context::RuntimeContextLimitedAccess<'_>,
+    ) -> crate::core::error::Result<()> {
+        Ok(())
+    }
+}
+
 /// Register all engine-internal test mock processors with the global
 /// `PROCESSOR_REGISTRY`. Idempotent — safe to call from every test
 /// fixture that builds a graph against `lookup_registered_ident` or
@@ -114,5 +134,6 @@ pub(crate) fn ensure_test_mocks_registered() {
         PROCESSOR_REGISTRY.register::<MockProcessor::Processor>();
         PROCESSOR_REGISTRY.register::<MockOutputOnlyProcessor::Processor>();
         PROCESSOR_REGISTRY.register::<MockInputOnlyProcessor::Processor>();
+        PROCESSOR_REGISTRY.register::<MockReactiveInputOnlyProcessor::Processor>();
     });
 }

--- a/runtime/streamlib-engine/src/iceoryx2/node.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/node.rs
@@ -1092,14 +1092,14 @@ mod tests {
                     },
                 );
             }
-            out_inner.add_channel_notifier(
+            out_inner.add_channel_link(
                 "out",
                 link_id,
-                notify.create_notifier().expect(
+                Some(notify.create_notifier().expect(
                     "create_notifier must fit the notify service's max_notifiers cap — a \
                      leaked notifier from the previous connect would trip \
                      ExceedsMaxSupportedNotifiers here",
-                ),
+                )),
             );
 
             if !in_inner.has_port("in") {

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -216,6 +216,17 @@ impl OutputWriterInner {
         }
     }
 
+    /// Number of destination notifiers this output port's channel holds — one
+    /// per `connect()` link whose destination waits on a listener. Observation
+    /// surface for tests and diagnostics.
+    pub fn channel_notifier_count(&self, output_port: &str) -> usize {
+        self.channels
+            .lock()
+            .get(output_port)
+            .map(|egress| egress.notifiers.len())
+            .unwrap_or(0)
+    }
+
     /// Reclaim the source-side egress for one disconnected `connect()` link.
     ///
     /// When the dropped `link_id` notifier was the port's last outbound link, the

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -27,7 +27,7 @@
 //! installing a channel publisher + destination notifiers at wiring
 //! time) operates on `Arc<OutputWriterInner>` directly via
 //! [`OutputWriterInner::set_channel_publisher`] and
-//! [`OutputWriterInner::add_channel_notifier`] — no PluginAbiObject, no
+//! [`OutputWriterInner::add_channel_link`] — no PluginAbiObject, no
 //! plugin ABI hop.
 //! The cdylib's per-frame `write` calls cross extern "C" exactly
 //! once per emit (sub-microsecond on amd64; see the PR microbench
@@ -72,17 +72,11 @@ fn trust_tier_label(trust_tier: ChannelTrustTier) -> ChannelTrustTierLabel {
 struct ChannelEgress {
     schema_ident: SchemaIdentWire,
     publisher: Publisher<ipc::Service, [u8], ()>,
-    /// Every outbound `connect()` link from this source port. This — not
-    /// [`Self::notifiers`] — is what decides when the last link went away and
+    /// Every outbound `connect()` link from this source port. Its length — not
+    /// the notifier count — is what decides when the last link went away and
     /// the publisher can be released, because a link whose destination never
     /// drains a listener carries no notifier at all.
-    link_ids: Vec<String>,
-    /// One `(link_id, notifier)` per outbound link whose destination waits on a
-    /// listener, so a subset of [`Self::link_ids`]. The link id tags each
-    /// notifier so a per-link `disconnect` reclaims exactly its own (see
-    /// [`OutputWriterInner::remove_channel_link`]) rather than the whole
-    /// fan-out — a source feeding N destinations must keep the other N-1 alive.
-    notifiers: Vec<(String, Notifier<ipc::Service>)>,
+    links: Vec<ChannelEgressLink>,
     /// iceoryx2 service name for this channel (`{source}/{output_port}`) —
     /// carried only for the growth / ceiling tracing fields.
     channel_service_name: String,
@@ -100,6 +94,21 @@ struct ChannelEgress {
     current_slot_capacity_bytes: usize,
     /// Count of samples refused for crossing [`Self::ceiling_bytes`].
     refused_over_ceiling_count: u64,
+}
+
+/// One outbound `connect()` link from a source output port, and the notifier
+/// that wakes its destination.
+///
+/// The notifier is `None` when that destination never drains a listener — a
+/// self-driven sink that polls its mailboxes — because a notification nobody
+/// collects fills the listener's queue and then fails delivery on every frame
+/// for the rest of the run. The link id tags the entry so a per-link
+/// `disconnect` reclaims exactly its own (see
+/// [`OutputWriterInner::remove_channel_link`]) rather than the whole fan-out —
+/// a source feeding N destinations must keep the other N-1 alive.
+struct ChannelEgressLink {
+    link_id: String,
+    notifier: Option<Notifier<ipc::Service>>,
 }
 
 /// The channel-egress primitives that prime an output port's channel
@@ -181,8 +190,7 @@ impl OutputWriterInner {
             ChannelEgress {
                 schema_ident,
                 publisher,
-                link_ids: Vec::new(),
-                notifiers: Vec::new(),
+                links: Vec::new(),
                 channel_service_name: service_name,
                 trust_tier,
                 ceiling_bytes,
@@ -202,37 +210,24 @@ impl OutputWriterInner {
             .unwrap_or(0)
     }
 
-    /// Record one outbound `connect()` link from this output port.
+    /// Record one outbound `connect()` link from this output port, with the
+    /// notifier that wakes its destination.
     ///
-    /// Called for every link, notifier or not — this is the set
-    /// [`Self::remove_channel_link`] counts down to decide the publisher's
-    /// release. No-op if the channel publisher has not been installed yet,
-    /// which the wiring op never does.
-    pub fn add_channel_link(&self, output_port: &str, link_id: &str) {
-        if let Some(egress) = self.channels.lock().get_mut(output_port) {
-            egress.link_ids.push(link_id.to_string());
-        }
-    }
-
-    /// Append a destination notifier to an output port's channel, tagged with
-    /// the `link_id` of the `connect()` link it serves.
-    ///
-    /// One notifier per outbound link whose destination waits on a listener —
-    /// each wakes a distinct destination's listener fd. A destination that
-    /// never drains one gets no notifier, so this is a subset of the links
-    /// [`Self::add_channel_link`] recorded. The `link_id` tag lets a later
-    /// per-link `disconnect` reclaim exactly this notifier via
-    /// [`Self::remove_channel_link`]. No-op (the notifier is dropped) if the
-    /// channel publisher has not been installed yet, which the wiring op never
-    /// does.
-    pub fn add_channel_notifier(
+    /// Pass `None` when the destination never drains a listener; the link is
+    /// then carried for reclaim bookkeeping and notified on no frame. No-op
+    /// (the notifier is dropped) if the channel publisher has not been
+    /// installed yet, which the wiring op never does.
+    pub fn add_channel_link(
         &self,
         output_port: &str,
         link_id: &str,
-        notifier: Notifier<ipc::Service>,
+        notifier: Option<Notifier<ipc::Service>>,
     ) {
         if let Some(egress) = self.channels.lock().get_mut(output_port) {
-            egress.notifiers.push((link_id.to_string(), notifier));
+            egress.links.push(ChannelEgressLink {
+                link_id: link_id.to_string(),
+                notifier,
+            });
         }
     }
 
@@ -243,7 +238,7 @@ impl OutputWriterInner {
         self.channels
             .lock()
             .get(output_port)
-            .map(|egress| egress.notifiers.len())
+            .map(|egress| egress.links.iter().filter(|l| l.notifier.is_some()).count())
             .unwrap_or(0)
     }
 
@@ -261,13 +256,12 @@ impl OutputWriterInner {
         let Some(egress) = channels.get_mut(output_port) else {
             return false;
         };
-        egress.link_ids.retain(|id| id != link_id);
-        egress.notifiers.retain(|(id, _)| id != link_id);
         // Keyed on the links, not the notifiers: a fan-out mixing destinations
         // that wait with destinations that poll holds fewer notifiers than
         // links, and releasing the publisher on the last *notifier* would cut
         // off the polling destinations still connected.
-        if egress.link_ids.is_empty() {
+        egress.links.retain(|link| link.link_id != link_id);
+        if egress.links.is_empty() {
             channels.remove(output_port);
             true
         } else {
@@ -335,7 +329,7 @@ impl OutputWriterInner {
         // (e.g. a listener not yet created) — log and continue rather than
         // failing the publish; the data is already in shared memory and the
         // next send() will wake the listener anyway.
-        for (_link_id, notifier) in &egress.notifiers {
+        for notifier in egress.links.iter().filter_map(|link| link.notifier.as_ref()) {
             if let Err(e) = notifier.notify() {
                 tracing::trace!(
                     "OutputWriter: notify() failed for port '{}': {:?}",
@@ -646,7 +640,7 @@ mod tests {
                 ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
             },
         );
-        inner.add_channel_notifier("out", "L-test-notify", notifier);
+        inner.add_channel_link("out", "L-test-notify", Some(notifier));
 
         // Pre-flight: the listener has no events queued.
         let mut count: usize = 0;
@@ -718,9 +712,12 @@ mod tests {
         );
 
         // The waiting destination brings a notifier; the polling one does not.
-        inner.add_channel_link("out", "L-waits");
-        inner.add_channel_notifier("out", "L-waits", notify.notifier_builder().create().unwrap());
-        inner.add_channel_link("out", "L-polls");
+        inner.add_channel_link(
+            "out",
+            "L-waits",
+            Some(notify.notifier_builder().create().unwrap()),
+        );
+        inner.add_channel_link("out", "L-polls", None);
 
         assert!(
             !inner.remove_channel_link("out", "L-waits"),
@@ -867,10 +864,10 @@ mod tests {
                 .max_listeners(1)
                 .open_or_create()
                 .unwrap();
-            inner.add_channel_notifier(
+            inner.add_channel_link(
                 "out",
                 &format!("L-test-fanout-{i}"),
-                notify.notifier_builder().create().unwrap(),
+                Some(notify.notifier_builder().create().unwrap()),
             );
             listeners.push(notify.listener_builder().create().unwrap());
         }
@@ -955,10 +952,8 @@ mod tests {
                 .create()
                 .unwrap()
         };
-        inner.add_channel_link("out", "L-link-a");
-        inner.add_channel_notifier("out", "L-link-a", notify("reclaim/notify/a"));
-        inner.add_channel_link("out", "L-link-b");
-        inner.add_channel_notifier("out", "L-link-b", notify("reclaim/notify/b"));
+        inner.add_channel_link("out", "L-link-a", Some(notify("reclaim/notify/a")));
+        inner.add_channel_link("out", "L-link-b", Some(notify("reclaim/notify/b")));
         assert!(inner.has_channel_publisher("out"));
 
         // Disconnect one of two links: the channel (and publisher) survive.

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -639,6 +639,73 @@ mod tests {
         );
     }
 
+    /// Why a notifier aimed at a destination that never drains is a defect and
+    /// not merely waste: iceoryx2 posts to the listener's signal mechanism on
+    /// every `notify()`, so an undrained listener's queue fills after a bounded
+    /// number of sends and every send after that fails to deliver —
+    /// permanently, since nothing will ever drain it. Drain the same listener
+    /// and the same send count delivers every time.
+    ///
+    /// The observable is `notify()`'s `Ok(usize)` — the number of listeners it
+    /// actually triggered. A failed delivery does not surface as `Err`:
+    /// iceoryx2 logs its own per-connection warning (a `{:?}` of the whole
+    /// `Notifier`, kilobytes wide) and returns a count that excludes the
+    /// listener it could not reach. That swallowed count is why the flood in
+    /// #1764 ran for the life of the process with the engine none the wiser.
+    #[test]
+    fn an_undrained_listener_stops_being_delivered_to_a_drained_one_never_does() {
+        // Well past any plausible queue depth — the ticket measured the onset
+        // at ~280 notifications against the default socket buffer.
+        const SENDS: usize = 8192;
+
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+
+        let open_notify_service = |name: &str| {
+            node.service_builder(&ServiceName::new(name).unwrap())
+                .event()
+                .max_notifiers(1)
+                .max_listeners(1)
+                .open_or_create()
+                .unwrap()
+        };
+
+        let undrained = open_notify_service(&unique_suffix("saturation/undrained"));
+        let undrained_notifier = undrained.notifier_builder().create().unwrap();
+        let _undrained_listener = undrained.listener_builder().create().unwrap();
+
+        let mut sends_until_undeliverable = None;
+        for send in 0..SENDS {
+            if undrained_notifier.notify().unwrap() == 0 {
+                sends_until_undeliverable = Some(send);
+                break;
+            }
+        }
+        let saturated_at = sends_until_undeliverable.unwrap_or_else(|| {
+            panic!("an undrained listener absorbed {SENDS} notifications and still took more")
+        });
+
+        // Once full it stays full: this is what turns a one-off warning into a
+        // per-frame flood for the rest of the run.
+        assert_eq!(
+            undrained_notifier.notify().unwrap(),
+            0,
+            "delivery recovered after saturating at send {saturated_at} with nothing draining"
+        );
+
+        let drained = open_notify_service(&unique_suffix("saturation/drained"));
+        let drained_notifier = drained.notifier_builder().create().unwrap();
+        let drained_listener = drained.listener_builder().create().unwrap();
+
+        for send in 0..SENDS {
+            assert_eq!(
+                drained_notifier.notify().unwrap(),
+                1,
+                "send {send} reached no listener despite the listener being drained every time"
+            );
+            drained_listener.try_wait_all(|_| {}).unwrap();
+        }
+    }
+
     /// 1→N fan-out DELIVERY lock (#1419): a single `write_raw` publishes ONE
     /// frame that reaches EVERY subscriber on the channel through one zero-copy
     /// loan + one send. Three subscribers each receive exactly one copy of the

--- a/runtime/streamlib-engine/src/iceoryx2/output.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/output.rs
@@ -72,9 +72,14 @@ fn trust_tier_label(trust_tier: ChannelTrustTier) -> ChannelTrustTierLabel {
 struct ChannelEgress {
     schema_ident: SchemaIdentWire,
     publisher: Publisher<ipc::Service, [u8], ()>,
-    /// One `(link_id, notifier)` per outbound `connect()` link from this source
-    /// port. The link id tags each notifier so a per-link `disconnect` reclaims
-    /// exactly its own notifier (see
+    /// Every outbound `connect()` link from this source port. This — not
+    /// [`Self::notifiers`] — is what decides when the last link went away and
+    /// the publisher can be released, because a link whose destination never
+    /// drains a listener carries no notifier at all.
+    link_ids: Vec<String>,
+    /// One `(link_id, notifier)` per outbound link whose destination waits on a
+    /// listener, so a subset of [`Self::link_ids`]. The link id tags each
+    /// notifier so a per-link `disconnect` reclaims exactly its own (see
     /// [`OutputWriterInner::remove_channel_link`]) rather than the whole
     /// fan-out — a source feeding N destinations must keep the other N-1 alive.
     notifiers: Vec<(String, Notifier<ipc::Service>)>,
@@ -176,6 +181,7 @@ impl OutputWriterInner {
             ChannelEgress {
                 schema_ident,
                 publisher,
+                link_ids: Vec::new(),
                 notifiers: Vec::new(),
                 channel_service_name: service_name,
                 trust_tier,
@@ -196,12 +202,26 @@ impl OutputWriterInner {
             .unwrap_or(0)
     }
 
+    /// Record one outbound `connect()` link from this output port.
+    ///
+    /// Called for every link, notifier or not — this is the set
+    /// [`Self::remove_channel_link`] counts down to decide the publisher's
+    /// release. No-op if the channel publisher has not been installed yet,
+    /// which the wiring op never does.
+    pub fn add_channel_link(&self, output_port: &str, link_id: &str) {
+        if let Some(egress) = self.channels.lock().get_mut(output_port) {
+            egress.link_ids.push(link_id.to_string());
+        }
+    }
+
     /// Append a destination notifier to an output port's channel, tagged with
     /// the `link_id` of the `connect()` link it serves.
     ///
-    /// One notifier per `connect()` link out of this port — each wakes a distinct
-    /// destination's listener fd. The `link_id` tag lets a later per-link
-    /// `disconnect` reclaim exactly this notifier via
+    /// One notifier per outbound link whose destination waits on a listener —
+    /// each wakes a distinct destination's listener fd. A destination that
+    /// never drains one gets no notifier, so this is a subset of the links
+    /// [`Self::add_channel_link`] recorded. The `link_id` tag lets a later
+    /// per-link `disconnect` reclaim exactly this notifier via
     /// [`Self::remove_channel_link`]. No-op (the notifier is dropped) if the
     /// channel publisher has not been installed yet, which the wiring op never
     /// does.
@@ -241,8 +261,13 @@ impl OutputWriterInner {
         let Some(egress) = channels.get_mut(output_port) else {
             return false;
         };
+        egress.link_ids.retain(|id| id != link_id);
         egress.notifiers.retain(|(id, _)| id != link_id);
-        if egress.notifiers.is_empty() {
+        // Keyed on the links, not the notifiers: a fan-out mixing destinations
+        // that wait with destinations that poll holds fewer notifiers than
+        // links, and releasing the publisher on the last *notifier* would cut
+        // off the polling destinations still connected.
+        if egress.link_ids.is_empty() {
             channels.remove(output_port);
             true
         } else {
@@ -650,6 +675,70 @@ mod tests {
         );
     }
 
+    /// A source port fanning out to a mix of destinations — one that waits on a
+    /// listener, one that polls — holds fewer notifiers than links. Releasing
+    /// the publisher when the last *notifier* goes would cut the polling
+    /// destination off mid-stream, so the release keys on the links.
+    #[test]
+    fn a_fan_out_holds_its_publisher_until_the_last_link_goes_not_the_last_notifier() {
+        let node = NodeBuilder::new().create::<ipc::Service>().unwrap();
+        let pubsub_name = unique_suffix("mixed-fanout/pubsub");
+        let notify_name = unique_suffix("mixed-fanout/notify");
+
+        let pubsub = node
+            .service_builder(&ServiceName::new(&pubsub_name).unwrap())
+            .publish_subscribe::<[u8]>()
+            .max_publishers(2)
+            .open_or_create()
+            .unwrap();
+        let publisher = pubsub
+            .publisher_builder()
+            .initial_max_slice_len(4096)
+            .create()
+            .unwrap();
+        let notify = node
+            .service_builder(&ServiceName::new(&notify_name).unwrap())
+            .event()
+            .max_notifiers(2)
+            .max_listeners(1)
+            .open_or_create()
+            .unwrap();
+
+        let inner = Arc::new(OutputWriterInner::new());
+        inner.set_channel_publisher(
+            "out",
+            SchemaIdentWire::from_segments("tatolab", "core", "VideoFrame", 1, 0, 0).unwrap(),
+            publisher,
+            ChannelEgressConfig {
+                service_name: "test/mixed-fanout".to_string(),
+                trust_tier: crate::iceoryx2::ChannelTrustTier::Trusted,
+                expected_payload_bytes: 4096,
+                ceiling_bytes: crate::iceoryx2::TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
+            },
+        );
+
+        // The waiting destination brings a notifier; the polling one does not.
+        inner.add_channel_link("out", "L-waits");
+        inner.add_channel_notifier("out", "L-waits", notify.notifier_builder().create().unwrap());
+        inner.add_channel_link("out", "L-polls");
+
+        assert!(
+            !inner.remove_channel_link("out", "L-waits"),
+            "the polling destination is still connected, so the publisher must survive"
+        );
+        assert!(
+            inner.has_channel_publisher("out"),
+            "dropping the only notifier must not take the channel down with it"
+        );
+        assert_eq!(inner.channel_notifier_count("out"), 0);
+
+        assert!(
+            inner.remove_channel_link("out", "L-polls"),
+            "the last link going away must release the publisher"
+        );
+        assert!(!inner.has_channel_publisher("out"));
+    }
+
     /// Why a notifier aimed at a destination that never drains is a defect and
     /// not merely waste: iceoryx2 posts to the listener's signal mechanism on
     /// every `notify()`, so an undrained listener's queue fills after a bounded
@@ -810,11 +899,15 @@ mod tests {
     }
 
     /// Per-link source reclaim (#1549): a source port feeding two destination
-    /// links holds two tagged notifiers on ONE channel egress. Disconnecting one
-    /// link drops only its notifier (the channel — and its publisher — survive so
-    /// the other destination keeps receiving); disconnecting the last link removes
-    /// the whole channel egress, releasing the publisher so a reconnect recreates
-    /// a fresh-sized service.
+    /// links that both wait on a listener holds two tagged notifiers on ONE
+    /// channel egress. Disconnecting one link drops only its notifier (the
+    /// channel — and its publisher — survive so the other destination keeps
+    /// receiving); disconnecting the last link removes the whole channel egress,
+    /// releasing the publisher so a reconnect recreates a fresh-sized service.
+    ///
+    /// The mixed fan-out, where a destination carries no notifier at all, is
+    /// locked separately by
+    /// [`a_fan_out_holds_its_publisher_until_the_last_link_goes_not_the_last_notifier`].
     ///
     /// Fail-without-fix: revert `remove_channel_link` to a no-op (the pre-#1549
     /// `close_iceoryx2_service` behaviour) and the first removal leaves both
@@ -862,7 +955,9 @@ mod tests {
                 .create()
                 .unwrap()
         };
+        inner.add_channel_link("out", "L-link-a");
         inner.add_channel_notifier("out", "L-link-a", notify("reclaim/notify/a"));
+        inner.add_channel_link("out", "L-link-b");
         inner.add_channel_notifier("out", "L-link-b", notify("reclaim/notify/b"));
         assert!(inner.has_channel_publisher("out"));
 

--- a/runtime/streamlib-engine/streamlib.yaml
+++ b/runtime/streamlib-engine/streamlib.yaml
@@ -66,6 +66,17 @@ processors:
         schema: any
         description: Test input port 2
 
+  - name: TestMockReactiveInputOnlyProcessor
+    description: "Mock processor with only input ports, woken by upstream writes, for testing"
+    execution: reactive
+    inputs:
+      - name: in1
+        schema: any
+        description: Test input port 1
+      - name: in2
+        schema: any
+        description: Test input port 2
+
   - name: TestMockOutputOnlyProcessor
     description: "Mock processor with only output ports for testing"
     execution: manual

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -159,6 +159,7 @@ impl PythonProcessorLinkDataAccess {
                         },
                     );
                 }
+                output_writer.add_channel_link(port_name, link_id);
                 // An empty name is the engine saying this destination never
                 // drains a listener, so there is nothing to wake and the link
                 // is wired for data only.

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -159,15 +159,20 @@ impl PythonProcessorLinkDataAccess {
                         },
                     );
                 }
-                let notify_service = node.open_or_create_notify_service(
-                    dest_notify_service_name,
-                    notify_max_notifiers,
-                )?;
-                output_writer.add_channel_notifier(
-                    port_name,
-                    link_id,
-                    notify_service.create_notifier()?,
-                );
+                // An empty name is the engine saying this destination never
+                // drains a listener, so there is nothing to wake and the link
+                // is wired for data only.
+                if !dest_notify_service_name.is_empty() {
+                    let notify_service = node.open_or_create_notify_service(
+                        dest_notify_service_name,
+                        notify_max_notifiers,
+                    )?;
+                    output_writer.add_channel_notifier(
+                        port_name,
+                        link_id,
+                        notify_service.create_notifier()?,
+                    );
+                }
                 Ok(())
             })
             .map_err(|wiring_failure| {

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -92,8 +92,10 @@ impl PythonProcessorLinkDataAccess {
     /// out of `port_name`.
     ///
     /// One call per link. The publisher is installed once — the first link out
-    /// of a port creates it and every later link only appends its notifier —
-    /// because iceoryx2 admits exactly one publisher per channel.
+    /// of a port creates it and every later link only appends itself — because
+    /// iceoryx2 admits exactly one publisher per channel. An empty
+    /// `dest_notify_service_name` means the destination never drains a
+    /// listener, so the link opens no notifier and carries data only.
     #[pyo3(signature = (
         port_name,
         channel_service_name,
@@ -159,21 +161,19 @@ impl PythonProcessorLinkDataAccess {
                         },
                     );
                 }
-                output_writer.add_channel_link(port_name, link_id);
                 // An empty name is the engine saying this destination never
                 // drains a listener, so there is nothing to wake and the link
                 // is wired for data only.
-                if !dest_notify_service_name.is_empty() {
+                let notifier = if dest_notify_service_name.is_empty() {
+                    None
+                } else {
                     let notify_service = node.open_or_create_notify_service(
                         dest_notify_service_name,
                         notify_max_notifiers,
                     )?;
-                    output_writer.add_channel_notifier(
-                        port_name,
-                        link_id,
-                        notify_service.create_notifier()?,
-                    );
-                }
+                    Some(notify_service.create_notifier()?)
+                };
+                output_writer.add_channel_link(port_name, link_id, notifier);
                 Ok(())
             })
             .map_err(|wiring_failure| {
@@ -186,6 +186,11 @@ impl PythonProcessorLinkDataAccess {
 
     /// Open this processor's subscriber for a link into `port_name`, plus the
     /// one listener every input shares.
+    ///
+    /// `notify_service_name` is always a real name here, unlike the output
+    /// side's: a helper-hosted destination drains its own listener whatever
+    /// execution mode the class declares, so the engine never tells one to
+    /// skip it.
     ///
     /// One call per link. The mailbox and the destination-keyed listener are
     /// installed once — fan-in appends subscribers to the same port, and

--- a/sdk/streamlib-python-wheel/tests/test_cli_launch.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli_launch.py
@@ -389,9 +389,16 @@ def assert_the_window_showed_live_video(node: LaunchedNode, what_ran: str) -> No
     # itself and polls its mailboxes, so it drains no listener; a notifier
     # pointed at it fills that listener and then fails delivery on every frame,
     # each failure a kilobytes-wide iceoryx2 dump. Measured at 303 warnings and
-    # 2.4MB over this graph before #1764. The observation window above is what
-    # makes this assertable — the onset is ~280 notifications in, 9.4s at 30fps,
-    # so a window any shorter than 12s would pass on the broken engine too.
+    # 2.4MB over this graph before #1764.
+    #
+    # The observation window is what makes this assertable: saturation takes
+    # ~280 notifications, and one notification rides every frame the SOURCE
+    # publishes. `TestPatternSource` is `continuous(interval_ms = 33)` on its
+    # own thread, so it publishes ~30/s whatever the display manages —
+    # ~360 by 12s, comfortably past the onset. That rate is independent of
+    # MINIMUM_FRAMES_FOR_LIVE_VIDEO above, which measures what the window drew;
+    # a slow display shortens neither the source's output nor this margin.
+    # Shorten the window below ~9.4s and this assertion stops discriminating.
     undeliverable_notifications = output.count("FailedToDeliverSignal")
     assert undeliverable_notifications == 0, (
         f"{what_ran}: {undeliverable_notifications} undeliverable link notifications in "

--- a/sdk/streamlib-python-wheel/tests/test_cli_launch.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli_launch.py
@@ -385,6 +385,19 @@ def assert_the_window_showed_live_video(node: LaunchedNode, what_ran: str) -> No
         f"{what_ran} showed only {frames_shown.group(1)} frames in "
         f"{SCAFFOLD_OBSERVATION_WINDOW_SECONDS}s — that is a slideshow, not live video"
     )
+    # The MVP minute is a terminal as well as a window. `DisplayWindow` drives
+    # itself and polls its mailboxes, so it drains no listener; a notifier
+    # pointed at it fills that listener and then fails delivery on every frame,
+    # each failure a kilobytes-wide iceoryx2 dump. Measured at 303 warnings and
+    # 2.4MB over this graph before #1764. The observation window above is what
+    # makes this assertable — the onset is ~280 notifications in, 9.4s at 30fps,
+    # so a window any shorter than 12s would pass on the broken engine too.
+    undeliverable_notifications = output.count("FailedToDeliverSignal")
+    assert undeliverable_notifications == 0, (
+        f"{what_ran}: {undeliverable_notifications} undeliverable link notifications in "
+        f"{SCAFFOLD_OBSERVATION_WINDOW_SECONDS}s — something is notifying a destination "
+        f"that never drains its listener; output ended:\n{node.recent_output()}"
+    )
 
 
 def write_app_with_helper_placed_processors(

--- a/sdk/streamlib-python-wheel/tests/test_helper_process.py
+++ b/sdk/streamlib-python-wheel/tests/test_helper_process.py
@@ -205,6 +205,39 @@ def test_a_helper_opens_its_own_ports_from_the_envelope_the_engine_sends():
     }
 
 
+def test_a_helper_publishes_to_a_destination_that_wants_no_notification():
+    """An empty `dest_notify_service_name` is the engine saying this
+    destination never drains a listener — a self-driven sink like
+    `DisplayWindow`, which polls its mailboxes from its own render thread.
+
+    The helper must wire the link for data only. Before #1764 it opened a
+    notify service unconditionally, so the empty name failed the child's whole
+    `setup` on an invalid iceoryx2 service name — reached through the MVP
+    graph's own `helper -> DisplayWindow` link.
+    """
+    from streamlib import ProcessorLinkDataAccess
+
+    link_id = "L-no-notify"
+    destination = ProcessorLinkDataAccess()
+    _helper.wire_link_data_access(
+        destination, {"inputs": [engine_shaped_link_wiring("input", link_id)]}
+    )
+
+    source = ProcessorLinkDataAccess()
+    source_wiring = engine_shaped_link_wiring("output", link_id)
+    source_wiring["dest_notify_service_name"] = ""
+    _helper.wire_link_data_access(source, {"outputs": [source_wiring]})
+
+    source.write_to_output_port("frames_to_downstream", {"frame_index": 12})
+
+    assert destination.any_input_port_has_data(), (
+        "dropping the notifier must not touch data delivery"
+    )
+    assert destination.read_from_input_port("frames_from_upstream") == {
+        "frame_index": 12
+    }
+
+
 # =============================================================================
 # The framed socket
 # =============================================================================

--- a/sdk/streamlib-sdk/src/hello_streamlib_example_e2e.rs
+++ b/sdk/streamlib-sdk/src/hello_streamlib_example_e2e.rs
@@ -139,7 +139,7 @@ fn fixture_frame_traverses_the_inline_forward_processor() {
             ceiling_bytes: TRUSTED_CHANNEL_PAYLOAD_CEILING_BYTES,
         },
     );
-    output_writer_inner.add_channel_notifier("video_out", "L-video-forward", notifier);
+    output_writer_inner.add_channel_link("video_out", "L-video-forward", Some(notifier));
 
     // Sink: an input mailbox subscribed to the same channel, bound to its local
     // `video_in` port. `read_raw` drains the subscriber and hands back the


### PR DESCRIPTION
## Summary

A running graph printed a wall of iceoryx2 warnings — one per frame, each a ~4KB `Debug` dump of the whole `Notifier` — starting a fixed number of frames into every run. The video was always fine; the terminal was the casualty, which is what made it an MVP-sentence bug.

The destination's `Listener` was created for **every** processor with input mailboxes, but only **Reactive** mode ever drains it. `Continuous` and `Manual` processors drive themselves and poll their mailboxes, so the listener they were handed filled at frame rate and then stopped receiving for the life of the process. `DisplayWindow` is `execution = manual` and polls from its winit pump — the notify path into it was write-only.

Taking the ticket's second option: **a link whose consumer does not consume notifications does not open a notifier for it.** No notify service, no notifier, no listener. Out of process the runner selects on the fd, so a subprocess destination keeps its notifier; the engine tells a helper *source* to skip one by sending an empty notify service name, which the wheel now honours alongside the two native SDKs that already did.

Two things the fix turned up that the ticket did not predict:

- **`notify()` never returns `Err` on a failed delivery.** iceoryx2 logs its own per-connection warning internally and returns `Ok(n)` with the unreachable listener excluded from the count. `write_raw` discarded that count, so the engine's existing error check could never have fired — which is why this ran unnoticed for the life of every process.
- **Dropping notifiers silently broke `remove_channel_link`**, which decided "last link out of this port" by counting notifiers. A source fanning out to one waiting and one polling destination would have torn its publisher down on the waiting one's disconnect, cutting the polling one off mid-stream. Caught before review; the egress now records every link with the notifier as an `Option`, behind a single `add_channel_link`, so the split is unrepresentable and the compiler visits every call site.

Also fixed, same defect on other paths: the reactive runner's three non-fd ticks — paused, no-waiter (every tick off Linux; on Linux when epoll setup fails), and epoll-error — each own a listener upstream keeps notifying, and now all drain through one helper.

## Closes

Closes #1764

## Exit criteria

- A destination that never drains a listener is wired for data only — no notify service, no notifier, no listener — while data delivery is byte-for-byte unchanged.
- A reactive or out-of-process destination keeps both ends.
- The scaffolded MVP graph runs clean past the saturation onset.

## Test plan

Red/green verified on the rig (RTX 3090, `DISPLAY=:1`):

| Lock | Result |
|---|---|
| `test_the_scaffolded_app_reaches_a_running_graph` — now counts `FailedToDeliverSignal` over the existing 12s window | **75 warnings with the fix disabled → 0 with it.** Both runs performed on the rig |
| `an_undrained_listener_stops_being_delivered_to_a_drained_one_never_does` | Delivery stops well inside 8192 sends and never resumes; drained never fails |
| `only_a_reactive_or_out_of_process_destination_consumes_notifications` | The predicate itself |
| `a_destination_that_consumes_nothing_is_wired_for_data_only` / `..._keeps_its_notifier_and_listener` | Both ends of the wiring seam |
| `a_fan_out_holds_its_publisher_until_the_last_link_goes_not_the_last_notifier` | The reclaim regression above |
| `draining_a_saturated_listener_lets_it_be_notified_again` | The runner's drain primitive |
| `test_a_helper_publishes_to_a_destination_that_wants_no_notification` | The wheel's empty-name path |

Suites: `cargo test -p streamlib-engine --lib` 1767 passed / 0 failed; `-p streamlib-python-wheel --lib` 39 passed; wheel pytest 113 passed (GPU-free) plus all 8 GPU-gated `test_cli_launch.py` tests on the rig; stubtest clean. Gates: `lint-logging`, `check-no-in-process-placement`, `check-boundaries`, `check-manifest-schema`, `check-processor-source-reachability` all green; BUSL headers present on all 9 changed `.rs` files.

The 12s window discriminates because notifications ride the **source's** publish rate — `TestPatternSource` is `continuous(interval_ms = 33)` on its own thread, ~360 notifications by 12s against a ~280 onset — independent of `MINIMUM_FRAMES_FOR_LIVE_VIDEO`, which measures what the display drew.

## Notes for owner

**One decision I did not make inline.** A helper destination explicitly declared `continuous` or `manual` still gets a notifier its runner never drains — the wheel drains only in `_run_reactive`, and the Deno runner likewise. The predicate cannot currently ask: every subprocess host reports `Manual` from `execution_config()` (that is the *host thread's* mode, not the child's), and the child's declared mode reaches no wiring-time surface. This is pre-existing and not reachable from the MVP graph — Python defaults a class with input ports to `reactive`, which every scaffolded and in-tree helper processor is — so I corrected the comment to state it rather than leave a false claim. **The fix needs a decision that belongs to you:** either the engine learns a child's declared mode at wiring time (a new surface across three subprocess hosts), or helper runners drain unconditionally in their non-reactive loops. Say which and I'll take it.

**Deliberately not locked.** The three non-fd reactive ticks call a tested primitive, but no test proves each *arm* calls it — reverting all three leaves the suite green. Locking them means driving `run_reactive_mode` with a real `RuntimeContext`, which is GPU-gated and so would not run in CI at all. I judged that fixture not worth it for four one-line calls; flagging rather than leaving it silent.

**Non-blocking findings, no tickets filed:**
- `write_raw` discards `notify()`'s triggered-listener count, so a future undrained-listener bug is still invisible to the engine. The ticket's "failing that" clause (iceoryx2's own kilobyte-wide `{:?}`) is left alone since the first clause is satisfied — say the word if you want the log bridge to truncate defensively.
- The host never calls `iceoryx2_log::set_log_level`, so iceoryx2's Debug/Trace records are dropped inside iceoryx2 regardless of `RUST_LOG` — only the cdylib forwarders raise it.
- The saturation test deliberately fills a listener, so it prints two ~4KB iceoryx2 dumps into every engine test run. That is the minimum for what it proves (that delivery stops *and stays* stopped).
- I did not run `cargo fmt`: this repo's committed formatting disagrees with the locally installed rustfmt, which shows 114 diffs against `main` itself. Changed files carry no new fmt drift.
- One full-suite run showed a single failure I did not capture the name of; two subsequent full runs passed clean. A separate gate run independently hit the documented `core::runtime::runtime::tests::stopping` parallel-run flake, which that workflow's own header calls out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for reactive processing by preventing notification channels from becoming saturated.
  - Preserved data delivery for destinations that do not require notifications.
  - Improved fan-out and reconnect behavior when links use mixed polling and notification-based delivery.
  - Prevented undeliverable link notifications during live video processing.
- **Enhancements**
  - Notification services are now configured only where needed, reducing unnecessary notification overhead while retaining reactive wake-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->