### PR TITLE
docs(plan): decide the Python-facing kernel API

### DIFF
--- a/docs/decisions/python-kernel-api.md
+++ b/docs/decisions/python-kernel-api.md
@@ -1,0 +1,139 @@
+# The Python kernel API
+
+Rationale for the `[python-kernel-api]` entries in `docs/plan/ARCHITECTURE.md` §Graphics,
+decided by the owner 2026-08-07. Discharges the "Shape only; the Python-facing API design is
+its own session" clause that §Graphics had carried since the pivot.
+
+## Trigger
+
+Read this before designing any Python-facing GPU surface, before adding a kernel capability
+to one language and not the other, before proposing that Python hand StreamLib pre-compiled
+SPIR-V, or when someone asks why the four GPU bridge traits were deleted.
+
+## Decision
+
+1. **Parity is the bar.** Python reaches every GPU capability Rust authoring reaches —
+   compute, graphics and ray-tracing kernels, acceleration structures, CPU readback. Python
+   names and drives; the engine allocates, compiles, binds, and dispatches. Being a proxy to
+   Rust-powered GPU work — not a lesser scripting surface beside it — is the differentiator
+   the library is built on.
+2. **A kernel is an object**: constructed in `setup()` where the capability typestate is
+   Full, dispatched per frame in `process()`. Bindings are passed at dispatch, by name.
+3. **Kernel outputs are engine-owned textures**, named by surface id, passed downstream in a
+   bag, and reached by a third-party GPU package through a scope: entering blits the texture
+   to a linear DLPack view over DMA-BUF / OPAQUE_FD, leaving blits any write back and orders
+   it on the surface's timeline ahead of the engine's next read. The engine owns the
+   ordering; Python never sees a fence.
+4. **GLSL is the source contract**, compiled by the engine at kernel construction and cached
+   by source hash; SPIR-V remains an escape hatch. The wheel carries a C++ compiler
+   (shaderc / glslang).
+5. **The four bridge traits are deleted.** Compute, graphics, ray tracing and CPU readback
+   are always-present capabilities of `GpuContext`.
+6. **Dispatch is synchronous**, with batching for multi-pass work.
+7. **Rust converges on the same spelling** — bindings at dispatch, nothing persisting on the
+   kernel — as its own change, sequenced after the Python surface.
+
+## Rejected alternatives
+
+**Texture reach, not names-only.** The cheaper option was to let Python *name* a kernel's
+output surface and pass it downstream without ever mapping it — enough for camera → kernel →
+display, and it needs no cross-process texture import. It was rejected because it would have
+contradicted a decision already on the books: §Packages holds that the engine's handle-shaped
+primitive surface is "surfaced to the Python ecosystem as DLPack and the CUDA Array
+Interface". A skia-class or torch-class package that manipulates GPU resources needs the
+texture itself, not a token for one. The wheel refuses this today — `acquire_texture` raises
+*"device textures are not reachable from a Python processor"* — which is an implementation
+gap, not a decision.
+
+**A scope, not read-only reach and not an explicit publish.** Third-party *read* access alone
+would have avoided the ordering question entirely, but it rules out the torch-writes-the-frame
+pattern and walks back the parity the first decision states. An explicit `publish()` was
+rejected because a forgotten call discards GPU work silently. The scope reuses the round trip
+the wheel already implements (`publish_device_write_back_to_surface`, ordered on the surface's
+timeline) and spells it as the `with` block Python readers expect. The blit in both directions
+is not a wart to hide: §Packages already commits to it, because DLPack expresses strided
+linear memory and engine textures are tiled. Saying a third party writes "the same texture"
+without naming the round trip would have left an implementer unable to tell which of two
+mechanisms was decided.
+
+**Kernel objects over per-frame calls.** The wire is already register-once-dispatch-many,
+keyed by SHA-256 of the shader. An imperative `ctx.gpu.dispatch_compute(source, …)` per frame
+would work — a cache makes it fast — but the expensive step and the cheap step would look
+identical in the source, and correctness would rest on a cache the reader cannot see. Objects
+put registration in a constructor and dispatch in a method, which is the same resource-handle
+pattern game engines settled on for the same reason. A declarative form on `@processor` was
+rejected separately: it cannot express a kernel whose shape depends on runtime configuration,
+and it adds a declaration surface the pivot has been removing everywhere else.
+
+**GLSL in the wheel over SPIR-V bytes.** Nothing in the tree compiles a shader at runtime —
+no `shaderc`, no `naga`, not even transitively — and every `glslc` invocation lives in a
+`build.rs`. SPIR-V-only would therefore put a C++ shader toolchain and a build step in front
+of anyone wanting to write a filter, in a library whose stated bar is that a user pip-installs
+it and edits a Python file. Compiling in a shader compiler does not strain §Distribution: that
+section's rule is that *system* libraries are dlopen'd — a compiler we vendor and link
+statically is ours, not the system's.
+
+**A C++ compiler over a pure-Rust one.** naga would have kept the wheel's compiled-in code
+entirely Rust and left §Distribution's wording untouched, which is the tidier outcome. It was
+rejected because its GLSL front end does not cover ray tracing, and ray-tracing kernels are a
+decided Python capability: a GLSL contract that silently excludes one kernel kind is not the
+contract stated, and an author would discover the hole only on writing a raygen shader. The
+cost accepted is a statically linked C++ toolchain inside an abi3 manylinux wheel, which
+widens "our Rust is compiled in" to "our code is compiled in" — vendored C/C++ included.
+
+**Collapsing the bridges over installing them.** The four traits exist to route between an
+app-process arm and a cdylib arm. The cdylib arm dies with the plugin ABI, helper children
+always take the app-process arm, and `importable-python-library-ripout.md` already records
+that the branch collapses onto the path it was using. Every non-test implementation in the
+tree lives in a `polyglot-*` example on the deletion list — the only others are mocks inside
+the escalate handler's own test module — and each keeps a UUID → Texture map built once at
+startup that never grows — so preserving the seam would have meant the wheel re-creating
+the application-setup-glue pattern the pivot exists to remove. Keeping the traits as a
+third-party extension point is not available either: an external implementor would have to
+depend on the `streamlib` crate, which §Packages forbids.
+
+**Synchronous with batching, not async.** Isolation is the axis the placement model optimises,
+so a helper blocking its own thread costs nothing another processor can observe, and a call
+that returns with its writes guaranteed visible is one a reader can reason about. Async
+dispatch would put a fence and timeline vocabulary into the Python surface for throughput the
+MVP does not need. Batching is not an optimisation here but a parity requirement: Rust nests
+several dispatches in one command buffer via `RhiCommandRecorder::record_dispatch`, and
+per-dispatch blocking alone would have made a two-pass blur cost twice the stalls in Python
+and left a Rust-only capability standing, contrary to (1).
+
+**Rust converges.** Rust already has kernel objects; what it lacks is safety in how bindings
+attach. `set_storage_image(0, src)` mutates state that persists until overwritten, so a
+missed rebind silently reuses last frame's texture, and because the setters take `&self`
+behind a mutex, two threads dispatching one kernel can interleave their bindings.
+`VulkanToneMapper::prepare()` exists to paper over exactly this. Two divergent kernel
+spellings in one engine is the parallel-system shape the doctrine forbids, so the direction is
+decided now; the refactor is sequenced separately because folding an RHI-wide change into the
+Python surface ticket would make the diff unreviewable.
+
+## What the existing demos were, and were not
+
+Worth recording, because their names mislead and they were the only evidence of a working
+Python kernel path. `examples/polyglot-vulkan-compute` is a **pure generator** — mandelbrot,
+one `imageStore`, and the incoming frame explicitly ignored. `examples/polyglot-cpu-readback-blur`
+**has no shader at all**; its blur runs on the CPU over mapped staging via numpy. Neither
+performed a GPU read-input-write-output pass, because the compute wire could not express one:
+`run_compute_kernel` carried a single `surface_uuid` bound as a storage image at slot 0,
+output-only. Graphics and ray tracing already carried general binding arrays, and the host
+`VulkanComputeKernel` already supported arbitrary slots and kinds — the restriction was
+wire-level only. Lifting compute to an N-binding array is what makes a Python filter possible
+at all.
+
+## Consequences
+
+- Cross-process texture import must be built; `acquire_texture` and `import_dma_buf` stop
+  raising.
+- The texture scope's blit-out / blit-back round trip extends the existing device-export
+  staging path from pixel buffers to tiled textures, and the engine orders the write-back
+  against its own next read without surfacing a timeline to Python.
+- The wheel gains a statically linked C++ shader compiler, and §Distribution's portability
+  entry widens from "our Rust is compiled in" to cover vendored C/C++.
+- `vulkan_compute_kernel.rs` and its graphics / ray-tracing equivalents lose their stateful
+  numeric-slot setters; every consumer moves, including the codec paths using the raw-view
+  escape hatches. `VulkanToneMapper::prepare()` retires as a shape.
+- The escalate compute op grows a binding array; the v1 single-output convention retires.
+- `GpuContext::set_*_bridge` and the four bridge modules under `core/context/` are deleted.

