### PR TITLE
chore(flow): give the ship-change REMOVED gate teeth, and tests

### DIFF
--- a/.claude/scripts/ship-change-removed-gate.sh
+++ b/.claude/scripts/ship-change-removed-gate.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
-# ship-change gate: every `- REMOVED: <pattern>` bullet in a change file must no longer
-# match anywhere in the tree (the change files themselves, their archive, and vendor/
-# are excluded). Run from the repo root.
+# ship-change gate: every `- REMOVED: <pattern>` bullet in a change file must name
+# something that no longer exists in the tree. Run from the repo root.
 #
 # Usage: ship-change-removed-gate.sh docs/plan/changes/<name>.md
-# Exit 0 = clean; exit 1 = something REMOVED still exists (locations printed).
+# Exit 0 = clean; 1 = residue still present, or a bullet that cannot prove anything;
+# 2 = usage / not a repo.
+#
+# A bullet is checked two independent ways, because neither alone is a removal proof:
+#
+#   contents  git grep -F over tracked files — "nothing references this any more".
+#   path      git ls-files over the same pattern read as a literal path — "the file or
+#             directory is gone". git grep never matches a filename, so an unreferenced
+#             leaf file is invisible to the content sweep; a path-shaped bullet without
+#             this check certifies only that nothing mentions it.
+#
+# Bullet grammar, enforced below — one pattern per bullet, first physical line, plain
+# text. A pattern that carries markdown decoration or joins several items can never
+# match a definition site, so it would pass green forever; those are rejected rather
+# than searched. Continuation lines are prose and are not searched.
 set -euo pipefail
 
 change="${1:?usage: ship-change-removed-gate.sh <change-file>}"
@@ -15,15 +28,64 @@ fail=0
 hits="$(mktemp)"
 trap 'rm -f "$hits"' EXIT
 
+# Excluded from the content sweep only — each is a surface that names a removed
+# artifact forever, by policy, so a hit there is not residue:
+#   CHANGELOG.md      release-please generates it from merged commit subjects; the
+#                     entry announcing a removal is unscrubbable.
+#   docs/decisions/** annotate-don't-overwrite (.claude/rules/docs-policy.md): a
+#                     superseded ADR keeps naming what it retired.
+#   docs/plan/changes/**  the change files' own inventories, including this one.
+#   vendor/**         the vendored vulkanalia fork, never ours to edit.
+# The path check does not inherit these: a file existing at the named path is residue
+# wherever it lives.
+content_excludes=(':!vendor/**' ':!docs/plan/changes/**' ':!CHANGELOG.md' ':!docs/decisions/**')
+
+reject() {
+  echo "MALFORMED BULLET: $1"
+  echo "  $2"
+  fail=1
+}
+
 count=0
 while IFS= read -r pat; do
   [ -n "$pat" ] || continue
   count=$((count + 1))
-  # git grep: tracked files only (build scratch and caches can't fake a pass), no
-  # dependence on a ripgrep binary. Judge by captured matches, not the exit code.
-  git grep -InF -- "$pat" -- ':!vendor/**' ':!docs/plan/changes/**' >"$hits" 2>/dev/null || true
+
+  case "$pat" in
+    *'`'*)
+      reject "$pat" "backticked — backticks appear only in markdown and rustdoc prose, never in a definition. Write the pattern as plain text."
+      continue ;;
+    *' / '*)
+      reject "$pat" "joins several items — the whole line is searched as one literal. Split it into one bullet per item."
+      continue ;;
+    *'{'*)
+      reject "$pat" "shell brace expansion is not expanded — it is searched literally and can never hit. Write one bullet per expanded name."
+      continue ;;
+    *' ('*)
+      reject "$pat" "trailing parenthetical is part of the searched literal. Move the note to a continuation line."
+      continue ;;
+    .|./|/|..)
+      reject "$pat" "degenerate pattern — it would match the whole tree."
+      continue ;;
+  esac
+
+  # Tracked files only: build scratch and caches must not be able to fake a pass or a
+  # failure. Judge by captured matches, not by the exit code.
+  git grep -InF -- "$pat" -- "${content_excludes[@]}" >"$hits" 2>/dev/null || true
   if [ -s "$hits" ]; then
