### PR TITLE
docs(plan): propose the MCP-served-with-the-node change

### DIFF
--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -282,7 +282,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   wheel's adapter closure excludes skia. Helper processes import the wheel itself — one
   native artifact, no separate helper cdylib. [importable-python-library]
 
-## Control plane & observability — IN-FLIGHT (→ importable-python-library, control-plane-bind-posture)
+## Control plane & observability — IN-FLIGHT (→ importable-python-library, control-plane-bind-posture, mcp-served-with-the-node)
 
 - **DECIDED** — One control plane: the api-server's HTTP + WebSocket + MCP surface,
   hosted in-process by any runtime that enables it. The MCP tool set is the canonical

--- a/docs/plan/changes/importable-python-library-ripout.md
+++ b/docs/plan/changes/importable-python-library-ripout.md
@@ -15,6 +15,12 @@ where a bullet says otherwise)
   vocabulary is observation-shaped (graph, tap, logs, health, nodes). The CLI `mcp`
   verb and `Dockerfile`/`docker/` re-point at the wheel-hosted runtime (or the Docker
   packaging story is deleted with a note — decide in-ticket from what CI uses).
+
+  > ~~The CLI `mcp` verb … re-point[s] at the wheel-hosted runtime.~~ — Superseded
+  > 2026-08-08 by `mcp-served-with-the-node.md` (owner ruling). The verb is deleted, not
+  > re-pointed: MCP is served by the node's own control plane at `POST /mcp`, with no CLI
+  > verb, stdio transport, or attach bridge. The `Dockerfile`/`docker/` half of this
+  > clause stands unchanged.
 - **`sdk/vulkan-jpeg`** rewires its pervasive `streamlib_plugin_sdk::sdk::*` imports
   to `streamlib-sdk`; the cdylib-safety constraint drops.
 - **`sdk/streamlib-macros`**: the `#[processor]` attribute grammar relocates out of