--- a/docs/decisions/python-kernel-api.md
+++ b/docs/decisions/python-kernel-api.md
@@ -75,9 +75,14 @@ statically is ours, not the system's.
 
 **A C++ compiler over a pure-Rust one.** naga would have kept the wheel's compiled-in code
 entirely Rust and left §Distribution's wording untouched, which is the tidier outcome. It was
-rejected because its GLSL front end does not cover ray tracing, and ray-tracing kernels are a
-decided Python capability: a GLSL contract that silently excludes one kernel kind is not the
-contract stated, and an author would discover the hole only on writing a raygen shader. The
+rejected because its GLSL front end does not cover the ray-tracing *pipeline stages* — raygen,
+miss, closest-hit, any-hit, intersection — that a ray-tracing kernel is built from; whatever
+inline ray-query support it carries addresses a different shape, a query issued from within a
+compute shader. Ray-tracing kernels are a decided Python capability, so a GLSL contract that
+silently excluded one kernel kind would not be the contract stated, and an author would
+discover the hole only on writing a raygen shader. Front-end coverage is a checkable claim
+that moves with releases; if it ever covers the pipeline stages, this rejection is worth
+revisiting on its own terms. The
 cost accepted is a statically linked C++ toolchain inside an abi3 manylinux wheel, which
 widens "our Rust is compiled in" to "our code is compiled in" — vendored C/C++ included.
 

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -142,8 +142,43 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   kernel abstraction per pipeline kind; consumers go through `GpuContext` only.
 - **DECIDED** — The engine's kernel primitives are exposable to Python as configured
   blocks: shader/compute source and binding config passed from Python, compiled and