-    echo "STILL PRESENT: $pat"
+    echo "STILL PRESENT (referenced): $pat"
+    head -20 "$hits" | sed 's/^/  /'
+    fail=1
+  fi
+
+  # `:(literal)` so a pattern containing glob metacharacters is read as the path it
+  # names, not as a wildcard. A symbol-shaped pattern names no path and matches nothing.
+  # vendor/ is dropped afterwards, not as a `:!` pathspec: git (2.43) silently drops an
+  # exact-file positive match the moment any exclude pathspec joins the list, which
+  # would make every leaf-file bullet — the one case this check exists for — pass green.
+  git ls-files -- ":(literal)$pat" 2>/dev/null | grep -v '^vendor/' >"$hits" || true
+  if [ -s "$hits" ]; then
+    echo "STILL PRESENT (on disk): $pat"
     head -20 "$hits" | sed 's/^/  /'
     fail=1
   fi
@@ -31,6 +93,8 @@ done < <(sed -n 's/^[-*][[:space:]]*REMOVED:[[:space:]]*//p' "$change")
 
 if [ "$count" -eq 0 ]; then
   echo "note: $change declares no '- REMOVED:' bullets — nothing to verify."
+elif [ "$fail" -eq 0 ]; then
+  echo "clean: $count REMOVED bullets, none referenced and none on disk."
 fi
 
 exit "$fail"

--- a/.claude/scripts/ship-change-removed-gate.sh
+++ b/.claude/scripts/ship-change-removed-gate.sh
@@ -41,15 +41,22 @@ trap 'rm -f "$hits"' EXIT
 content_excludes=(':!vendor/**' ':!docs/plan/changes/**' ':!CHANGELOG.md' ':!docs/decisions/**')
 
 reject() {
-  echo "MALFORMED BULLET: $1"
+  echo "MALFORMED BULLET: ${1:-(empty)}"
   echo "  $2"
   fail=1
 }
 
 count=0
 while IFS= read -r pat; do
-  [ -n "$pat" ] || continue
   count=$((count + 1))
+
+  # An empty pattern is a declared removal that searches for nothing. Counted and
+  # rejected, never skipped: skipping it would also under-report the bullet total, so
+  # the summary line would vouch for a file it had not fully read.
+  if [ -z "$pat" ]; then
+    reject "$pat" "no pattern after 'REMOVED:' — write the artifact on the bullet's own line."
+    continue
+  fi
 
   case "$pat" in
     *'`'*)
@@ -80,10 +87,12 @@ while IFS= read -r pat; do
 
   # `:(literal)` so a pattern containing glob metacharacters is read as the path it
   # names, not as a wildcard. A symbol-shaped pattern names no path and matches nothing.
-  # vendor/ is dropped afterwards, not as a `:!` pathspec: git (2.43) silently drops an
-  # exact-file positive match the moment any exclude pathspec joins the list, which
-  # would make every leaf-file bullet — the one case this check exists for — pass green.
-  git ls-files -- ":(literal)$pat" 2>/dev/null | grep -v '^vendor/' >"$hits" || true
+  # No exclusions here, by design — a file sitting at the named path is residue wherever
+  # it lives, vendor/ included. Never add a `:!` pathspec to this call either: git (2.43)
+  # silently drops an exact-file positive match the moment any exclude joins the list,
+  # which would make every leaf-file bullet — the one case this check exists for — pass
+  # green.
+  git ls-files -- ":(literal)$pat" >"$hits" 2>/dev/null || true
   if [ -s "$hits" ]; then
     echo "STILL PRESENT (on disk): $pat"
     head -20 "$hits" | sed 's/^/  /'

--- a/.claude/scripts/tests/ship-change-removed-gate.test.sh
+++ b/.claude/scripts/tests/ship-change-removed-gate.test.sh
@@ -149,7 +149,18 @@ new_repo <<'EOF'
 EOF
 plant vendor/tatolab-vulkanalia/src/lib.rs "// streamlib-pack"
 run_gate
