### PR TITLE
chore(operating-model): raise the change-proposal cap from 200 to 350 lines

### DIFF
--- a/.claude/skills/propose-change/SKILL.md
+++ b/.claude/skills/propose-change/SKILL.md
@@ -15,7 +15,7 @@ this skill — route to `/align` first.
    - New behavior or a changed contract → this skill.
    - Anything touching the plugin ABI, RHI, IPC wire format, or the processor model →
      this skill **plus** an ADR.
-   - Too fuzzy or too broad to state as a ≤200-line delta with few unknowns →
+   - Too fuzzy or too broad to state as a ≤350-line delta with few unknowns →
      `/explore-idea` first; come back when the shape is crisp.
 2. **Recon, read-only.** Spawn the relevant domain experts to map current state before
    writing a word — proposals invented without reading the tree reference APIs that
@@ -25,7 +25,8 @@ this skill — route to `/align` first.
    - Sections typed `ADDED:` / `MODIFIED:` / `REMOVED:` against ARCHITECTURE.md.
      Every `- REMOVED: <pattern>` bullet is a grep pattern the ship gate will verify is
      gone.
-   - **≤200 lines.** Longer means the change should split.
+   - **≤350 lines.** Never reach it by dropping file:line citations or the worked API
+     spelling — those are the delta's evidence, not its padding.
    - A factual gap you can resolve by reading the repo: resolve it. An architectural
      choice the plan doesn't state: write `[NEEDS DECISION]` with the options and your
      recommendation. **You may never resolve one yourself.**