-  executed by the engine on its device — no user-side Vulkan, ever. Shape only; the
-  Python-facing API design is its own session. [importable-python-library]
+  executed by the engine on its device — no user-side Vulkan, ever.
+  [importable-python-library]
+- **DECIDED** — Python reaches every GPU capability Rust authoring reaches: compute,
+  graphics and ray-tracing kernels, acceleration structures, and CPU readback. Python
+  names and drives; the engine allocates, compiles, binds, and dispatches. No kernel
+  capability is Rust-only. [python-kernel-api]
+- **DECIDED** — A kernel's output is an engine-owned texture that Python names by
+  surface id and passes downstream in a bag, and that a third-party GPU library in its
+  own Python package reaches through a scope: entering blits the texture to a linear
+  view (DLPack over DMA-BUF / OPAQUE_FD), leaving blits any write back and orders it on
+  the surface's timeline ahead of the engine's next read. The engine owns that
+  ordering — no fence or timeline vocabulary reaches Python. Cross-process texture
+  import is part of the capability. [python-kernel-api]
+- **DECIDED** — Python spells a kernel as an object: constructed in `setup()` where the
+  capability typestate is Full, dispatched per frame in `process()`. Construction is
+  registration and dispatch is a method call; no kernel handle string reaches Python.
+  Compute takes a general N-binding array like graphics and ray tracing — a Python
+  compute kernel reads one surface and writes another, at parity with Rust.
+  [python-kernel-api]
+- **DECIDED** — Compute, graphics, ray tracing, and CPU readback are always-present
+  capabilities of `GpuContext`, reached the same way by every caller. The four bridge
+  traits and their installation step are deleted: no kernel capability can be absent at
+  runtime, and no application glue supplies one. [python-kernel-api]
+- **DECIDED** — GLSL is the shader source contract: Python passes GLSL text and the
+  engine compiles it at kernel construction, cached by source hash; pre-compiled SPIR-V
+  stays accepted as an escape hatch. Authoring a kernel requires no toolchain beyond the
+  installed wheel, for every kernel kind. The wheel carries a C++ GLSL compiler
+  (shaderc / glslang). [python-kernel-api]
+- **DECIDED** — Dispatch is synchronous: it returns when the GPU work has retired and
+  the writes are visible, and no fence or timeline vocabulary reaches Python. Several
+  dispatches batch into one submission with barriers between them and a single fence at
+  the end — the Python equivalent of the command-recorder flow. [python-kernel-api]
+- **DECIDED** — One kernel spelling in both languages: bindings are passed at dispatch,
+  by name, and never persist on the kernel object. Rust's stateful numeric-slot setters
+  go; the command-recorder flow keeps its seam by carrying bindings to the recorder
+  rather than stashing them on the kernel. The Rust convergence is its own change,
+  sequenced after the Python surface. [python-kernel-api]
 - **OPEN** — Everything else.
 
 ## Media I/O — camera, display, audio — IN-FLIGHT (→ importable-python-library, one-monotonic-clock)