-expect_pass "the vendored tree is out of scope"
+expect_pass "the vendored tree is out of scope for the content sweep"
+
+# ...but only the content sweep. The path check has no exclusions at all: a file at the
+# named path is residue wherever it lives, and a bullet that retires the vendored fork
+# must not pass while the fork is still checked in.
+new_repo <<'EOF'
+- REMOVED: vendor/tatolab-vulkanalia
+EOF
+plant vendor/tatolab-vulkanalia/src/lib.rs "pub fn vk_create() {}"
+run_gate
+expect_fail "a vendored path that still exists is residue" \
+  "STILL PRESENT (on disk): vendor/tatolab-vulkanalia"
 
 new_repo <<'EOF'
 - REMOVED: streamlib-pack
@@ -206,6 +217,26 @@ new_repo <<'EOF'
 EOF
 run_gate
 expect_fail "a degenerate whole-tree pattern is rejected" "degenerate pattern"
+
+new_repo <<'EOF'
+- REMOVED:
+EOF
+run_gate
+expect_fail "a bullet with no pattern is rejected, not skipped" "no pattern after 'REMOVED:'"
+
+# An empty bullet must not vanish from the count either — a summary that says "2 bullets"
+# for a file declaring 3 vouches for a bullet it never read.
+new_repo <<'EOF'
+- REMOVED: Alpha
+- REMOVED:
+- REMOVED: Beta
+EOF
+run_gate
+if [ "$status" -eq 1 ] && printf '%s' "$out" | grep -qF "MALFORMED BULLET: (empty)"; then
+  ok "an empty bullet among good ones fails the file"
+else
+  bad "an empty bullet among good ones fails the file (got $status)"
+fi
 
 # The rejections must not fire on legitimate patterns.
 new_repo <<'EOF'

