### PR TITLE
docs(plan): ship mcp-served-with-the-node

### DIFF
--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -282,7 +282,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   wheel's adapter closure excludes skia. Helper processes import the wheel itself — one
   native artifact, no separate helper cdylib. [importable-python-library]
 
-## Control plane & observability — IN-FLIGHT (→ importable-python-library, control-plane-bind-posture, mcp-served-with-the-node)
+## Control plane & observability — IN-FLIGHT (→ importable-python-library, control-plane-bind-posture)
 
 - **DECIDED** — One control plane: the api-server's HTTP + WebSocket + MCP surface,
   hosted in-process by any runtime that enables it. The MCP tool set is the canonical
@@ -291,7 +291,12 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   Post-pivot the vocabulary is observation-shaped: graph, tap, logs, health, nodes.
   The live-mutation verbs (submit / replace / connect / remove) and their MCP tools
   are removed — code is the source of truth; the edit loop is `dev`, not live
-  mutation. [importable-python-library]
+  mutation. MCP is served by the node's control plane at `POST /mcp`, mounted with
+  the node and sharing its lifecycle; it has exactly one transport, and no CLI verb,
+  stdio server, or bridge process stands between a host and that endpoint — an MCP
+  host is configured with a running node's URL.
+  [importable-python-library; mcp-served-with-the-node — SHIPPED #1712]
+  <!-- verify: cargo test -p streamlib-cli --bins the_rust_cli_owns_no_observation_verb -->
 - **DECIDED** — `dev` and `run` bind the control plane identically: all interfaces
   (`0.0.0.0`) by default, narrowed per invocation by `--host`. There is no dev-only
   exposure posture — a node another host can reach is bound wide by definition, so
@@ -302,7 +307,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   prerequisite of the rip-out. [control-plane-one-surface]
 - **DECIDED** — The CLI ships inside the wheel and slims to `new` / `dev` / `run` (a
   thin runner over the same engine the wheel exposes) plus the observation verbs
-  (`nodes` / `graph` / `tap` / `logs` / `mcp`); build-orchestration, packaging,
+  (`nodes` / `graph` / `tap` / `logs`); build-orchestration, packaging,
   provisioning, and codegen verbs are deleted. The standalone streamlib-runtime
   binary retires. Python embeds the engine in-process via the wheel; the control
   plane exists to observe and drive *running* nodes, not to embed.

--- a/docs/plan/changes/archive/2026-08-08-mcp-served-with-the-node.md
+++ b/docs/plan/changes/archive/2026-08-08-mcp-served-with-the-node.md
@@ -67,15 +67,18 @@ plane exists to observe and drive *running* nodes, not to embed."
 
 ## REMOVED
 
-One bare pattern per bullet — the ship gate greps the whole line verbatim, so no bullet
-here carries a slash, a parenthetical, or a second item.
+One bare pattern per bullet. The ship gate fixed-string-greps everything after the
+`- REMOVED:` prefix, so a bullet carrying a slash, a parenthetical, a second item — or
+surrounding backticks — can never match code and passes vacuously. The backticks are
+omitted deliberately: rustdoc writes them in doc comments, so a backticked pattern
+matches prose while a surviving definition goes unnoticed.
 
-- REMOVED: `serve_stdio_jsonrpc`
-- REMOVED: `tools/streamlib-cli/src/commands/mcp.rs`
-- REMOVED: `Commands::Mcp`
-- REMOVED: `for_stdio_protocol`
-- REMOVED: `PrettyMirrorStream`
-- REMOVED: `pretty_mirror_stream`
+- REMOVED: serve_stdio_jsonrpc
+- REMOVED: tools/streamlib-cli/src/commands/mcp.rs
+- REMOVED: Commands::Mcp
+- REMOVED: for_stdio_protocol
+- REMOVED: PrettyMirrorStream
+- REMOVED: pretty_mirror_stream
 
 ### What the last three bullets are
 

--- a/docs/plan/diagrams/system.mmd
+++ b/docs/plan/diagrams/system.mmd
@@ -14,7 +14,7 @@ flowchart LR
   rhi["RHI\n(vulkan/rhi + streamlib-consumer-rhi)"]
   interop["Interop adapters\n(Vulkan↔CUDA, Vulkan↔GL — app-process Rust)"]
   ctl["Control plane\n(api-server: HTTP / WS / MCP — engine-side)"]
-  cli["CLI (in the wheel)\nnew / dev / run · nodes / graph / tap / logs / mcp"]
+  cli["CLI (in the wheel)\nnew / dev / run · nodes / graph / tap / logs"]
   wire["Wire\n(self-describing bags between nodes —\nthe only cross-language boundary)"]
 
   registry["Node registry\n(per-user on-disk, one JSON per live node)"]


### PR DESCRIPTION
## Summary

Folds `mcp-served-with-the-node` into the plan and archives it. Delivered by #1712 — PRs #1782 and #1785, both merged.

**MODIFIED — §Control plane & observability**
- The one-control-plane bullet gains the transport statement: MCP is served at `POST /mcp`, mounted with the node and sharing its lifecycle; exactly one transport, and no CLI verb, stdio server, or bridge stands between a host and that endpoint.
- The CLI verb list loses `mcp` → `new` / `dev` / `run` plus `nodes` / `graph` / `tap` / `logs`.
- `diagrams/system.mmd`'s CLI label follows.

**The section stays IN-FLIGHT.** It carries three changes (`importable-python-library`, `control-plane-bind-posture`, this one) and only this one has shipped, so flipping the whole section would claim the other two. The `— SHIPPED #1712` tag and its `verify:` command go on the bullet instead, matching the convention the helper-process-placement bullet already set.

## Gate

```
$ bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/archive/2026-08-08-mcp-served-with-the-node.md
EXIT=0
```

Silent + exit 0 is the script's clean run — it prints only on failure. Per-pattern, against tracked files with the gate's own exclusions:

| pattern | hits |
|---|---|
| `serve_stdio_jsonrpc` | 0 |
| `tools/streamlib-cli/src/commands/mcp.rs` | 0 |
| `Commands::Mcp` | 0 |
| `for_stdio_protocol` | 0 |
| `PrettyMirrorStream` | 0 |
| `pretty_mirror_stream` | 0 |

The `verify:` marker's command was run, not just written: `cargo test -p streamlib-cli --bins the_rust_cli_owns_no_observation_verb` → 1 passed.

## Notes for owner

**The gate was passing vacuously, and I fixed the change file rather than accept the green.** I wrote every `- REMOVED:` bullet with backticks — `` - REMOVED: `serve_stdio_jsonrpc` ``. The script fixed-string-greps everything after the prefix, so it was searching for the backticked string, which appears in rustdoc comments and **never in a Rust definition**. All six passed on the first run and all six were meaningless: a surviving `fn serve_stdio_jsonrpc` would have gone unnoticed.

Bare, they are a real check. Proven rather than asserted — injecting `// serve_stdio_jsonrpc` into `runtime/streamlib-api-server/src/lib.rs` makes the gate fail with the file and line; reverting makes it pass. The removals were genuinely complete (I had verified them with bare greps during #1712), so nothing was hidden — but the gate would not have caught it if they hadn't been.

This is a **third variant** of the defect `importable-python-library-ripout.md` already documents ("any bullet joining two items with `/` or carrying a parenthetical can never match and passes vacuously"). Backticks join that list; the archived change file now names all three. **Worth a look at the other in-flight change files before they ship** — `importable-python-library-ripout.md` in particular has ~35 REMOVED bullets, and its own note says several are already in the vacuous state.

**One bookkeeping item deliberately not resolved here.** `Commands::Shutdown` was deleted by #1712 with no `- REMOVED:` bullet in any change file, so the gate cannot prove it. Adding a bullet for something already deleted would make the gate assert a removal it never watched happen, which is worse than the gap. Flagging rather than papering over. Related open question from #1785: the `shutdown` MCP tool is still served with no CLI client — you ruled option (a), leave it, which I confirmed is safe (SIGTERM on a real node: clean exit, graceful teardown, registry cleaned up in ~700ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that MCP is served directly through the node at `POST /mcp` using a single transport.
  * Updated architecture documentation and diagrams to remove obsolete CLI, bridge, and standalone server references.
  * Corrected archived change checklists so removed items can be matched reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->