@@ -239,8 +274,10 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   system, libcuda) are dlopen'd at runtime, never linked — the wgpu/opencv-python
   manylinux shape; "baked in" means our Rust is compiled in, not that system deps
   are static. abi3 across a small range of GIL-enabled CPython builds only
-  (free-threaded builds wait for the stable ABI to exist for them). The wheel's
-  adapter closure excludes skia. Helper processes import the wheel itself — one
+  (free-threaded builds wait for the stable ABI to exist for them). "Our code" includes
+  vendored C/C++ we compile and link statically, not only our Rust: the wheel carries a
+  C++ GLSL shader compiler so a kernel author needs no system shader toolchain. The
+  wheel's adapter closure excludes skia. Helper processes import the wheel itself — one
   native artifact, no separate helper cdylib. [importable-python-library]
 
 ## Control plane & observability — IN-FLIGHT (→ importable-python-library, control-plane-bind-posture)

--- a/docs/plan/GLOSSARY.md
+++ b/docs/plan/GLOSSARY.md
@@ -86,6 +86,12 @@ address-space-local pointer is not a handle. Pixels never cross as Python object
 **Present target**: the engine-owned presentation surface minted from a raw window
 handle; the only way frames reach a window.
 
+**Kernel**: a GPU program the engine compiles and runs on its device — compute,
+graphics, or ray-tracing. Constructed once from source, dispatched many times, spelled
+the same way in Python and Rust, and never executed by user-side Vulkan. _Avoid_:
+"shader" for the whole object (that is its source text), "pipeline" (the Vulkan-internal
+object it builds).
+
 **The plan**: `docs/plan/ARCHITECTURE.md` plus `docs/plan/diagrams/` — the single source
 of architectural decisions.
 

--- a/docs/plan/diagrams/system.mmd
+++ b/docs/plan/diagrams/system.mmd
@@ -26,6 +26,7 @@ flowchart LR
   app --> wheel
   wheel --> engine
   engine --> helper
+  helper -->|kernels + texture handles| engine
   ctl --> registry
   rustapp --> crate
   crate --> engine


### PR DESCRIPTION
## Summary

§Graphics has carried *"Shape only; the Python-facing API design is its own session"* since the pivot, which blocked #1758 at the `/implement` plan gate. This align discharges that clause. §Graphics goes from 2 DECIDED entries to 9.

**The decisions**