--- a/.claude/scripts/tests/ship-change-removed-gate.test.sh
+++ b/.claude/scripts/tests/ship-change-removed-gate.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Unit tests for .claude/scripts/ship-change-removed-gate.sh.
+#
+# Each case builds a throwaway git repo, plants an artifact, and asserts what the gate
+# says about it. The gate is the only mechanism that proves a ripout landed, so every
+# way a bullet can pass vacuously gets a case here — a green gate on a tree that still
+# holds the artifact is the failure mode this file exists to catch.
+#
+# No toolchain, no network: bash + git.
+set -uo pipefail
+
+gate="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/ship-change-removed-gate.sh"
+[ -f "$gate" ] || { echo "gate script not found at $gate" >&2; exit 2; }
+
+passed=0
+failed=0
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+case_no=0
+out=""
+status=0
+
+# new_repo — a fresh repo in $repo with the change file at docs/plan/changes/c.md.
+# Bullets are passed as one heredoc-ish string on stdin.
+new_repo() {
+  case_no=$((case_no + 1))
+  repo="$work/case-$case_no"
+  mkdir -p "$repo/docs/plan/changes"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email t@example.com
+  git -C "$repo" config user.name t
+  { printf '# Change: c\n\n## REMOVED\n\n'; cat; } >"$repo/docs/plan/changes/c.md"
+}
+
+# plant <path> <contents> — a tracked file. Staged, not committed: git grep and
+# git ls-files both read the index, which is what the gate searches.
+plant() {
+  mkdir -p "$repo/$(dirname "$1")"
+  printf '%s\n' "$2" >"$repo/$1"
+  git -C "$repo" add -- "$1"
+}
+
+run_gate() {
+  git -C "$repo" add -- docs/plan/changes/c.md
+  out="$(cd "$repo" && bash "$gate" docs/plan/changes/c.md 2>&1)"
+  status=$?
+}
+
+ok() { passed=$((passed + 1)); printf '  ok   %s\n' "$1"; }
+bad() {
+  failed=$((failed + 1))
+  printf '  FAIL %s\n' "$1"
+  printf '%s\n' "$out" | sed 's/^/       | /'
+}
+
+expect_pass() { if [ "$status" -eq 0 ]; then ok "$1"; else bad "$1 (expected exit 0, got $status)"; fi; }
+expect_fail() {
+  if [ "$status" -eq 1 ] && printf '%s' "$out" | grep -qF -- "$2"; then
+    ok "$1"
+  else
+    bad "$1 (expected exit 1 mentioning '$2', got $status)"
+  fi
+}
+
+echo "ship-change-removed-gate.sh"
+
+# --- the baseline: absence passes, presence fails -------------------------------
+
+new_repo <<'EOF'
+- REMOVED: ProcessorVTable
+EOF
+plant src/lib.rs "pub struct Something;"
+run_gate
+expect_pass "a symbol that is genuinely gone passes"
+
+new_repo <<'EOF'
+- REMOVED: ProcessorVTable
+EOF
+plant src/lib.rs "pub struct ProcessorVTable { slot: usize }"
+run_gate
+expect_fail "a symbol still defined in a tracked file fails" "STILL PRESENT (referenced): ProcessorVTable"
+
+new_repo <<'EOF'
+* REMOVED: ProcessorVTable
+EOF
+plant src/lib.rs "pub struct ProcessorVTable;"
+run_gate
+expect_fail "a '*' bullet marker is parsed too" "STILL PRESENT (referenced): ProcessorVTable"
+
+new_repo <<'EOF'
+- REMOVED: ProcessorVTable
+EOF
+mkdir -p "$repo/src"
+printf 'pub struct ProcessorVTable;\n' >"$repo/src/untracked.rs"
+run_gate
+expect_pass "an untracked file cannot fake a failure"
+
+# --- defect 6: git grep never matches a filename ---------------------------------
+
+new_repo <<'EOF'
+- REMOVED: tools/streamlib-pack
+EOF
+plant tools/streamlib-pack/src/main.rs "fn main() {}"
+run_gate
+expect_fail "a directory that still exists fails even when nothing references it" \
+  "STILL PRESENT (on disk): tools/streamlib-pack"
+
+new_repo <<'EOF'
+- REMOVED: schemas/streamlib.schema.json
+EOF
+plant schemas/streamlib.schema.json '{"title":"unreferenced leaf"}'
+run_gate
+expect_fail "an unreferenced leaf file fails on the path check" \
+  "STILL PRESENT (on disk): schemas/streamlib.schema.json"
+
+new_repo <<'EOF'
+- REMOVED: tools/streamlib-pack
+EOF
+plant tools/streamlib-keep/src/main.rs "fn main() {}"
+run_gate
+expect_pass "a sibling directory is not mistaken for the removed one"
+
+new_repo <<'EOF'
+- REMOVED: sdk/a[b].rs
+EOF
+plant sdk/ab.rs "fn a() {}"
+run_gate
+expect_pass "a glob metacharacter in a bullet is read as a literal path, not a wildcard"
+
+# --- defect 7: surfaces that name a removed artifact by policy -------------------
+
+new_repo <<'EOF'
+- REMOVED: streamlib-pack
+EOF
+plant CHANGELOG.md "* remove streamlib-pack (#1715)"
+run_gate
+expect_pass "a release-please CHANGELOG entry is not residue"
+
+new_repo <<'EOF'
+- REMOVED: streamlib-pack
+EOF
+plant docs/decisions/packaging.md "> ~~streamlib-pack builds the artifact.~~ — Superseded."
+run_gate
+expect_pass "a superseded ADR that still names the artifact is not residue"
+
+new_repo <<'EOF'
+- REMOVED: streamlib-pack
+EOF
+plant vendor/tatolab-vulkanalia/src/lib.rs "// streamlib-pack"
+run_gate
+expect_pass "the vendored tree is out of scope"
+
+new_repo <<'EOF'
+- REMOVED: streamlib-pack
+EOF
+plant docs/plan/changes/archive/2026-01-01-other.md "- REMOVED: streamlib-pack"
+run_gate
+expect_pass "another change file's own inventory is not residue"
+
+# A file that lives at the excluded path is still residue when the bullet names the
+# path itself — the content exclusions must not leak into the path check.
+new_repo <<'EOF'
+- REMOVED: docs/decisions/packaging.md
+EOF
+plant docs/decisions/packaging.md "unrelated prose"
+run_gate
+expect_fail "an excluded-from-grep path is still checked for existence" \
+  "STILL PRESENT (on disk): docs/decisions/packaging.md"
+
+# --- defects 1-4: bullets that can never match -----------------------------------
+
+new_repo <<'EOF'
+- REMOVED: `tools/streamlib-pack`
+EOF
+plant tools/streamlib-pack/src/main.rs "fn main() {}"
+run_gate
+expect_fail "a backticked bullet is rejected, not searched" "MALFORMED BULLET"
+
+new_repo <<'EOF'
+- REMOVED: `tools/streamlib-pack`
+EOF
+run_gate
+expect_fail "a backticked bullet is rejected even when the tree is clean" "MALFORMED BULLET"
+
+new_repo <<'EOF'
+- REMOVED: streamlib-adapter-vulkan-abi / streamlib-adapter-vulkan-helpers
+EOF
+run_gate
+expect_fail "a '/'-joined bullet is rejected" "joins several items"
+
+new_repo <<'EOF'
+- REMOVED: tools/streamlib-cli/src/commands/{add,install}.rs
+EOF
+run_gate
+expect_fail "a brace-expansion bullet is rejected" "brace expansion"
+
+new_repo <<'EOF'
+- REMOVED: native_lib_resolver (the cdylib resolution)
+EOF
+run_gate
+expect_fail "a trailing parenthetical is rejected" "trailing parenthetical"
+
+new_repo <<'EOF'
+- REMOVED: .
+EOF
+run_gate
+expect_fail "a degenerate whole-tree pattern is rejected" "degenerate pattern"
+
+# The rejections must not fire on legitimate patterns.
+new_repo <<'EOF'
+- REMOVED: host_callbacks()
+- REMOVED: runtime/streamlib-engine/src/core/plugin/
+- REMOVED: export_plugin!
+- REMOVED: RunnerAutoBuild
+EOF
+run_gate
+expect_pass "a call-shaped, path-shaped, macro-shaped or plain symbol is not rejected"
+
+# --- defect 5: only the first physical line is a pattern -------------------------
+
+new_repo <<'EOF'
+- REMOVED: ProcessorVTable
+  The vtable and its layout regression test, both retired with the plugin ABI.
+EOF
+plant src/lib.rs "// the layout regression test lived here"
+run_gate
+expect_pass "a continuation line is prose, not a second pattern"
+
+# --- shape and usage -------------------------------------------------------------
+
+new_repo <<'EOF'
+- REMOVED: Alpha
+- REMOVED: Beta
+EOF
+run_gate
+if [ "$status" -eq 0 ] && printf '%s' "$out" | grep -qF "clean: 2 REMOVED bullets"; then
+  ok "a clean run reports how many bullets it actually checked"
+else
+  bad "a clean run reports how many bullets it actually checked (got $status)"
+fi
+
+new_repo <<'EOF'
+EOF
+run_gate
+if [ "$status" -eq 0 ] && printf '%s' "$out" | grep -qF "declares no '- REMOVED:' bullets"; then
+  ok "a change file with no REMOVED bullets says so"
+else
+  bad "a change file with no REMOVED bullets says so (got $status)"
+fi
+
+new_repo <<'EOF'
+- REMOVED: Alpha
+EOF
+out="$(cd "$repo" && bash "$gate" docs/plan/changes/nope.md 2>&1)"
+status=$?
+if [ "$status" -eq 2 ]; then ok "a missing change file exits 2"; else bad "a missing change file exits 2 (got $status)"; fi
+
+new_repo <<'EOF'
+- REMOVED: Alpha
+EOF
+outside="$work/not-a-repo"
+mkdir -p "$outside/docs/plan/changes"
+cp "$repo/docs/plan/changes/c.md" "$outside/docs/plan/changes/c.md"
+out="$(cd "$outside" && bash "$gate" docs/plan/changes/c.md 2>&1)"
+status=$?
+if [ "$status" -eq 2 ]; then ok "outside a repo the gate refuses to pass"; else bad "outside a repo the gate refuses to pass (got $status)"; fi
+
+echo
+echo "$passed passed, $failed failed"
+[ "$failed" -eq 0 ]