--- a/docs/plan/changes/mcp-served-with-the-node.md
+++ b/docs/plan/changes/mcp-served-with-the-node.md
@@ -1,0 +1,125 @@
+# Change: mcp-served-with-the-node
+
+MCP has exactly one transport: the node's own control plane. The `streamlib mcp` CLI
+verb, its stdio JSON-RPC transport, and its `--attach` bridge are deleted. Owner ruling,
+2026-08-08, taken during `/implement #1712` when the verb's remaining purpose was
+examined against the mutation-verb trim that ticket performs.
+
+No ADR: this touches no plugin ABI, no RHI, no engine IPC wire format, and no processor
+model surface. It removes a control-plane *carrier*; the MCP tool vocabulary is unchanged
+by this file (it is trimmed to observation shape by `importable-python-library-ripout`).
+
+Recon verified every cited file:line against the tree on 2026-08-08.
+
+## Behavior after this change
+
+An MCP host reaches StreamLib by pointing at a running node's control-plane URL — the
+same `POST /mcp` the api-server already mounts when the node boots. There is nothing to
+start, nothing to attach, and no second lifecycle to reason about: `streamlib dev` is the
+whole setup step, and the agent's own config carries the node's URL.
+
+This is not new plumbing. `handlers.rs:128` mounts `/mcp` unconditionally on every
+api-server router, so every node that hosts a control plane already serves MCP today. What
+this change removes is the *second* way to reach the same dispatch.
+
+## Why the verb has no remaining purpose
+
+The `mcp` verb has two modes (`tools/streamlib-cli/src/commands/mcp.rs:32-37`), and the
+pivot has taken the ground out from under both:
+
+- **In-process** (`mcp.rs:44-68`) builds a fresh empty `Runner::with_auto_build()` and
+  serves MCP against it. Its entire point was that an agent could then *populate* it with
+  `submit_processor` / `connect`. Those verbs are deleted by
+  `importable-python-library-ripout` (§Control plane: "code is the source of truth; the
+  edit loop is `dev`, not live mutation"), leaving an engine that boots empty and can
+  never be filled — a GPU context and an engine boot in exchange for an empty `graph`, a
+  `tap` with no channels, and `logs` of nothing. `RunnerAutoBuild` is itself a REMOVED
+  pattern in that change, so the mode does not survive it regardless.
+- **`--attach <url>`** (`mcp.rs:86-124`) is a byte-for-byte pipe from stdio to the very
+  `POST {url}/mcp` an MCP host can speak to directly over streamable HTTP. It carries no
+  behavior the endpoint does not already have — it is a transport adapter for hosts that
+  only spoke stdio.
+
+Keeping either would also contradict §Control plane's existing decided line: "the control
+plane exists to observe and drive *running* nodes, not to embed."
+
+## MODIFIED
+
+- **§Control plane & observability, the CLI-surface bullet** — strike `mcp` from the verb
+  list. The list becomes `new` / `dev` / `run` plus the observation verbs `nodes` /
+  `graph` / `tap` / `logs`. Nothing else in that bullet changes.
+
+- **§Control plane & observability, the one-control-plane bullet** — append the transport
+  statement: MCP is served by the node's control plane at `POST /mcp`, mounted with the
+  node and sharing its lifecycle; it has exactly one transport, and no CLI verb, stdio
+  server, or bridge process stands between a host and that endpoint. An MCP host is
+  configured with a running node's URL.
+
+- **`docs/plan/diagrams/system.mmd:17`** — the `cli` node label reads `new / dev / run ·
+  nodes / graph / tap / logs / mcp`; drop the trailing `/ mcp`. The `ctl` node label
+  (line 16) already carries MCP as part of the api-server's surface and is correct as-is.
+
+- **`docs/plan/changes/importable-python-library-ripout.md:15-16`** — annotate the clause
+  "The CLI `mcp` verb and `Dockerfile`/`docker/` re-point at the wheel-hosted runtime" as
+  superseded in its `mcp` half. Its `Dockerfile`/`docker/` half is untouched. Its line 172
+  parenthetical ("mutation verbs trimmed from `control.rs` and `mcp.rs`") is satisfied
+  more strongly by deletion of the file, not weakened by it.
+
+## REMOVED
+
+One bare pattern per bullet — the ship gate greps the whole line verbatim, so no bullet
+here carries a slash, a parenthetical, or a second item.
+
+- REMOVED: `serve_stdio_jsonrpc`
+- REMOVED: `tools/streamlib-cli/src/commands/mcp.rs`
+- REMOVED: `Commands::Mcp`
+- REMOVED: `for_stdio_protocol`
+- REMOVED: `PrettyMirrorStream`
+- REMOVED: `pretty_mirror_stream`
+
+### What the last three bullets are
+
+A consequence chain, not scope creep — each item's sole reason to exist is the verb above
+it, verified by reverse-dependency sweep:
+
+`StreamlibLoggingConfig::for_stdio_protocol` (`core/logging/config.rs:137`) exists so a
+subcommand speaking a byte protocol on stdout can push the pretty log mirror to fd 2. Its
+only caller is `main.rs:555`, the `mcp` arm of `logging_config_for`. It is the only
+producer of `PrettyMirrorStream::Stderr` (`config.rs:139`), whose only reader is
+`init.rs:255`. With `Stderr` unreachable, `PrettyMirrorStream` is a one-variant enum and
+`StreamlibLoggingConfig::pretty_mirror_stream` (`config.rs:59`) is a dial with one legal
+value — a no-op field on a public struct, which engine doctrine prohibits pre-1.0.
+
+The field is set to `PrettyMirrorStream::Stdout` at ~13 sites, all of them tests plus one
+test binary (`core/logging/tests.rs`, `tests/bin/log_emit_1000.rs`); removal is mechanical
+there. `streamlib::sdk::logging::StreamlibLoggingConfig` is public API, so this is a
+breaking change to it — permitted pre-1.0, and named here so it is not discovered in a
+diff.
+
+## Consequences to route, not decide
+
+- **Exposure posture.** The in-process stdio path was auth-free by construction — a local
+  child process, no socket. After this change the only path to MCP is the node's HTTP
+  surface, which is bearer-gated only when a token is configured (`handlers.rs:128-134`;
+  `mcp_auth_token: None` mounts no auth layer) on a node that binds `0.0.0.0` by default
+  per `[control-plane-bind-posture]`. This is already the status quo for `graph`, `tap`,
+  and `logs` — MCP joins a surface that bullet already governs, and this change decides
+  nothing about it. §Control plane's **OPEN** bullet on auth and remote-access posture
+  remains the only place that may narrow it, untouched here.
+
+- **Ticket #1712's stated constraint is void.** Its body carries "Sequencing prerequisite
+  of the contract deletion (#1715) — the CLI `mcp` verb must keep working throughout."
+  There is no verb to keep working. Owed to `/reconcile-tracker`.
+
+- **`mvp-app-experience.md:49`** asserts "The `mcp` in-process path (`mcp.rs:44-68`) does
+  none of this today and stays as-is." That file is already blanket-annotated as partially
+  superseded and instructs "derive nothing new from this file", so it needs no separate
+  annotation; recorded here so the contradiction is not read as live guidance.
+
+## Ticketing note
+
+This is a subtraction inside work already ticketed. `/derive-tickets` should fold it into
+**#1712** rather than mint a new ticket: the api-server trim, the CLI retirement, and the
+wheel's verb set are all that ticket's diff, and the wheel never grows an `mcp` verb it
+would then have to lose. The logging-config chain rides the same PR that deletes the verb —
+it does not compile otherwise.


### PR DESCRIPTION
## Summary

MCP has exactly one transport: the node's own control plane. This change strikes the `mcp` CLI verb from §Control plane & observability's verb list and states that MCP is served at `POST /mcp`, mounted with the node and sharing its lifecycle — no CLI verb, no stdio transport, no attach bridge.

Owner ruling, 2026-08-08, taken during `/implement #1712` when the verb's remaining purpose was examined against that ticket's mutation-verb trim. Approved by the owner before this PR.

**No ADR** — no plugin ABI, RHI, engine IPC wire format, or processor-model surface is touched. This removes a control-plane *carrier*; the MCP tool vocabulary is trimmed to observation shape by `importable-python-library-ripout`, not here.

## Why the verb has no remaining purpose

`POST /mcp` is mounted unconditionally on every api-server router (`handlers.rs:128`), so every control-plane-hosting node already serves MCP. What this removes is the second way to reach the same dispatch:

- **In-process** (`commands/mcp.rs:44-68`) builds a fresh empty `Runner::with_auto_build()`. Its whole point was that an agent could then populate it via `submit_processor` / `connect` — both deleted by the ripout change. What remains boots empty and can never be filled: an empty `graph`, a `tap` with no channels, `logs` of nothing. `RunnerAutoBuild` is itself a REMOVED pattern there, so the mode does not survive regardless.
- **`--attach <url>`** (`commands/mcp.rs:86-124`) is a byte-for-byte pipe to the very `POST {url}/mcp` an MCP host can speak to directly over streamable HTTP.

Both also contradict the already-decided line: *"the control plane exists to observe and drive running nodes, not to embed."*

## Delta

**MODIFIED** — the CLI-surface bullet (verb list becomes `new`/`dev`/`run` + `nodes`/`graph`/`tap`/`logs`); the one-control-plane bullet (append the single-transport statement); `diagrams/system.mmd:17`.

**REMOVED** — six gate patterns, each a bare single token so the ship gate can actually prove them (its fixed-string grep makes slashed or parenthetical bullets pass vacuously): `serve_stdio_jsonrpc`, `tools/streamlib-cli/src/commands/mcp.rs`, `Commands::Mcp`, `for_stdio_protocol`, `PrettyMirrorStream`, `pretty_mirror_stream`.

Also applied here: a supersession annotation on `importable-python-library-ripout.md`'s `mcp` half, which would otherwise send #1712's implementer down a dead instruction. Its `Dockerfile`/`docker/` half stands unchanged.

## Notes for owner

- **A public-API break, named rather than left for a diff.** The last three REMOVED patterns are a verified consequence chain: `for_stdio_protocol` exists only so the `mcp` verb could push the pretty log mirror to fd 2; it is the only producer of `PrettyMirrorStream::Stderr`; without it `PrettyMirrorStream` is a one-variant enum and `StreamlibLoggingConfig::pretty_mirror_stream` a dial with one legal value — a no-op field on a public SDK struct, prohibited pre-1.0. ~13 call sites, all tests plus one test binary.
- **Exposure posture is routed, not decided.** The in-process path was auth-free by construction (local child, no socket); afterward the only path is the node's HTTP surface, bearer-gated only when a token is configured, on a node binding `0.0.0.0` per `[control-plane-bind-posture]`. That is already the status quo for `graph`/`tap`/`logs` — MCP joins a surface the **OPEN** auth-and-remote-access bullet already governs. This change decides nothing about it.
- **Owed to `/reconcile-tracker`:** #1712's body constraint *"the CLI `mcp` verb must keep working throughout"* is void.
- **No new ticket.** `/derive-tickets` folds this into #1712 — the api-server trim, the CLI retirement, and the wheel's verb set are already that ticket's diff, and this way the wheel never grows an `mcp` verb it would immediately lose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented MCP access through each node’s `POST /mcp` control-plane endpoint.
  * Clarified that the standalone `mcp` CLI command and its stdio and attach modes are no longer available.
  * Updated architecture diagrams, control-plane guidance, and migration notes.
* **Breaking Changes**
  * Removed the `mcp` CLI command and related public logging configuration options.
  * Docker packaging guidance remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->