1. **Parity.** Python reaches every GPU capability Rust authoring reaches — compute, graphics and ray-tracing kernels, acceleration structures, CPU readback. Python names and drives; the engine allocates, compiles, binds, dispatches.
2. **Texture reach.** A third-party GPU package reaches a kernel's output through a scope: entering blits to a linear DLPack view over DMA-BUF / OPAQUE_FD, leaving blits any write back, ordered on the surface's timeline by the engine. No fence vocabulary in Python.
3. **Kernel objects.** Built in `setup()`, dispatched in `process()`, bindings passed at dispatch by name. Compute lifts to a general N-binding array.
4. **Always-present capabilities.** The four GPU bridge traits and their installation step are deleted.
5. **GLSL is the source contract**, compiled in-engine and cached by source hash; the wheel carries a C++ compiler.
6. **Synchronous dispatch**, with batching for multi-pass work.
7. **One spelling in both languages** — Rust converges on bindings-at-dispatch as its own change.

## Why some of these went the way they did

**Compute needed lifting to N bindings or Python filters are impossible.** `run_compute_kernel` carried a single `surface_uuid` bound as a storage image at slot 0, output-only. The two demos that appeared to prove the path worked did not: `polyglot-vulkan-compute` is a pure generator that ignores its input frame, and `polyglot-cpu-readback-blur` has no shader at all — its blur is numpy over mapped staging. Neither ever did a GPU read-write pass. Graphics and ray tracing already carried general binding arrays and the host `VulkanComputeKernel` already supported arbitrary slots; the restriction was wire-level only.

**The bridge traits had no future.** Their only job was routing between an app-process arm and a cdylib arm; the cdylib arm dies with the ABI and helper children always take the other. Every non-test impl lives in a `polyglot-*` example on the deletion list, each with a UUID→Texture map built once at startup that never grows. Preserving the seam would have meant the wheel re-creating the app-setup-glue pattern the pivot exists to remove.

**Texture writes are a round trip, stated as one.** §Packages already commits to the blit — DLPack expresses strided linear memory, engine textures are tiled. An entry claiming a third party writes "the same texture" would have left an implementer unable to tell which of two mechanisms was decided.

**The compiler choice is architectural, not incidental.** naga would have kept the wheel's compiled-in code entirely Rust, but its GLSL front end does not cover ray tracing — and RT kernels are a decided Python capability. A GLSL contract that silently excludes one kernel kind is not the contract stated.

## Collateral

- §Distribution's portability wording widens from "our Rust is compiled in" to cover vendored C/C++.
- `diagrams/system.mmd` gains the `helper → engine` kernels-and-texture-handles edge.
- `GLOSSARY.md` gains **Kernel**, with `_Avoid_`: "shader" for the whole object, "pipeline".
- `docs/decisions/python-kernel-api.md` carries rationale, rejected alternatives, and the record of what the demos actually were.

## Consequences this commits us to

- Cross-process texture import must be built; `acquire_texture` and `import_dma_buf` stop raising.
- The wheel gains a statically linked C++ shader compiler.
- `vulkan_compute_kernel.rs` and its graphics / ray-tracing equivalents lose their stateful numeric-slot setters; every consumer moves, including codec paths using the raw-view escape hatches. `VulkanToneMapper::prepare()` retires as a shape.
- The escalate compute op grows a binding array; the v1 single-output convention retires.
- `GpuContext::set_*_bridge` and the four bridge modules under `core/context/` are deleted.

## Notes for owner

- **No code, no tickets, no `changes/` file** — per the align hard rule. #1758 stays blocked until `/propose-change` and `/derive-tickets` run over this. #1758's body also predates these decisions and will need restating.
- The Rust convergence (7) is decided but deliberately unscoped here; it is an RHI-wide refactor that wants its own change.
- A Fable review pass caught three defects in the first draft, all fixed: the citation slug broke the file's convention (`[ADR-python-kernel-api]` → `[python-kernel-api]`), the ADR carried a tracker reference the decisions README bans, and the texture-write entry contradicted §Packages' blit contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the Python kernel API for compute, graphics, and ray-tracing workflows.
  * Clarified kernel construction, dispatch, resource bindings, synchronization, and GPU interoperability.
  * Added guidance for shader compilation, texture exchange, and acceleration-structure access.
  * Added a glossary definition for kernels and updated the system architecture diagram.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->