--- a/docs/plan/OPERATING-MODEL.md
+++ b/docs/plan/OPERATING-MODEL.md
@@ -27,7 +27,7 @@ Design constraints this must satisfy, from evidence in this repo:
 docs/plan/PRODUCT & ARCHITECTURE  (ARCHITECTURE.md)   ONE doc. The agreed system.
 docs/plan/GLOSSARY.md                                 Ubiquitous language. Terms only.
 docs/plan/diagrams/*.mmd                              Mermaid sources → generated .excalidraw
-docs/plan/changes/<name>.md                           In-flight deltas (≤200 lines each)
+docs/plan/changes/<name>.md                           In-flight deltas (≤350 lines each)
 docs/plan/changes/archive/YYYY-MM-DD-<name>/          Shipped deltas, folded in
 docs/decisions/                                       ADRs, append-only (kept as-is)
 docs/learnings/                                       Empirical cache (kept as-is)
@@ -89,7 +89,7 @@ dangle silently, unreviewable PR diffs). The pipeline instead:
 ### Changes — typed deltas, archived on merge
 
 A change proposal (`changes/<name>.md`) is written as a **delta against the plan**, never
-a restatement: sections marked `ADDED` / `MODIFIED` / `REMOVED`, ≤200 lines, deriving
+a restatement: sections marked `ADDED` / `MODIFIED` / `REMOVED`, ≤350 lines, deriving
 as few tracer-bullet tickets as it honestly needs (count is guidance, not a cap —
 owner decision 2026-08-02). Two markers with different powers:
 
@@ -268,8 +268,11 @@ PR — never accreted mid-session because something annoyed an agent once.
 
 ## Numeric caps (hard numbers survive agent interpretation; prose doesn't)
 
-- Change proposal ≤ 200 lines. Ticket count per change is guidance, not a cap (owner
-  decision 2026-08-02): as few tracer bullets as the change honestly needs.
+- Change proposal ≤ 350 lines (raised from 200, owner decision 2026-08-07: sessions were
+  meeting 200 by deleting file:line citations and worked API examples, inverting the cap's
+  purpose — the number bounds the proposal, it never buys room by dropping evidence).
+  Ticket count per change is guidance, not a cap (owner decision 2026-08-02): as few
+  tracer bullets as the change honestly needs.
 - Scale gate, decided at entry: bug fix / refactor / test work → **no change artifact at
   all** (the default path); new behavior or changed contract → delta change; anything
   touching the RHI, the IPC wire format, the processor model, or the Python API's

--- a/docs/plan/OPERATING-MODEL.md
+++ b/docs/plan/OPERATING-MODEL.md
@@ -268,11 +268,10 @@ PR — never accreted mid-session because something annoyed an agent once.
 
 ## Numeric caps (hard numbers survive agent interpretation; prose doesn't)
 
-- Change proposal ≤ 350 lines (raised from 200, owner decision 2026-08-07: sessions were
-  meeting 200 by deleting file:line citations and worked API examples, inverting the cap's
-  purpose — the number bounds the proposal, it never buys room by dropping evidence).
-  Ticket count per change is guidance, not a cap (owner decision 2026-08-02): as few
-  tracer bullets as the change honestly needs.
+- Change proposal ≤ 350 lines (owner decision 2026-08-07, raised from 200); the number is
+  never met by dropping file:line citations or worked API spelling. Ticket count per change
+  is guidance, not a cap (owner decision 2026-08-02): as few tracer bullets as the change
+  honestly needs.
 - Scale gate, decided at entry: bug fix / refactor / test work → **no change artifact at
   all** (the default path); new behavior or changed contract → delta change; anything
   touching the RHI, the IPC wire format, the processor model, or the Python API's

--- a/docs/plan/changes/README.md
+++ b/docs/plan/changes/README.md
@@ -5,7 +5,7 @@ ticketed by `/derive-tickets`, folded in and archived by `/ship-change`.
 
 Format: sections typed `ADDED:` / `MODIFIED:` / `REMOVED:`. Every `- REMOVED: <pattern>`
 bullet is a grep pattern `.claude/scripts/ship-change-removed-gate.sh` verifies is gone
-from the tree before the change may archive. Limits: ≤200 lines per change. Ticket count
+from the tree before the change may archive. Limits: ≤350 lines per change. Ticket count
 is guidance, not a cap (owner decision 2026-08-02): derive as few tracer-bullet tickets
 as the change honestly needs — the cap existed to stop ticket-spam, and a change that
 needs more vertical slices splits only when it is genuinely two changes.


### PR DESCRIPTION
Operating-model change, shipped on its own per `flow.md`. Owner decision 2026-08-07.

## Evidence

The 200-line cap was being met by deleting the content a proposal exists to carry.

- **`importable-python-library-ripout.md` shipped at 217 lines** — already over the cap, and nothing caught it, because no gate counts lines.
- **`archive/2026-08-07-in-process-hosting-ripout.md` landed at 197** — three lines under the ceiling. A file that stops that close to a bar is a file that was trimmed to clear it.
- **`python-kernel-surface.md` went 240 → 200 across five trimming passes** (#1771). What went: the worked `setup()`/`process()` API example, the batch and tensor scopes, `compute_kernel_bridge.rs:55-62`, `vulkan_compute_kernel.rs:1816`, and nine escalate call sites collapsed to a range. The prose compressions were fine; those were not.

Citations and API spelling are the cheapest lines to delete and the most expensive to lose — they are precisely what `/derive-tickets` and `review-pr` consume. A hard line count selects against them.

**Precedent**: the sibling number in the same `## Numeric caps` section — ticket count per change — was already softened to "guidance, not a cap" by the 2026-08-02 owner decision. The line cap was the last unrevisited hard number in that section.

## Overlap check

No `.claude/rules/` file covers this, and no mechanical gate exists (`.claude/scripts/`, `.claude/hooks/`, `xtask/src/` — nothing counts lines).

**Deliberately not adding one.** Line-counting is mechanical, and the skill's own guidance prefers a gate over prose when it is — but a CI check would make the number *more* binding, which is the opposite of what this evidence asks for. Recording the reasoning so it isn't proposed later as an obvious win.

## Sites

Six, not the four originally identified — a grep sweep turned up two more.

| File | Line |
|---|---|
| `docs/plan/OPERATING-MODEL.md` | `:30` (tree listing), `:92`, `:271` |
| `docs/plan/changes/README.md` | `:8` |
| `.claude/skills/propose-change/SKILL.md` | `:18`, `:28` |

The skill's **"Longer means the change should split"** gloss is dropped — the operating model never stated it. In its place is the constraint the evidence actually asks for: *never reach the number by dropping file:line citations or the worked API spelling — those are the delta's evidence, not its padding.*

## Sequencing

Land this before #1771, which carries the plan delta this rule change unblocks (234 lines — legal under 350, not under 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Increased the proposal size limit from 200 to 350 lines.
  * Updated planning guidance and document structure to reflect the new limit.
  * Clarified that file and line citations, API spelling, and ticket counts should be preserved as evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->