--- a/.claude/skills/ship-change/SKILL.md
+++ b/.claude/skills/ship-change/SKILL.md
@@ -10,9 +10,11 @@ Precondition: every ticket of the change is merged (check the milestone). Exact
 sequence — no improvisation:
 
 1. `bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/<name>.md` —
-   **exit 0 required.** Nonzero output lists what still exists in the tree; that residue
-   is finished first (a follow-up ticket in the same milestone), and this skill re-runs
-   after. Never archive with residue.
+   **exit 0 required.** `STILL PRESENT` lists what remains in the tree, referenced or on
+   disk; that residue is finished first (a follow-up ticket in the same milestone), and
+   this skill re-runs after. Never archive with residue. `MALFORMED BULLET` is not
+   residue and never becomes a ticket — the bullet cannot prove anything as written, so
+   the change file is corrected in place (grammar: `docs/plan/changes/README.md`).
 2. `mkdir -p .claude/state && touch .claude/state/plan-session`
 3. Fold each `ADDED`/`MODIFIED` section into `docs/plan/ARCHITECTURE.md`; flip the
    affected sections `IN-FLIGHT` → `SHIPPED`, each with a `<!-- verify: <glob or

--- a/.github/workflows/check-ship-change-removed-gate.yml
+++ b/.github/workflows/check-ship-change-removed-gate.yml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The job runs bash tests over throwaway repos it creates itself — no
+          # authenticated git operation, so the checkout token has no business in
+          # the local git config.
+          persist-credentials: false
 
       - name: bash .claude/scripts/tests/ship-change-removed-gate.test.sh
         run: bash .claude/scripts/tests/ship-change-removed-gate.test.sh

--- a/.github/workflows/check-ship-change-removed-gate.yml
+++ b/.github/workflows/check-ship-change-removed-gate.yml
@@ -1,0 +1,31 @@
+name: Check Ship-Change Removed Gate
+
+# Unit tests for `.claude/scripts/ship-change-removed-gate.sh` — the only mechanism
+# that proves a change's REMOVED inventory actually left the tree before the change
+# may archive.
+#
+# The gate shipped without tests and was green on 25 of 36 bullets whose artifacts
+# were all still on disk. Every way a bullet can pass vacuously now has a case in
+# `.claude/scripts/tests/ship-change-removed-gate.test.sh`; this job is what keeps
+# them from rotting back.
+#
+# Only the gate's own tests run here. Active change files legitimately fail the gate
+# — their removals have not happened yet — so CI never runs it against them.
+#
+# bash + git, no toolchain, no network: sub-second on a clean runner.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ship-change-removed-gate-tests:
+    name: ship-change-removed-gate tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bash .claude/scripts/tests/ship-change-removed-gate.test.sh
+        run: bash .claude/scripts/tests/ship-change-removed-gate.test.sh


### PR DESCRIPTION
## The problem

`.claude/scripts/ship-change-removed-gate.sh` is the only mechanism that proves a change's `REMOVED` inventory actually left the tree — `/ship-change` step 1, exit 0 required before a change may archive. It is currently green on removals that have not happened.

```
$ bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/importable-python-library-ripout.md
# 25 of 36 bullets pass

