### PR TITLE
feat(engine): expose a graph-readiness signal the app process can poll after run()

### DIFF
--- a/runtime/streamlib-engine/src/core/compiler/compiler.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler.rs
@@ -272,7 +272,7 @@ impl Compiler {
                     if let Some(node) = graph.traversal_mut().v(proc_id).first_mut() {
                         // Set state to stopping
                         if let Some(state) = node.get::<StateComponent>() {
-                            *state.0.lock() = ProcessorState::Stopping;
+                            state.transition_to(ProcessorState::Stopping);
                         }
                         // Send shutdown signal — eventfd wakes reactive
                         // mode's epoll, channel send wakes continuous/manual.
@@ -357,7 +357,7 @@ impl Compiler {
                     let mut graph = graph_arc.write();
                     if let Some(node) = graph.traversal_mut().v(proc_id).first_mut() {
                         if let Some(state) = node.get::<StateComponent>() {
-                            *state.0.lock() = ProcessorState::Stopped;
+                            state.transition_to(ProcessorState::Stopped);
                         }
                     }
                     // Remove from graph

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/prepare_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/prepare_processor_op.rs
@@ -6,6 +6,7 @@ use crate::core::graph::{
     Graph, GraphNodeWithComponents, ProcessorPauseGateComponent, ProcessorReadyBarrierComponent,
     ProcessorReadyBarrierHandle, ProcessorUniqueId, ShutdownChannelComponent, StateComponent,
 };
+use crate::core::processors::ProcessorState;
 
 /// Attach infrastructure components to a processor node.
 /// Returns a barrier handle for coordinating with the processor thread.
@@ -25,8 +26,14 @@ pub(crate) fn prepare_processor(
     // Attach infrastructure components (NO ProcessorInstanceComponent - thread creates it)
     node_mut.insert(barrier_component);
     node_mut.insert(ShutdownChannelComponent::new());
-    node_mut.insert(StateComponent::default());
     node_mut.insert(ProcessorPauseGateComponent::new());
+
+    // Transitioned, never re-inserted: `add_v` attached the state when the node
+    // was added, and a fresh component would strand every waiter already
+    // holding the old one.
+    if let Some(state) = node_mut.get::<StateComponent>() {
+        state.transition_to(ProcessorState::Idle);
+    }
 
     tracing::debug!("[{}] Infrastructure components attached", proc_id);
     Ok(barrier_handle)

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/spawn_processor_op.rs
@@ -17,9 +17,9 @@ use crate::core::descriptors::ProcessorRuntime;
 use crate::core::error::{Error, Result};
 use crate::core::execution::run_processor_loop;
 use crate::core::graph::{
-    Graph, GraphNodeWithComponents, ProcessorInstanceComponent, ProcessorPauseGateComponent,
-    ProcessorReadyBarrierComponent, ProcessorUniqueId, ShutdownChannelComponent, StateComponent,
-    SubprocessHandleComponent, ThreadHandleComponent,
+    Graph, GraphNodeWithComponents, ObservableProcessorState, ProcessorInstanceComponent,
+    ProcessorPauseGateComponent, ProcessorReadyBarrierComponent, ProcessorUniqueId,
+    ShutdownChannelComponent, StateComponent, SubprocessHandleComponent, ThreadHandleComponent,
 };
 use crate::core::processors::{PROCESSOR_REGISTRY, ProcessorInstanceFactory, ProcessorState};
 
@@ -287,7 +287,7 @@ fn spawn_dedicated_thread(
                 };
 
                 let state = match node.get::<StateComponent>() {
-                    Some(s) => s.0.clone(),
+                    Some(s) => s.clone_inner(),
                     None => {
                         tracing::error!("[{}] No StateComponent", proc_id_clone);
                         return;
@@ -373,7 +373,7 @@ fn spawn_dedicated_thread(
                 });
                 if let Err(e) = setup_result {
                     tracing::error!("[{}] Setup failed: {}", proc_id_clone, e);
-                    *state_arc.lock() = ProcessorState::Error;
+                    state_arc.transition_to(ProcessorState::Error);
                     return;
                 }
 
@@ -381,7 +381,7 @@ fn spawn_dedicated_thread(
             }
 
             // Update state to Running
-            *state_arc.lock() = ProcessorState::Running;
+            state_arc.transition_to(ProcessorState::Running);
 
             // === PHASE 5: Process loop ===
             tracing::trace!(
@@ -426,7 +426,7 @@ fn spawn_dedicated_thread(
 /// enforcement) — and yield `None` so the caller skips setup and the loop.
 fn full_access_grant_or_mark_untrusted_error(
     isolation_tier: IsolationTier,
-    state_arc: &Arc<Mutex<ProcessorState>>,
+    state_arc: &Arc<ObservableProcessorState>,
     processor_id: &ProcessorUniqueId,
 ) -> Option<FullAccessGrant> {
     match isolation_tier.grant_full_access() {
@@ -439,7 +439,7 @@ fn full_access_grant_or_mark_untrusted_error(
                 processor_id,
                 isolation_tier.as_str(),
             );
-            *state_arc.lock() = ProcessorState::Error;
+            state_arc.transition_to(ProcessorState::Error);
             None
         }
     }
@@ -518,7 +518,7 @@ mod tests {
     /// grant-absence and the `Error` state both flip.
     #[test]
     fn untrusted_tier_gate_refuses_and_marks_error() {
-        let state = Arc::new(Mutex::new(ProcessorState::Idle));
+        let state = Arc::new(ObservableProcessorState::new(ProcessorState::Idle));
         let proc_id = ProcessorUniqueId::from("test.untrusted");
         let grant =
             full_access_grant_or_mark_untrusted_error(IsolationTier::Untrusted, &state, &proc_id);
@@ -527,7 +527,7 @@ mod tests {
             "untrusted tier must not yield a FullAccess grant"
         );
         assert_eq!(
-            *state.lock(),
+            state.current(),
             ProcessorState::Error,
             "the refused untrusted setup must mark the processor Error"
         );
@@ -537,7 +537,7 @@ mod tests {
     /// never touches processor state (setup proceeds normally).
     #[test]
     fn trusted_tier_gate_yields_grant_and_leaves_state() {
-        let state = Arc::new(Mutex::new(ProcessorState::Idle));
+        let state = Arc::new(ObservableProcessorState::new(ProcessorState::Idle));
         let proc_id = ProcessorUniqueId::from("test.trusted");
         let grant = full_access_grant_or_mark_untrusted_error(
             IsolationTier::TrustedInstalled,
@@ -549,7 +549,7 @@ mod tests {
             "trusted tier must yield a FullAccess grant"
         );
         assert_eq!(
-            *state.lock(),
+            state.current(),
             ProcessorState::Idle,
             "the trusted path must not touch processor state"
         );

--- a/runtime/streamlib-engine/src/core/execution/thread_runner.rs
+++ b/runtime/streamlib-engine/src/core/execution/thread_runner.rs
@@ -16,7 +16,7 @@ use parking_lot::Mutex;
 use crate::core::RuntimeContext;
 use crate::core::context::{IsolationTier, RuntimeContextFullAccess, RuntimeContextLimitedAccess};
 use crate::core::execution::{ExecutionConfig, ProcessExecution};
-use crate::core::graph::ProcessorUniqueId;
+use crate::core::graph::{ObservableProcessorState, ProcessorUniqueId};
 use crate::core::processors::{ProcessorInstance, ProcessorState};
 /// Duration to sleep when paused (avoids busy-waiting).
 const PAUSE_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
@@ -33,7 +33,7 @@ pub fn run_processor_loop(
     processor: Arc<Mutex<ProcessorInstance>>,
     shutdown_rx: crossbeam_channel::Receiver<()>,
     #[cfg(unix)] shutdown_eventfd: Option<OwnedFd>,
-    state: Arc<Mutex<ProcessorState>>,
+    state: Arc<ObservableProcessorState>,
     pause_gate: Arc<AtomicBool>,
     exec_config: ExecutionConfig,
     runtime_ctx: RuntimeContext,
@@ -107,7 +107,7 @@ pub fn run_processor_loop(
         }
     }
 
-    *state.lock() = ProcessorState::Stopped;
+    state.transition_to(ProcessorState::Stopped);
     tracing::info!("[{}] Thread stopped", id);
 }
 
@@ -439,7 +439,7 @@ fn run_manual_mode(
     id: &ProcessorUniqueId,
     processor: &Arc<Mutex<ProcessorInstance>>,
     shutdown_rx: &crossbeam_channel::Receiver<()>,
-    state: &Arc<Mutex<ProcessorState>>,
+    state: &Arc<ObservableProcessorState>,
     pause_gate: &Arc<AtomicBool>,
     runtime_ctx: &RuntimeContext,
     isolation_tier: IsolationTier,
@@ -502,7 +502,7 @@ fn run_manual_mode(
         // then overwrite the state with `Stopped`, hiding what happened.
         if !already_reported_failure && processor.lock().has_failed_unrecoverably() {
             tracing::error!("[{}] Processor failed unrecoverably", id);
-            *state.lock() = ProcessorState::Error;
+            state.transition_to(ProcessorState::Error);
             already_reported_failure = true;
         }
 

--- a/runtime/streamlib-engine/src/core/execution/thread_runner.rs
+++ b/runtime/streamlib-engine/src/core/execution/thread_runner.rs
@@ -107,7 +107,7 @@ pub fn run_processor_loop(
         }
     }
 
-    state.transition_to(ProcessorState::Stopped);
+    state.transition_to_unless_already_failed(ProcessorState::Stopped);
     tracing::info!("[{}] Thread stopped", id);
 }
 
@@ -458,6 +458,7 @@ fn run_manual_mode(
             id,
             isolation_tier.as_str(),
         );
+        state.transition_to(ProcessorState::Error);
         return;
     };
     tracing::info!("[{}] Invoking start()...", id);
@@ -467,7 +468,12 @@ fn run_manual_mode(
         match guard.start(&full_ctx) {
             Ok(()) => tracing::info!("[{}] start() completed successfully", id),
             Err(e) => {
-                tracing::warn!("[{}] start() failed: {}", id, e);
+                // Marked here or nowhere: this thread goes straight to
+                // teardown, and a processor whose `start()` failed is not
+                // running — a reader that saw `Running` between `setup` and
+                // here must be able to find out it was wrong.
+                tracing::error!("[{}] start() failed: {}", id, e);
+                state.transition_to(ProcessorState::Error);
                 return;
             }
         }

--- a/runtime/streamlib-engine/src/core/graph/components/state_component.rs
+++ b/runtime/streamlib-engine/src/core/graph/components/state_component.rs
@@ -41,6 +41,22 @@ impl ObservableProcessorState {
         self.changed.notify_all();
     }
 
+    /// Move the processor to `state`, unless it has already failed.
+    ///
+    /// A thread that unwinds after `Error` would otherwise report the state it
+    /// unwound *into* — `Stopped`, indistinguishable from a clean shutdown —
+    /// and lose the only record that anything went wrong. Checked under the
+    /// same lock as the write, so a failure landing concurrently is not
+    /// overwritten either.
+    pub fn transition_to_unless_already_failed(&self, state: ProcessorState) {
+        let mut current = self.current.lock();
+        if *current == ProcessorState::Error {
+            return;
+        }
+        *current = state;
+        self.changed.notify_all();
+    }
+
     /// Block until the processor's `setup` has resolved, one way or the other,
     /// giving up at `deadline`. Returns the state it settled on.
     ///
@@ -162,6 +178,21 @@ mod tests {
             state.wait_until_setup_resolved(Instant::now() + UNREACHABLE_DEADLINE),
             ProcessorState::Running
         );
+    }
+
+    /// The thread that unwinds after a failure reports `Stopped` on its way
+    /// out. It must not bury the failure, or a processor whose `start()` failed
+    /// becomes indistinguishable from one that shut down cleanly.
+    #[test]
+    fn stopping_a_processor_does_not_bury_why_it_stopped() {
+        let failed = ObservableProcessorState::new(ProcessorState::Running);
+        failed.transition_to(ProcessorState::Error);
+        failed.transition_to_unless_already_failed(ProcessorState::Stopped);
+        assert_eq!(failed.current(), ProcessorState::Error);
+
+        let clean = ObservableProcessorState::new(ProcessorState::Running);
+        clean.transition_to_unless_already_failed(ProcessorState::Stopped);
+        assert_eq!(clean.current(), ProcessorState::Stopped);
     }
 
     /// A processor that never starts gives the caller back the state it is

--- a/runtime/streamlib-engine/src/core/graph/components/state_component.rs
+++ b/runtime/streamlib-engine/src/core/graph/components/state_component.rs
@@ -2,19 +2,89 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 use std::sync::Arc;
+use std::time::Instant;
 
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use serde_json::Value as JsonValue;
 
 use super::JsonSerializableComponent;
 use crate::core::processors::ProcessorState;
 
-/// Current state of the processor.
-pub struct StateComponent(pub Arc<Mutex<ProcessorState>>);
+/// A processor's state together with the signal that it changed.
+///
+/// One value rather than a state behind one lock and a notification beside it:
+/// a waiter reading the state through a separate lock can miss the very
+/// transition it waits for, because the writer publishes and notifies in the
+/// window between that read and the wait.
+pub struct ObservableProcessorState {
+    current: Mutex<ProcessorState>,
+    changed: Condvar,
+}
 
-impl Default for StateComponent {
-    fn default() -> Self {
-        Self(Arc::new(Mutex::new(ProcessorState::Idle)))
+impl ObservableProcessorState {
+    /// A processor state starting at `initial`.
+    pub fn new(initial: ProcessorState) -> Self {
+        Self {
+            current: Mutex::new(initial),
+            changed: Condvar::new(),
+        }
+    }
+
+    /// The state the processor is in right now.
+    pub fn current(&self) -> ProcessorState {
+        *self.current.lock()
+    }
+
+    /// Move the processor to `state` and wake everything waiting on it.
+    pub fn transition_to(&self, state: ProcessorState) {
+        *self.current.lock() = state;
+        self.changed.notify_all();
+    }
+
+    /// Block until the processor's `setup` has resolved, one way or the other,
+    /// giving up at `deadline`. Returns the state it settled on.
+    ///
+    /// `Running` means setup returned; `Error` means it failed. A state still
+    /// [`before setup completed`] is the deadline expiring.
+    ///
+    /// [`before setup completed`]: ProcessorState::is_before_setup_completed
+    pub fn wait_until_setup_resolved(&self, deadline: Instant) -> ProcessorState {
+        let mut current = self.current.lock();
+        while current.is_before_setup_completed() {
+            if self.changed.wait_until(&mut current, deadline).timed_out() {
+                break;
+            }
+        }
+        *current
+    }
+}
+
+/// Current state of the processor.
+pub struct StateComponent(Arc<ObservableProcessorState>);
+
+impl StateComponent {
+    /// A processor state starting at `initial`.
+    pub fn new(initial: ProcessorState) -> Self {
+        Self(Arc::new(ObservableProcessorState::new(initial)))
+    }
+
+    /// The state the processor is in right now.
+    pub fn current(&self) -> ProcessorState {
+        self.0.current()
+    }
+
+    /// Move the processor to `state` and wake everything waiting on it.
+    pub fn transition_to(&self, state: ProcessorState) {
+        self.0.transition_to(state);
+    }
+
+    /// Share the state with a thread that will drive or observe it.
+    ///
+    /// The shared value outlives the component, which is what lets a waiter
+    /// keep watching a processor across a graph write it does not hold a lock
+    /// for.
+    pub fn clone_inner(&self) -> Arc<ObservableProcessorState> {
+        Arc::clone(&self.0)
     }
 }
 
@@ -24,7 +94,85 @@ impl JsonSerializableComponent for StateComponent {
     }
 
     fn to_json(&self) -> JsonValue {
-        let state = self.0.lock();
-        serde_json::json!(format!("{:?}", *state))
+        serde_json::json!(self.current().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// A deadline far enough out that reaching it means the wait failed to
+    /// observe the transition, rather than that the machine was slow.
+    const UNREACHABLE_DEADLINE: Duration = Duration::from_secs(30);
+
+    /// The whole point: the wait ends when the transition happens, not when
+    /// the deadline expires. A poll loop would pass the state assertion and
+    /// fail this one's timing bound.
+    #[test]
+    fn a_wait_ends_on_the_transition_rather_than_on_the_deadline() {
+        let state = Arc::new(ObservableProcessorState::new(ProcessorState::Idle));
+
+        let transitioning = Arc::clone(&state);
+        let transition = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            transitioning.transition_to(ProcessorState::Running);
+        });
+
+        let began_waiting = Instant::now();
+        let settled = state.wait_until_setup_resolved(began_waiting + UNREACHABLE_DEADLINE);
+        let waited = began_waiting.elapsed();
+        transition.join().expect("the transition thread panicked");
+
+        assert_eq!(settled, ProcessorState::Running);
+        assert!(
+            waited < Duration::from_secs(5),
+            "waited {waited:?} for a transition that happened after 50ms — the wait is not \
+             riding the change signal"
+        );
+    }
+
+    /// Setup failing has to end the wait too, or a graph with one broken
+    /// processor burns the caller's whole timeout before saying so.
+    #[test]
+    fn a_failed_setup_ends_the_wait() {
+        let state = Arc::new(ObservableProcessorState::new(ProcessorState::Idle));
+
+        let failing = Arc::clone(&state);
+        std::thread::spawn(move || failing.transition_to(ProcessorState::Error))
+            .join()
+            .expect("the transition thread panicked");
+
+        assert_eq!(
+            state.wait_until_setup_resolved(Instant::now() + UNREACHABLE_DEADLINE),
+            ProcessorState::Error
+        );
+    }
+
+    /// The missed-wakeup case: the transition already happened, so there is no
+    /// notification left to receive and the predicate alone has to end the wait.
+    #[test]
+    fn a_transition_that_already_happened_does_not_hang_the_wait() {
+        let state = ObservableProcessorState::new(ProcessorState::Pending);
+        state.transition_to(ProcessorState::Running);
+
+        assert_eq!(
+            state.wait_until_setup_resolved(Instant::now() + UNREACHABLE_DEADLINE),
+            ProcessorState::Running
+        );
+    }
+
+    /// A processor that never starts gives the caller back the state it is
+    /// stuck in, which is what turns the timeout into a diagnostic.
+    #[test]
+    fn an_expired_deadline_reports_the_state_it_gave_up_in() {
+        let state = ObservableProcessorState::new(ProcessorState::Pending);
+
+        let settled = state.wait_until_setup_resolved(Instant::now() + Duration::from_millis(20));
+
+        assert_eq!(settled, ProcessorState::Pending);
+        assert!(settled.is_before_setup_completed());
     }
 }

--- a/runtime/streamlib-engine/src/core/graph/graph_readiness.rs
+++ b/runtime/streamlib-engine/src/core/graph/graph_readiness.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Waiting for a graph's processors to come up.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use super::components::ObservableProcessorState;
+use super::nodes::ProcessorUniqueId;
+use crate::core::error::{Error, Result};
+use crate::core::processors::ProcessorState;
+
+/// Every processor's state, held directly rather than reached through the
+/// graph.
+///
+/// Taken once and then waited on with no lock held: the transitions being
+/// waited for are made by processor threads that need the graph lock to make
+/// them, so a waiter holding it would be waiting for itself. The set is fixed
+/// at the moment it is taken — a processor added afterwards is not in it.
+pub struct ObservableGraphReadiness {
+    processor_states: Vec<(ProcessorUniqueId, Arc<ObservableProcessorState>)>,
+}
+
+impl ObservableGraphReadiness {
+    pub(crate) fn new(
+        processor_states: Vec<(ProcessorUniqueId, Arc<ObservableProcessorState>)>,
+    ) -> Self {
+        Self { processor_states }
+    }
+
+    /// Block until every processor has finished `setup` and reached `Running`,
+    /// giving up after `timeout`.
+    ///
+    /// Processors are waited on in turn against one shared deadline, so a
+    /// failure is reported when the wait reaches it rather than the instant it
+    /// happens. Whichever processor ends the wait, the error names the state
+    /// every processor was in, so a failure behind a slow one is still in the
+    /// report.
+    pub fn wait_until_every_processor_is_running(&self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+
+        for (processor_id, observable_state) in &self.processor_states {
+            let settled = observable_state.wait_until_setup_resolved(deadline);
+            if settled == ProcessorState::Running {
+                continue;
+            }
+            return Err(Error::Runtime(if settled.is_before_setup_completed() {
+                format!(
+                    "[{processor_id}] had not finished setup within {timeout:?} (still \
+                     {settled}); every processor: {}",
+                    self.describe_every_processor()
+                )
+            } else {
+                format!(
+                    "[{processor_id}] is {settled} rather than Running; every processor: {}",
+                    self.describe_every_processor()
+                )
+            }));
+        }
+
+        Ok(())
+    }
+
+    /// Read off the states already held, so the diagnostic never takes the
+    /// graph lock — the timeout it explains is most likely a thread wedged
+    /// holding exactly that lock.
+    fn describe_every_processor(&self) -> String {
+        self.processor_states
+            .iter()
+            .map(|(processor_id, observable_state)| {
+                format!("{processor_id}={}", observable_state.current())
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}

--- a/runtime/streamlib-engine/src/core/graph/mod.rs
+++ b/runtime/streamlib-engine/src/core/graph/mod.rs
@@ -5,6 +5,7 @@ mod components;
 mod data_structure;
 
 mod edges;
+mod graph_readiness;
 mod nodes;
 mod processor_state_ecs_component;
 mod traits;
@@ -16,6 +17,7 @@ mod graph_tests;
 
 // top level
 pub use data_structure::{Graph, GraphState};
+pub use graph_readiness::ObservableGraphReadiness;
 pub use processor_state_ecs_component::{ProcessorState, ProcessorStateComponent};
 pub use traits::{GraphEdgeWithComponents, GraphNodeWithComponents, GraphWeight};
 pub use validation::validate_graph;

--- a/runtime/streamlib-engine/src/core/graph/processor_state_ecs_component.rs
+++ b/runtime/streamlib-engine/src/core/graph/processor_state_ecs_component.rs
@@ -11,7 +11,7 @@ pub enum ProcessorState {
     /// Waiting to be started (registered but not yet running).
     #[default]
     Pending,
-    /// Setup complete, ready to process but not yet active.
+    /// Prepared by the compiler, but its thread has not run `setup` yet.
     Idle,
     /// Actively processing frames.
     Running,
@@ -23,6 +23,21 @@ pub enum ProcessorState {
     Stopped,
     /// Error state (processing failed).
     Error,
+}
+
+impl ProcessorState {
+    /// Whether the processor has yet to finish `setup`.
+    ///
+    /// The two states a processor passes through before its thread runs
+    /// `setup`: `Pending` from the moment it is added to the graph, `Idle` once
+    /// the compiler has prepared it. Every later state means setup resolved —
+    /// `Running` if it returned, `Error` if it raised — which is what makes
+    /// this the readiness predicate: for a processor in a helper process,
+    /// `setup` is the call that waits for the child to register and wire its
+    /// ports.
+    pub fn is_before_setup_completed(self) -> bool {
+        matches!(self, Self::Pending | Self::Idle)
+    }
 }
 
 impl std::fmt::Display for ProcessorState {

--- a/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
+++ b/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
@@ -1,10 +1,6 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
-use std::sync::Arc;
-
-use parking_lot::Mutex;
-
 use crate::core::graph::{
     GraphNodeWithComponents, ProcessorNode, ProcessorTraversalMut, StateComponent,
     TraversalSourceMut,
@@ -16,8 +12,10 @@ use crate::core::processors::{
 impl<'a> TraversalSourceMut<'a> {
     /// Add a new processor node to the graph.
     ///
-    /// On registry miss, the node is still added with empty ports and its
-    /// `StateComponent` initialized to `ProcessorState::Error`. The caller
+    /// The node carries a [`StateComponent`] from here on — `Pending`, or
+    /// `Error` on a registry miss.
+    ///
+    /// On registry miss, the node is still added with empty ports. The caller
     /// (typically `add_processor_impl`) should detect this and surface
     /// `Error::UnknownProcessorType`. Leaving the failed node in the graph
     /// gives API consumers (`GET /api/graph`) visibility of what failed and
@@ -64,10 +62,16 @@ impl<'a> TraversalSourceMut<'a> {
 
         let node_idx = self.graph.add_node(node);
 
-        if registry_miss {
-            if let Some(node_mut) = self.graph.node_weight_mut(node_idx) {
-                node_mut.insert(StateComponent(Arc::new(Mutex::new(ProcessorState::Error))));
-            }
+        // Attached here rather than when the compiler prepares the node, so a
+        // processor has an observable state for its whole life in the graph:
+        // a reader waiting for the graph to come up can hold every processor's
+        // state before `start()` has prepared any of them.
+        if let Some(node_mut) = self.graph.node_weight_mut(node_idx) {
+            node_mut.insert(StateComponent::new(if registry_miss {
+                ProcessorState::Error
+            } else {
+                ProcessorState::Pending
+            }));
         }
 
         ProcessorTraversalMut {

--- a/runtime/streamlib-engine/src/core/observability/inspector.rs
+++ b/runtime/streamlib-engine/src/core/observability/inspector.rs
@@ -39,7 +39,7 @@ impl GraphInspector {
         // Get state from node's component storage if available
         let state = node
             .get::<StateComponent>()
-            .map(|s| *s.0.lock())
+            .map(StateComponent::current)
             .unwrap_or_default();
 
         // Get metrics from node's component storage if available

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -81,7 +81,7 @@ async fn add_processor_impl(
             .v(&node_id)
             .first()
             .and_then(|node| node.get::<StateComponent>())
-            .map(|state_component| matches!(*state_component.0.lock(), ProcessorState::Error))
+            .map(|state_component| state_component.current() == ProcessorState::Error)
             .unwrap_or(false);
 
         if registry_miss {

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -4,6 +4,7 @@
 use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -19,8 +20,8 @@ use crate::core::context::{
     AudioClockConfig, GpuContext, RuntimeContext, SharedAudioClock, TimeContext,
 };
 use crate::core::graph::{
-    GraphNodeWithComponents, GraphState, LinkUniqueId, ProcessorPauseGateComponent,
-    ProcessorUniqueId,
+    GraphNodeWithComponents, GraphState, LinkUniqueId, ObservableGraphReadiness,
+    ProcessorPauseGateComponent, ProcessorUniqueId, StateComponent,
 };
 use crate::core::processors::ProcessorSpec;
 use crate::core::processors::ProcessorState;
@@ -740,7 +741,7 @@ impl Runner {
 
             // Update processor state
             if let Some(state) = node.get::<crate::core::graph::StateComponent>() {
-                *state.0.lock() = ProcessorState::Paused;
+                state.transition_to(ProcessorState::Paused);
             }
 
             // Publish event
@@ -781,7 +782,7 @@ impl Runner {
 
             // Update processor state
             if let Some(state) = node.get::<crate::core::graph::StateComponent>() {
-                *state.0.lock() = ProcessorState::Running;
+                state.transition_to(ProcessorState::Running);
             }
 
             // Publish event
@@ -808,6 +809,40 @@ impl Runner {
 
             Ok(pause_gate.is_paused())
         })
+    }
+
+    // =========================================================================
+    // Graph readiness
+    // =========================================================================
+
+    /// Take hold of every processor's state, to wait on without the graph.
+    ///
+    /// The graph lock is released before anything blocks on what it hands
+    /// back, which is the whole point: the transitions being waited for are
+    /// made by processor threads that need that lock.
+    pub fn observable_graph_readiness(&self) -> ObservableGraphReadiness {
+        ObservableGraphReadiness::new(self.compiler.scope(|graph, _tx| {
+            graph
+                .traversal()
+                .v(())
+                .iter()
+                .filter_map(|node| {
+                    Some((node.id.clone(), node.get::<StateComponent>()?.clone_inner()))
+                })
+                .collect()
+        }))
+    }
+
+    /// Block until every processor in the graph has finished `setup` and
+    /// reached `Running`, giving up after `timeout`.
+    ///
+    /// This is what "the graph is up" means for a processor in a helper
+    /// process: its `setup` is the call that waits for the child to register
+    /// and wire its ports, so a publisher that starts only after this returns
+    /// cannot lose bags to a link nobody has attached to yet.
+    pub fn wait_until_every_processor_is_running(&self, timeout: Duration) -> Result<()> {
+        self.observable_graph_readiness()
+            .wait_until_every_processor_is_running(timeout)
     }
 
     // =========================================================================

--- a/runtime/streamlib-engine/tests/graph_readiness_signal_test.rs
+++ b/runtime/streamlib-engine/tests/graph_readiness_signal_test.rs
@@ -1,0 +1,163 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! `Runner::wait_until_every_processor_is_running` — the signal an app process
+//! polls to know the graph is up.
+//!
+//! What makes it load-bearing: a processor in a helper process attaches its
+//! iceoryx2 subscriber during `setup`, tens of milliseconds after the graph
+//! compiles, and a link drops whatever it carries before its consumer attaches.
+//! A publisher gated on this call cannot lose those bags.
+//!
+//! The trap these tests exist for is the *false ready* — a graph reporting
+//! itself up because it has not been asked to start yet, which is
+//! indistinguishable from success at the call site and reintroduces the exact
+//! drop the signal removes.
+
+use std::time::{Duration, Instant};
+
+use serial_test::serial;
+use streamlib::sdk::descriptors::{
+    Org, Package, PortDescriptor, PortSchemaSpec, ProcessorDescriptor, SchemaIdent, SemVer,
+    TypeName,
+};
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
+use streamlib::sdk::runtime::Runner;
+
+/// Short enough that a test waiting it out stays quick, long enough that
+/// reaching it means nothing transitioned rather than that the machine stalled.
+const SHORT_TIMEOUT: Duration = Duration::from_millis(250);
+
+fn register_test_type(short: &str) -> SchemaIdent {
+    let id = SchemaIdent::new(
+        Org::new("tatolab").unwrap(),
+        Package::new("graph-readiness-signal-test").unwrap(),
+        TypeName::new(short).unwrap(),
+        SemVer::new(1, 0, 0),
+    );
+    let descriptor = ProcessorDescriptor::new(id.clone(), "graph readiness signal test")
+        .with_input(PortDescriptor::new(
+            "bags_from_upstream",
+            "",
+            PortSchemaSpec::Any,
+            false,
+        ))
+        .with_output(PortDescriptor::new(
+            "bags_to_downstream",
+            "",
+            PortSchemaSpec::Any,
+            false,
+        ));
+    let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
+    id
+}
+
+#[test]
+#[serial]
+fn a_graph_with_no_processors_has_nothing_to_wait_for() {
+    let runtime = Runner::new().unwrap();
+
+    runtime
+        .wait_until_every_processor_is_running(SHORT_TIMEOUT)
+        .expect("an empty graph is up by definition");
+}
+
+/// The false-ready guard. A processor is observable from the moment it is
+/// added, not from the moment the compiler prepares it — so a wait that begins
+/// before `start()` sees a `Pending` processor and keeps waiting.
+///
+/// Mentally move the state back to where the compiler attaches it and this
+/// fails: the graph reports zero processors, every one of them is vacuously
+/// running, and the call returns `Ok` on a pipeline that has not started.
+#[test]
+#[serial]
+fn a_graph_that_was_never_started_is_not_reported_as_running() {
+    let runtime = Runner::new().unwrap();
+    let processor_id = runtime
+        .add_processor(ProcessorSpec::new(
+            register_test_type("NeverStarted"),
+            serde_json::json!({}),
+        ))
+        .expect("a registered type adds cleanly");
+
+    let failure = runtime
+        .wait_until_every_processor_is_running(SHORT_TIMEOUT)
+        .expect_err("a graph that never started must not report itself running");
+
+    let reported = failure.to_string();
+    assert!(
+        reported.contains(processor_id.as_str()),
+        "the timeout must name the processor it gave up on, got: {reported}"
+    );
+    assert!(
+        reported.contains("Pending"),
+        "the timeout must say what state it gave up in, got: {reported}"
+    );
+}
+
+/// A failure behind a processor that never starts still reaches the report.
+///
+/// Processors are waited on in turn, so a failure is observed when the wait
+/// reaches it — here it never does, because the processor ahead of it stays
+/// `Pending` until the deadline. What must not happen is the failure going
+/// unmentioned: the caller is told which processor ended the wait *and* what
+/// state every other one was in, so the real cause is in the message either
+/// way.
+#[test]
+#[serial]
+fn a_failure_behind_a_processor_that_never_starts_is_still_reported() {
+    let runtime = Runner::new().unwrap();
+    runtime
+        .add_processor(ProcessorSpec::new(
+            register_test_type("StaysPending"),
+            serde_json::json!({}),
+        ))
+        .expect("a registered type adds cleanly");
+    // A registry miss lands the node in `Error` without spawning anything.
+    let _ = runtime.add_processor(ProcessorSpec::new(
+        streamlib::sdk::schema_ident!("tatolab", "ghost-package", "BehindTheSlowOne", "9.9.9"),
+        serde_json::json!({}),
+    ));
+
+    let reported = runtime
+        .wait_until_every_processor_is_running(SHORT_TIMEOUT)
+        .expect_err("a graph holding a failed processor is not running")
+        .to_string();
+
+    assert!(
+        reported.contains("=Error"),
+        "the failed processor must be in the report even when the wait gave up on another, \
+         got: {reported}"
+    );
+}
+
+/// A processor that cannot run ends the wait where it is rather than burning
+/// the caller's whole timeout — the graph will never come up, and saying so
+/// late is worse than saying so now.
+#[test]
+#[serial]
+fn a_processor_that_failed_ends_the_wait_without_burning_the_timeout() {
+    let runtime = Runner::new().unwrap();
+    // A registry miss leaves the node in the graph in `Error` — the same state
+    // a failed `setup` lands a processor in, reached without spawning one.
+    let _ = runtime.add_processor(ProcessorSpec::new(
+        streamlib::sdk::schema_ident!("tatolab", "ghost-package", "NotRegistered", "9.9.9"),
+        serde_json::json!({}),
+    ));
+
+    let began_waiting = Instant::now();
+    let failure = runtime
+        .wait_until_every_processor_is_running(Duration::from_secs(30))
+        .expect_err("a graph holding a failed processor is not running");
+    let waited = began_waiting.elapsed();
+
+    assert!(
+        failure.to_string().contains("Error rather than Running"),
+        "the failure must distinguish a broken processor from a slow one, got: {failure}"
+    );
+    assert!(
+        waited < Duration::from_secs(5),
+        "waited {waited:?} on a processor that was already Error — the wait is not \
+         short-circuiting on failure"
+    );
+}

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -152,8 +152,9 @@ class Runtime:
         processor is running once its helper process has registered and wired
         its ports; anything published into the graph before that is dropped by
         the link. Raises `RuntimeError` if a processor failed instead of
-        starting or if `timeout` elapses, and `ValueError` for a `timeout` that
-        is negative, NaN, or too large to be a duration.
+        starting, if `timeout` elapses, or if this runtime has already been
+        shut down; and `ValueError` for a `timeout` that is negative, NaN, or
+        too large to be a duration.
         """
 
     def shutdown(self) -> None:

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -144,6 +144,18 @@ class Runtime:
     def run(self) -> None:
         """Run the pipeline until Ctrl-C, SIGTERM or `shutdown()`, then tear down."""
 
+    def wait_until_every_processor_is_running(self, *, timeout: float = 30.0) -> None:
+        """Block until every processor in the graph is running.
+
+        Call it before `run()` or from another thread while `run()` blocks — a
+        graph that has not started yet is waited through, not refused. A Python
+        processor is running once its helper process has registered and wired
+        its ports; anything published into the graph before that is dropped by
+        the link. Raises `RuntimeError` if a processor failed instead of
+        starting or if `timeout` elapses, and `ValueError` for a `timeout` that
+        is negative, NaN, or too large to be a duration.
+        """
+
     def shutdown(self) -> None:
         """Ask the pipeline to stop. Safe from any thread; idempotent."""
 

--- a/sdk/streamlib-python-wheel/python/streamlib/testing.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/testing.py
@@ -154,7 +154,7 @@ class SingleProcessorTestPipeline:
             except queue.Empty:
                 run_failure = None
             if run_failure is not None:
-                raise run_failure
+                raise run_failure from None
             raise
 
     def _run_until_shut_down(self) -> None:

--- a/sdk/streamlib-python-wheel/python/streamlib/testing.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/testing.py
@@ -44,6 +44,11 @@ DEFAULT_BAG_TIMEOUT_SECONDS = 30.0
 # diagnostic rather than a wedged test run.
 ENGINE_TEARDOWN_TIMEOUT_SECONDS = 60.0
 
+# How long `__enter__` waits for every processor's helper process to attach.
+# Generous because a cold first spawn pays for a child interpreter's startup and
+# imports; a graph that has not come up by now is broken, not slow.
+GRAPH_READY_TIMEOUT_SECONDS = 60.0
+
 # Channel names are minted here and travel to the endpoints as configuration —
 # a queue cannot travel through `config`, but the name of one can.
 _next_channel_number = itertools.count()
@@ -58,13 +63,10 @@ _running_pipeline_lock = threading.Lock()
 class SingleProcessorTestPipeline:
     """One processor, with a feeder on every input and a collector on every output.
 
-    **Known gap (#1759): bags fed immediately after `__enter__` can be dropped.**
-    A link discards what it publishes before its consumer has attached, and the
-    processor under test attaches when its helper process finishes registering —
-    tens of milliseconds after the graph compiles. Nothing in this API reports
-    that attach yet, so the loss surfaces as `await_bag` reporting that the
-    processor produced nothing. Until #1759 lands, feed after the graph has been
-    running rather than in the first instants of the `with` block.
+    `__enter__` returns only once every processor is running — which for the
+    processor under test means its helper process has registered and wired its
+    ports — so the first `feed` on the next line cannot be dropped by a link
+    whose consumer has not attached.
     """
 
     def __init__(
@@ -136,6 +138,24 @@ class SingleProcessorTestPipeline:
             target=self._run_until_shut_down, name="streamlib-test-pipeline", daemon=True
         )
         self._run_loop.start()
+        self._await_every_processor_running(runtime)
+
+    def _await_every_processor_running(self, runtime: Runtime) -> None:
+        try:
+            runtime.wait_until_every_processor_is_running(
+                timeout=GRAPH_READY_TIMEOUT_SECONDS
+            )
+        except BaseException:
+            # A graph that never came up usually never started: the run loop
+            # raised on another thread and left every processor where it was.
+            # That failure is the cause; this one is the symptom.
+            try:
+                run_failure = self._run_failure.get_nowait()
+            except queue.Empty:
+                run_failure = None
+            if run_failure is not None:
+                raise run_failure
+            raise
 
     def _run_until_shut_down(self) -> None:
         try:
@@ -174,9 +194,8 @@ class SingleProcessorTestPipeline:
 
         A bag is a named map, same as anything a processor writes.
 
-        Fed in the first instants after `__enter__`, a bag can be dropped before
-        the processor's helper has attached — see this class's docstring and
-        #1759.
+        Safe from the first line of the `with` block: `__enter__` already
+        waited for the processor's helper to attach.
         """
         feed_test_harness_bag(
             self._channel_for(self._input_channels, port_name, "input"), bag

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -8,9 +8,10 @@
 //! not merely stopped — before [`PythonRuntimeHandle::run`] returns, so no
 //! engine thread can still be alive when CPython finalizes.
 
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::time::Duration;
 
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use streamlib::sdk::graph::{InputLinkPortRef, OutputLinkPortRef};
@@ -86,7 +87,10 @@ impl From<EngineTeardownIncomplete> for PyErr {
 /// run loop in the interpreter, which then returns having run nothing.
 enum PythonRuntimeLifecycleState {
     EngineConstructedNotYetRun(Arc<Runner>),
-    RunLoopBlockedUntilShutdownRequested,
+    /// Weak, never strong: the run loop owns the only strong reference, and a
+    /// second one here would make teardown's `Arc::into_inner` find the engine
+    /// still borrowed and report that its threads were never joined.
+    RunLoopBlockedUntilShutdownRequested(Weak<Runner>),
     EngineTornDownAndThreadsJoined,
 }
 
@@ -131,11 +135,43 @@ impl PythonRuntimeHandle {
     fn engine_being_built(&self, what: &str) -> PyResult<Arc<Runner>> {
         match &*self.lifecycle() {
             PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => Ok(engine.clone()),
-            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested => {
+            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested(_) => {
                 Err(PyRuntimeError::new_err(format!(
                     "cannot {what}: this Runtime is already running. Build the whole graph \
                      before calling run()."
                 )))
+            }
+            PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined => {
+                Err(PyRuntimeError::new_err(format!(
+                    "cannot {what}: this Runtime has been shut down. Construct a new one."
+                )))
+            }
+        }
+    }
+
+    /// Take a reference to the engine to read the graph's readiness from.
+    ///
+    /// Answers in both live states, not just the running one. A processor
+    /// carries its state from the moment it is added and the compiler
+    /// transitions that same state rather than replacing it, so a wait started
+    /// against a graph that has not been run yet is already watching the states
+    /// `run()` will move. That is what lets a caller start the run loop on one
+    /// thread and wait on another without sequencing the two — there is no
+    /// window in which the wait arrives too early.
+    ///
+    /// The caller must drop this before waiting on what it reads. The run loop
+    /// has to hold the only strong reference for teardown to join the engine's
+    /// threads, and one kept alive across the wait would make `Arc::into_inner`
+    /// report that it could not.
+    fn engine_to_read_graph_readiness_from(&self, what: &str) -> PyResult<Arc<Runner>> {
+        match &*self.lifecycle() {
+            PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => Ok(engine.clone()),
+            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested(engine) => {
+                engine.upgrade().ok_or_else(|| {
+                    PyRuntimeError::new_err(format!(
+                        "cannot {what}: this Runtime's engine is being torn down."
+                    ))
+                })
             }
             PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined => {
                 Err(PyRuntimeError::new_err(format!(
@@ -310,11 +346,18 @@ impl PythonRuntimeHandle {
     fn run(&self, python: Python<'_>) -> PyResult<()> {
         let engine = {
             let mut lifecycle = self.lifecycle();
+            // Replaced with the terminal state first because the running state
+            // needs the engine to point at, which is what is being taken here.
             match std::mem::replace(
                 &mut *lifecycle,
-                PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested,
+                PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined,
             ) {
-                PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => engine,
+                PythonRuntimeLifecycleState::EngineConstructedNotYetRun(engine) => {
+                    *lifecycle = PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested(
+                        Arc::downgrade(&engine),
+                    );
+                    engine
+                }
                 already_run => {
                     *lifecycle = already_run;
                     return Err(PyRuntimeError::new_err(
@@ -373,7 +416,7 @@ impl PythonRuntimeHandle {
                 drop(lifecycle);
                 Ok(Self::drop_engine_without_holding_the_gil(python, engine)?)
             }
-            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested => {
+            PythonRuntimeLifecycleState::RunLoopBlockedUntilShutdownRequested(_) => {
                 // Issued while still holding the lock: `run()` takes it to move
                 // to the torn-down state and clears the latch there, so this
                 // request cannot outlive the run loop it is meant for.
@@ -382,6 +425,49 @@ impl PythonRuntimeHandle {
             }
             PythonRuntimeLifecycleState::EngineTornDownAndThreadsJoined => Ok(()),
         }
+    }
+
+    /// Block until every processor in the graph is running, then return.
+    ///
+    /// Call it around `run()` — before it, or from another thread while it
+    /// blocks; a graph that has not started yet is waited through rather than
+    /// refused. A processor runs once its `setup` has returned, and for a
+    /// Python processor `setup` is what waits for its helper process to
+    /// register and wire its ports. Publishing into the graph before that
+    /// point loses bags: a link drops what it carries while its consumer is
+    /// not yet attached.
+    ///
+    /// Raises if a processor failed instead of starting, or if `timeout`
+    /// elapses first; the message names the processor and the state it was
+    /// left in, so forgetting `run()` altogether reads as every processor
+    /// still `Pending`.
+    #[pyo3(signature = (*, timeout = 30.0))]
+    fn wait_until_every_processor_is_running(
+        &self,
+        python: Python<'_>,
+        timeout: f64,
+    ) -> PyResult<()> {
+        // Checked rather than `from_secs_f64`, which panics on a negative, a
+        // NaN, or a value too large for a `Duration` — all reachable from
+        // Python, none of them a reason to abort the interpreter.
+        let timeout = Duration::try_from_secs_f64(timeout).map_err(|_| {
+            PyValueError::new_err(format!(
+                "timeout must be a finite, non-negative number of seconds, not {timeout}"
+            ))
+        })?;
+        let engine = self.engine_to_read_graph_readiness_from("wait for the graph to come up")?;
+        // Two detached steps rather than one, so the engine reference is gone
+        // before the long one begins: reading the states needs the engine,
+        // waiting on them does not. Detached because both take the graph lock,
+        // which an engine thread can hold while it needs this interpreter's GIL.
+        let graph_readiness = python.detach(|| {
+            let graph_readiness = engine.observable_graph_readiness();
+            drop(engine);
+            graph_readiness
+        });
+        python
+            .detach(|| graph_readiness.wait_until_every_processor_is_running(timeout))
+            .map_err(|wait_failure| PyRuntimeError::new_err(wait_failure.to_string()))
     }
 
     fn __enter__(python_self: PyRef<'_, Self>) -> PyRef<'_, Self> {

--- a/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
+++ b/sdk/streamlib-python-wheel/tests/interpreter_lifecycle_app.py
@@ -167,6 +167,30 @@ def scenario_shutdown_from_another_thread() -> None:
         marker("STOPPED_FROM_ANOTHER_THREAD")
 
 
+def scenario_readiness_wait_across_teardown() -> None:
+    """A readiness wait taken while `run()` blocks must not break teardown.
+
+    The wait reaches the engine the run loop owns, and the contract says every
+    engine thread is joined before `run()` returns. A reference left behind by
+    the wait makes that join find the engine still borrowed, and `run()` raises
+    instead of returning — a non-zero exit the driver sees.
+    """
+    runtime = streamlib.Runtime()
+
+    def wait_then_stop() -> None:
+        # The same stdin handshake the cross-thread shutdown scenario uses:
+        # until the driver closes it, `run()` may not yet hold the engine.
+        sys.stdin.read()
+        runtime.wait_until_every_processor_is_running(timeout=30.0)
+        marker("GRAPH_READY")
+        runtime.shutdown()
+
+    threading.Thread(target=wait_then_stop, daemon=True).start()
+    runtime.run()
+
+    marker("RUN_RETURNED")
+
+
 def scenario_shutdown_spun_across_the_run_loop_exit() -> None:
     """Hammer `shutdown()` from a worker across the first run loop's exit.
 
@@ -236,6 +260,7 @@ SCENARIOS = {
     "held_by_a_live_thread_at_exit": scenario_held_by_a_live_thread_at_exit,
     "second_run_refused": scenario_second_run_is_refused,
     "shutdown_from_another_thread": scenario_shutdown_from_another_thread,
+    "readiness_wait_across_teardown": scenario_readiness_wait_across_teardown,
     "two_pipelines_in_one_process": scenario_two_pipelines_in_one_process,
     "shutdown_spun_across_the_run_loop_exit": scenario_shutdown_spun_across_the_run_loop_exit,
 }

--- a/sdk/streamlib-python-wheel/tests/test_cli.py
+++ b/sdk/streamlib-python-wheel/tests/test_cli.py
@@ -28,6 +28,26 @@ MINIMAL_APP_SOURCE = "def setup(rt):\n    pass\n"
 RESOLUTION_FAILURE_TIMEOUT_SECONDS = 60.0
 
 
+@pytest.fixture(autouse=True)
+def restore_the_launchers_import_path():
+    """Undo what `execute_app_entry_file` leaves on `sys.path`.
+
+    The launcher leads `sys.path` with the entry file's directory and keeps it
+    there on purpose — the app imports its own modules for as long as it runs,
+    so restoring it the way `sys.argv` is restored would break the app. In a
+    real launch that lasts until the process exits; here it lasts until the end
+    of the pytest session, and each test that launches an app leaves another
+    `tmp_path` in front. The first slot is what a helper process is told to
+    import the app's processors from, so a leaked one sends every later
+    suite's children looking in an empty temporary directory.
+    """
+    launcher_import_path = list(sys.path)
+    try:
+        yield
+    finally:
+        sys.path[:] = launcher_import_path
+
+
 def write_app(directory: Path, file_name: str, source: str = MINIMAL_APP_SOURCE) -> Path:
     entry_file = directory / file_name
     entry_file.parent.mkdir(parents=True, exist_ok=True)

--- a/sdk/streamlib-python-wheel/tests/test_graph_readiness.py
+++ b/sdk/streamlib-python-wheel/tests/test_graph_readiness.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""`Runtime.wait_until_every_processor_is_running`, around and outside its window.
+
+The wait is legal before `run()` as well as during it, which is not a
+convenience: a caller that starts the run loop on another thread cannot know
+when that thread reached `run()`, and refusing the early call would make the
+harness depend on the scheduling order it exists to remove. What makes it sound
+is that a processor carries its state from the moment it is added, so an early
+wait is already watching the states `run()` will move.
+
+After teardown there is nothing left to watch and it has to say so, because the
+alternative — returning as though the graph were up — is the false ready the
+signal was added to remove. A timeout no `Duration` can hold has to be refused
+rather than panic across the binding.
+
+`Runtime()` boots the engine without starting it, so nothing here reaches a
+device. The in-window behaviour needs a real graph and lives with the harness
+that uses it (`test_single_processor_pipeline.py`).
+"""
+
+import pytest
+
+import streamlib
+from streamlib import RuntimeContextLimitedAccess, output, processor
+
+
+@processor(execution="continuous", interval_ms=10)
+class NeverStartedSource:
+    @output()
+    def bags_to_downstream(self) -> None: ...
+
+    def process(self, ctx: RuntimeContextLimitedAccess) -> None: ...
+
+
+def test_waiting_on_a_graph_that_was_never_run_times_out_naming_the_state():
+    """Not an error, a wait — and when nothing ever starts it, the timeout says
+    every processor is still `Pending` rather than blaming the caller."""
+    runtime = streamlib.Runtime()
+    try:
+        runtime.add(NeverStartedSource)
+        with pytest.raises(RuntimeError, match="Pending"):
+            runtime.wait_until_every_processor_is_running(timeout=0.5)
+    finally:
+        runtime.shutdown()
+
+
+def test_waiting_on_an_empty_graph_that_was_never_run_returns():
+    """No processors, nothing to wait for — the same answer before `run()` as
+    after it."""
+    runtime = streamlib.Runtime()
+    try:
+        runtime.wait_until_every_processor_is_running(timeout=5.0)
+    finally:
+        runtime.shutdown()
+
+
+def test_waiting_after_shutdown_says_the_runtime_is_gone():
+    runtime = streamlib.Runtime()
+    runtime.shutdown()
+
+    with pytest.raises(RuntimeError, match="has been shut down"):
+        runtime.wait_until_every_processor_is_running(timeout=1.0)
+
+
+@pytest.mark.parametrize("rejected_timeout", [-1.0, float("nan"), float("inf"), 1e30])
+def test_a_timeout_python_can_express_but_a_duration_cannot_is_refused(rejected_timeout):
+    """`Duration::from_secs_f64` panics on all of these, and a panic crossing
+    the binding aborts the interpreter rather than failing the call."""
+    runtime = streamlib.Runtime()
+    try:
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            runtime.wait_until_every_processor_is_running(timeout=rejected_timeout)
+    finally:
+        runtime.shutdown()

--- a/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
+++ b/sdk/streamlib-python-wheel/tests/test_interpreter_lifecycle.py
@@ -278,6 +278,36 @@ def test_a_second_run_is_refused(app_under_test):
 
 
 @pytest.mark.requires_gpu
+def test_a_readiness_wait_does_not_break_the_teardown_contract(app_under_test):
+    """The readiness wait is reachable while `run()` blocks, and `run()` still
+    returns clean afterwards.
+
+    The wait has to reach the engine the run loop owns, which is the shape the
+    teardown contract forbids outliving the run. What keeps it legal is that
+    the binding upgrades its reference only long enough to take the processor
+    states and drops it before waiting. Mentally hold that `Arc` across the
+    wait instead and the hazard is back: teardown's `Arc::into_inner` can find
+    the engine still borrowed and `run()` raises rather than returning. This
+    test does not reproduce that interleaving — it pins the everyday path,
+    that reaching the engine mid-run leaves teardown intact.
+    """
+    app = app_under_test("readiness_wait_across_teardown")
+    app.await_engine_ready()
+
+    # The readiness wait cannot begin until `run()` holds the engine, so the
+    # driver opens the gate only once the engine reports itself up.
+    app.process.stdin.close()
+
+    app.await_clean_exit()
+    assert "GRAPH_READY" in app.markers(), (
+        f"the readiness wait must return while run() blocks; output:\n{app.output}"
+    )
+    assert "RUN_RETURNED" in app.markers(), (
+        f"run() must return normally after a readiness wait; output:\n{app.output}"
+    )
+
+
+@pytest.mark.requires_gpu
 def test_shutdown_from_another_thread_ends_a_blocking_run(app_under_test):
     """`shutdown()` must end a running pipeline, from any thread.
 

--- a/sdk/streamlib-python-wheel/tests/test_single_processor_pipeline.py
+++ b/sdk/streamlib-python-wheel/tests/test_single_processor_pipeline.py
@@ -15,16 +15,7 @@ import pytest
 from single_processor_under_test import ConfiguredScaler, DoublingFilter
 from streamlib.testing import SingleProcessorTestPipeline
 
-pytestmark = [
-    pytest.mark.requires_gpu,
-    pytest.mark.skip(
-        reason=(
-            "#1759: the harness has no way to know the processor under test's helper has "
-            "attached, so bags fed before it does are dropped by the link. The transport "
-            "itself works — the same graph round-trips with a settle before the first feed"
-        )
-    ),
-]
+pytestmark = [pytest.mark.requires_gpu]
 
 
 def test_a_fed_bag_reaches_the_processor_and_its_output_comes_back():
@@ -32,6 +23,12 @@ def test_a_fed_bag_reaches_the_processor_and_its_output_comes_back():
 
     The feeder and collector are native endpoints in the app process; the
     processor under test is a child interpreter. A bag crosses out and back.
+
+    Feeding on the first line of the `with` block is the assertion, not a
+    shortcut: `__enter__` has to have waited for the processor's helper to
+    attach. Mentally remove that wait and this fails on nearly every run — the
+    feeder publishes into a link the helper attaches to tens of milliseconds
+    later, and the link drops what it carries in the meantime.
     """
     with SingleProcessorTestPipeline(DoublingFilter) as pipeline:
         pipeline.feed("numbers_from_upstream", {"value": 21})
@@ -56,8 +53,12 @@ def test_the_processor_under_test_is_constructed_with_the_config():
 
 
 def test_a_port_the_processor_does_not_declare_is_named_in_the_error():
+    """A typo'd port name has to come back as the typo plus the real names —
+    `feed` names inputs, so the output port is not among them."""
     with SingleProcessorTestPipeline(DoublingFilter) as pipeline:
-        with pytest.raises(KeyError, match="numbers_to_downstream"):
+        with pytest.raises(KeyError, match="no_such_port"):
+            pipeline.feed("no_such_port", {"value": 1})
+        with pytest.raises(KeyError, match="numbers_from_upstream"):
             pipeline.feed("no_such_port", {"value": 1})
 
 


### PR DESCRIPTION
## Summary

`SingleProcessorTestPipeline.__enter__` returned as soon as it started the run loop, so a `feed` on the very next line published into a link whose consumer — the processor under test's helper process — attached tens of milliseconds later. The link drops what it carries in that window, so the bags were lost and the suite was skipped. A three-second settle was the only thing that made it pass.

The engine now has a real signal for that moment, and the harness blocks on it.

**Engine.** `StateComponent` carries a condvar beside the state, so a waiter blocks on the transition rather than sampling for it, and the ~8 open-coded `*state.0.lock() = X` sites go through `transition_to`. `Runner::observable_graph_readiness()` hands out the per-processor states themselves, so the wait runs with the graph lock released — the threads making those transitions need that lock — and without holding the engine.

The state attaches at `add_v` instead of at compiler-prepare time. That closes a false ready: a wait beginning before `start()` would otherwise find no states at all and report an empty graph as vacuously running. It is also what makes an early wait sound, since the compiler transitions that same state rather than replacing it.

**Wheel.** `run()` leaves a `Weak<Runner>` behind — weak because the teardown contract requires the run loop to hold the only strong reference — and `Runtime.wait_until_every_processor_is_running` reads the states in one detached step and waits in another, so the engine reference is gone before the long wait starts. The wait is legal before `run()` as well as during it: `Thread.start()` says nothing about when that thread reaches `run()`, and refusing the early call would leave the harness turning on the scheduling order it exists to remove.

The harness API is unchanged — the wait is invisible to the tests that use it.

## Closes

Closes #1759

## Exit criteria

- [x] A readiness observable the app process can reach after `run()`
- [x] `SingleProcessorTestPipeline.__enter__` blocks on it; no settle sleep anywhere
- [x] `tests/test_single_processor_pipeline.py` unskipped and green
- [x] The interpreter-lifecycle contract survives — teardown still joins every thread

## Test plan

- `tests/test_single_processor_pipeline.py` — 6/6, feeding on the first line of the `with` block. Five consecutive runs, then three full-suite runs under randomized ordering. The reviewer independently monkey-patched the readiness gate to a no-op and confirmed the scenario goes red (`produced nothing within 8.0s`), so the gate is proven rather than asserted.
- `runtime/streamlib-engine/tests/graph_readiness_signal_test.rs` (new, 4) — an empty graph is up by definition; a never-started graph is **not** reported as running (the false-ready guard); a failed processor ends the wait without burning the timeout; a failure sitting *behind* a processor that never starts still reaches the report.
- `state_component.rs` unit tests (4) — the wait ends on the transition and not on the deadline (a poll loop passes the state assertion and fails the timing bound); a failed setup ends it; an already-happened transition does not hang it; an expired deadline reports the state it gave up in.
- `tests/test_graph_readiness.py` (new, 7) — pre-run, post-shutdown, and four timeout values Python can express that a `Duration` cannot.
- `test_interpreter_lifecycle.py` — a readiness wait taken while `run()` blocks leaves teardown intact.
- Full wheel suite 174 passed / 1 skipped; GPU-free half 120 passed; `cargo test -p streamlib-engine --lib` 1771 passed.
- Gates: stubtest, pyright, `check-no-in-process-placement`, rustfmt on every changed file, clippy on both crates (no new hits).

## Notes for owner

**Two questions the reviewers raised as your call, not mine:**

1. `ObservableGraphReadiness` is new public surface on `streamlib::sdk::graph`, and the plan has no processor-state or readiness entry. The ticket body specifies "an accessor over the graph's `StateComponent`s", which this is, and it extends `StateComponent` rather than paralleling it — but does it earn a line in `ARCHITECTURE.md`, or is "ticket-level, no plan entry" the right answer?
2. `clone_inner()` fails the zero-context naming test on its own, but it matches the existing `ProcessorPauseGateComponent::clone_inner()` two lines away in the same function. Rename both, or grandfather it as an established component idiom?

**Deviation from the ticket.** The ticket sketched an accessor plus a Python-side poll loop. I built the signal instead (condvar, no polling), which left a bare `processor_states()` accessor with no callers — so it is not in the diff. The observable is `observable_graph_readiness()`.

**Found on the way, not fixed (outside this ticket):**

- `spawn_dedicated_thread` has four early returns between phases 3 and 4 (`spawn_processor_op.rs:283-322`) that log an error and abandon the thread *without* transitioning the state. Pre-existing and previously unwatched; now each one makes a readiness caller burn its full timeout and be told "had not finished setup (still Idle)" when the real cause was already logged. Cheap fix — transition to `Error` on each — but it is not what #1759 asked for.
- `spawn_python_native_subprocess_op.rs:216` waits for its child's `ready` with no deadline at all; the wheel host has a 60s one.
- `capture_helper_process_launch_environment` captures the app's import root **once per process**. The harness builds a fresh `Runtime` per pipeline, so two test modules in different directories both using the harness in one pytest process would hit this. This is what the CLI-suite `sys.path` leak in the third commit exposed.
- `GraphInspector` is dead code — no callers anywhere, and `core/observability/mod.rs` does not even re-export it.
- Pre-existing on `main`: unused `ProcessorTypeReference` import in `add_v_op.rs`; `cargo fmt --all --check` fails repo-wide on 204 files (not a CI gate, and the set includes `vendor/tatolab-vulkanalia*`, which is off-limits to reformat).

**Behaviour change worth knowing.** Moving `StateComponent` to `add_v` means a successfully-added, never-started node now renders `"state": "Pending"` in `GET /api/graph` where it previously had no state key. Additive, and arguably a fix — an un-started node now renders like a started one — but no test covers it. `to_json` also moved from `Debug` to `Display`; every variant produces an identical string, so no wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime readiness checks that wait until all processors are running.
  * Added Python support with configurable timeouts and validation for invalid values.
  * Readiness failures now report processor states and startup errors.
* **Improvements**
  * Test pipelines wait for startup completion before accepting input, preventing initial data loss.
  * Processor lifecycle states are tracked consistently across startup, pause, resume, shutdown, and failures.
* **Bug Fixes**
  * Improved runtime teardown when readiness checks run during shutdown.
  * Improved diagnostics for invalid ports and startup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->