$ ls -d runtime/streamlib-plugin-abi sdk/streamlib-plugin-sdk tools/streamlib-pack runtime/streamlib-runtime sdk/streamlib-deno
sdk/streamlib-deno  tools/streamlib-pack  runtime/streamlib-plugin-abi  sdk/streamlib-plugin-sdk  runtime/streamlib-runtime
```

Nothing has been deleted. #1715 is the largest deletion in M39, and this gate is what would have signed it off.

An audit proved 35 of 36 bullets vacuous by injecting each artifact's real source form into a tracked file and watching the gate not notice.

## Root cause

The script extracts everything after `- REMOVED:` — first physical line, verbatim — and feeds it to `git grep -InF` (fixed string). Seven ways a bullet becomes meaningless; this PR fixes the four that are the script's to fix.

| # | Defect | Fixed here |
|---|---|---|
| 1 | Surrounding backticks (35/36 bullets) | rejected |
| 2 | `/`-joined items searched as one literal | rejected |
| 3 | Trailing parenthetical inside the literal | rejected |
| 4 | Shell brace expansion searched literally | rejected |
| 5 | Line wrap — `sed` takes line one only | plan PR (one item per bullet) |
| 6 | `git grep` never matches a filename | **path-existence check** |
| 7 | Over-broad scope (CHANGELOG, decisions) | **pathspec exclusions** |

## What changed

**Path existence (defect 6).** `git grep` searches contents, so a path-shaped bullet only ever proved *"nothing references this"*, never *"the file is gone"*. Each bullet now also runs `git ls-files` over the pattern read as a literal path. This is not a formatting slip — three files in the ripout inventory are on disk and referenced by nothing, so they pass green even with perfect bullet syntax:

```
refs=0  ondisk=1  sdk/streamlib-python/python/streamlib/subprocess_runner.py
refs=0  ondisk=1  sdk/streamlib-python/python/streamlib/_processor_registry.py
refs=0  ondisk=1  sdk/streamlib-python/python/streamlib/cgl_context.py
```

A symbol-shaped bullet (`ProcessorVTable`, `export_plugin!`) names no path and matches nothing, so the check is a no-op for them. Output is now labelled `STILL PRESENT (referenced)` vs `STILL PRESENT (on disk)`.

**Pathspec exclusions (defect 7).** Added `':!CHANGELOG.md' ':!docs/decisions/**'` to the content sweep. `CHANGELOG.md` is release-please-generated from merged commit subjects — the entry announcing a removal is unscrubbable. `docs/decisions/` is annotate-don't-overwrite per `.claude/rules/docs-policy.md` — a superseded ADR keeps naming what it retired. Neither is residue. Both exclusions apply to the content sweep **only**: a file living at a named path is residue wherever it lives, and there is a test pinning that.

**Bullet grammar (defects 1–4).** A pattern carrying backticks, joining items with ` / `, using `{a,b}` brace expansion, or trailing a ` (parenthetical)` cannot match a definition site — backticked text appears only in markdown and rustdoc prose. Those now fail as `MALFORMED BULLET` with the fix named, instead of being searched and passing green. Call-shaped (`host_callbacks()`), path-shaped, macro-shaped (`export_plugin!`) and plain symbols are not rejected — pinned by test.

**Tests.** The gate shipped with none, which is how all of this survived. `.claude/scripts/tests/ship-change-removed-gate.test.sh` — 25 cases, each building a throwaway git repo, planting an artifact, and asserting what the gate says. Every vacuous-pass shape has a case. bash + git, no toolchain, no network, sub-second; run by `.github/workflows/check-ship-change-removed-gate.yml`.

Writing them surfaced a git quirk now pinned by its own test: **any `:!` exclude pathspec silently drops an exact-file positive match** (git 2.43), which would have made every leaf-file bullet — the one case the path check exists for — pass green. `vendor/` is filtered after the fact for that reason.

```
$ bash .claude/scripts/tests/ship-change-removed-gate.test.sh
25 passed, 0 failed
$ shellcheck .claude/scripts/ship-change-removed-gate.sh .claude/scripts/tests/*.sh   # clean
```

## Blast radius

Only the three change files whose bullets are malformed change verdict, and they are all already vacuous today:

| file | bullets | malformed |
|---|---|---|
| `importable-python-library-ripout.md` | 36 | 35 |
| `schema-agreement-ripout.md` | 9 | 9 |
| `pypi-packaging.md` | 2 | 2 |

Every other change file — active and archived — has plain-text bullets and its verdict is unchanged (verified by diffing old vs new across all 12). None of them gains an on-disk hit. The three above are corrected in the plan PR stacked on this one, which is where the path check starts earning its keep.

`.claude/skills/ship-change/SKILL.md` gains one clause: a `MALFORMED BULLET` is not residue and never becomes a follow-up ticket — the change file is corrected in place.

## Why a dedicated PR

`.claude/rules/flow.md`: operating-model changes are their own PR, with rationale. This session does not edit `propose-change` — the skill the follow-up plan PR runs inside — for the same rule's "never edit the skill you are using" clause; the bullet grammar is documented plan-side in `docs/plan/changes/README.md` there instead.

## Note, not a ticket

`docs/plan/changes/archive/2026-08-07-in-process-hosting-ripout.md` no longer passes its own gate: `streamlib-pyembed-spike` now collides with `xtask/src/check_no_in_process_placement.rs`, the check written to enforce its removal. That change genuinely shipped; it gets annotated in the follow-up plan PR rather than chased. The general shape is worth naming — **a ban's enforcement code must name the thing it bans**, so a removal proven by a new checker will always re-trip its own gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - The removal validation gate now detects malformed removal entries and distinguishes them from content that still exists.
  - Validation provides clearer reports for invalid entries, remaining references, and files still present.
  - Expanded path exclusions and parsing rules improve detection accuracy.

- **Documentation**
  - Updated guidance explains how to correct malformed removal entries before archiving.

- **Testing**
  - Added comprehensive coverage for valid, invalid, excluded, missing, and repository-context scenarios.
  - Added continuous checks for the validation suite on pull requests and updates to the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->