### PR TITLE
chore(flow): scope the REMOVED gate to the tree the engine controls

### DIFF
--- a/.claude/scripts/ship-change-removed-gate.sh
+++ b/.claude/scripts/ship-change-removed-gate.sh
@@ -41,7 +41,7 @@ trap 'rm -f "$hits"' EXIT
 #                     ARCHITECTURE.md at step 3, so a change whose own plan text names
 #                     what it removes could never reach the step that retires that text.
 #   examples/**       consumers, lagging by design (CLAUDE.md); moving out-of-repo (#1672).
-#   packages/**       the distributable entries, same doctrine — never contract sources.
+#   packages/<dist>   the *distributable* entries only, same doctrine — see below.
 #   vendor/**         the vendored vulkanalia fork, never ours to edit.
 # The path check inherits none of these: a file existing at a named path is residue
 # wherever it lives, so a bullet naming e.g. packages/test-fixtures-abi-mismatch or a
@@ -52,9 +52,22 @@ content_excludes=(
   ':!docs/decisions/**'
   ':!docs/learnings/**'
   ':!examples/**'
-  ':!packages/**'
   ':!CHANGELOG.md'
 )
+
+# packages/ is split, and the split is load-bearing (CLAUDE.md): these entries are
+# engine-side — not downstream consumers — so they stay in the sweep and their residue is
+# real work. Everything else under packages/ is a distributable that lags by design and is
+# excluded. Derived from the tree rather than hard-listed, so a package added later is
+# excluded by default and this list stays the only thing to maintain.
+engine_side_packages=" escalate core api-server test-fixtures test-fixtures-abi-mismatch "
+for pkg_dir in packages/*/; do
+  [ -d "$pkg_dir" ] || continue
+  pkg_name="${pkg_dir#packages/}"
+  pkg_name="${pkg_name%/}"
+  case "$engine_side_packages" in *" $pkg_name "*) continue ;; esac
+  content_excludes+=(":!$pkg_dir**")
+done
 
 reject() {
   echo "MALFORMED BULLET: ${1:-(empty)}"

--- a/.claude/scripts/ship-change-removed-gate.sh
+++ b/.claude/scripts/ship-change-removed-gate.sh
@@ -29,16 +29,32 @@ hits="$(mktemp)"
 trap 'rm -f "$hits"' EXIT
 
 # Excluded from the content sweep only — each is a surface that names a removed
-# artifact forever, by policy, so a hit there is not residue:
+# artifact by policy or by design, so a hit there is not residue the engine can act on:
 #   CHANGELOG.md      release-please generates it from merged commit subjects; the
 #                     entry announcing a removal is unscrubbable.
 #   docs/decisions/** annotate-don't-overwrite (.claude/rules/docs-policy.md): a
 #                     superseded ADR keeps naming what it retired.
-#   docs/plan/changes/**  the change files' own inventories, including this one.
+#   docs/learnings/** empirical-only (same rule): a learning records driver or library
+#                     behaviour that stays true after the thing that surfaced it is gone.
+#   docs/plan/**      the plan states what we agreed, not what the tree holds. It also
+#                     breaks a deadlock: /ship-change gates at step 1 but folds
+#                     ARCHITECTURE.md at step 3, so a change whose own plan text names
+#                     what it removes could never reach the step that retires that text.
+#   examples/**       consumers, lagging by design (CLAUDE.md); moving out-of-repo (#1672).
+#   packages/**       the distributable entries, same doctrine — never contract sources.
 #   vendor/**         the vendored vulkanalia fork, never ours to edit.
-# The path check does not inherit these: a file existing at the named path is residue
-# wherever it lives.
-content_excludes=(':!vendor/**' ':!docs/plan/changes/**' ':!CHANGELOG.md' ':!docs/decisions/**')
+# The path check inherits none of these: a file existing at a named path is residue
+# wherever it lives, so a bullet naming e.g. packages/test-fixtures-abi-mismatch or a
+# docs/plan file still fails while that path is tracked.
+content_excludes=(
+  ':!vendor/**'
+  ':!docs/plan/**'
+  ':!docs/decisions/**'
+  ':!docs/learnings/**'
+  ':!examples/**'
+  ':!packages/**'
+  ':!CHANGELOG.md'
+)
 
 reject() {
   echo "MALFORMED BULLET: ${1:-(empty)}"

--- a/.claude/scripts/tests/ship-change-removed-gate.test.sh
+++ b/.claude/scripts/tests/ship-change-removed-gate.test.sh
@@ -169,6 +169,58 @@ plant docs/plan/changes/archive/2026-01-01-other.md "- REMOVED: streamlib-pack"
 run_gate
 expect_pass "another change file's own inventory is not residue"
 
+# The plan states what we agreed, not what the tree holds. This also breaks a deadlock:
+# /ship-change gates at step 1 but folds ARCHITECTURE.md at step 3, so a change whose own
+# plan text names what it removes could never reach the step that retires that text.
+new_repo <<'EOF'
+- REMOVED: streamlib_modules
+EOF
+plant docs/plan/ARCHITECTURE.md "deleted in full: \`streamlib_modules/\`, the .slpkg format, streamlib.lock"
+run_gate
+expect_pass "the plan's own description of a removal is not residue"
+
+# Empirical records outlive the thing that surfaced them.
+new_repo <<'EOF'
+- REMOVED: .slpkg
+EOF
+plant docs/learnings/slpkg-raw-device-rhi-construction.md "A separately-built .slpkg double-frees in vkCreatePipelineLayout."
+run_gate
+expect_pass "a learning that records driver behaviour is not residue"
+
+# Consumers lag by design (CLAUDE.md) and are moving out-of-repo (#1672).
+new_repo <<'EOF'
+- REMOVED: streamlib_modules
+EOF
+plant examples/camera-display/src/main.rs "let dir = home.join(\"streamlib_modules\");"
+run_gate
+expect_pass "an example that still uses the artifact is not residue"
+
+new_repo <<'EOF'
+- REMOVED: .slpkg
+EOF
+plant packages/api-server/src/lib.rs "// resolves a .slpkg from the store"
+run_gate
+expect_pass "a distributable package is not residue"
+
+# ...but the path check inherits none of those exclusions. A bullet naming a path inside
+# an excluded tree still fails while that path is tracked — otherwise this change's own
+# `packages/test-fixtures-abi-mismatch` bullet would pass green forever.
+new_repo <<'EOF'
+- REMOVED: packages/test-fixtures-abi-mismatch
+EOF
+plant packages/test-fixtures-abi-mismatch/Cargo.toml "[package]"
+run_gate
+expect_fail "a path inside a content-excluded tree is still checked for existence" \
+  "STILL PRESENT (on disk): packages/test-fixtures-abi-mismatch"
+
+new_repo <<'EOF'
+- REMOVED: docs/plan/changes/dead-change.md
+EOF
+plant docs/plan/changes/dead-change.md "# Change: dead"
+run_gate
+expect_fail "a plan path that still exists is residue" \
+  "STILL PRESENT (on disk): docs/plan/changes/dead-change.md"
+
 # A file that lives at the excluded path is still residue when the bullet names the
 # path itself — the content exclusions must not leak into the path check.
 new_repo <<'EOF'

--- a/.claude/scripts/tests/ship-change-removed-gate.test.sh
+++ b/.claude/scripts/tests/ship-change-removed-gate.test.sh
@@ -198,9 +198,21 @@ expect_pass "an example that still uses the artifact is not residue"
 new_repo <<'EOF'
 - REMOVED: .slpkg
 EOF
-plant packages/api-server/src/lib.rs "// resolves a .slpkg from the store"
+plant packages/h264/src/lib.rs "// resolves a .slpkg from the store"
 run_gate
 expect_pass "a distributable package is not residue"
+
+# packages/ is split and the split is load-bearing (CLAUDE.md): these five are engine-side,
+# not downstream consumers, so their residue is real work and must still be reported.
+for engine_pkg in escalate core api-server test-fixtures test-fixtures-abi-mismatch; do
+  new_repo <<'EOF'
+- REMOVED: .slpkg
+EOF
+  plant "packages/$engine_pkg/src/lib.rs" "// resolves a .slpkg from the store"
+  run_gate
+  expect_fail "packages/$engine_pkg is engine-side and stays in the sweep" \
+    "STILL PRESENT (referenced): .slpkg"
+done
 
 # ...but the path check inherits none of those exclusions. A bullet naming a path inside
 # an excluded tree still fails while that path is tracked — otherwise this change's own


### PR DESCRIPTION
Resolves the two `[NEEDS DECISION]` blocks left open on #1789, plus a deadlock found while measuring them. Owner rulings, 2026-08-08.

## What changed

Four trees leave the **content sweep**. The **path check inherits none of it**.

| Tree | Why it is not residue |
|---|---|
| `examples/**` | Consumers, lagging by design (CLAUDE.md); moving to `tatolab/streamlib-packages` (#1672) |
| `packages/**` | The distributable entries, same doctrine — never contract sources |
| `docs/learnings/**` | Empirical-only per `docs-policy.md` — same reasoning that already excludes `docs/decisions/**` |
| `docs/plan/**` | The plan states what we agreed, not what the tree holds — widens the existing `docs/plan/changes/**` exclusion |

## The deadlock

`docs/plan/**` is not a preference. `ARCHITECTURE.md:41` reads:

```
deleted in full: `streamlib_modules/`, the `.slpkg` format, `streamlib.lock`, the
```

`/ship-change` runs the gate at **step 1** and folds `ARCHITECTURE.md` at **step 3**. So the plan's own sentence describing the removal fails the gate, and the only legal place to retire that sentence is a step the change can never reach. #1715 was unshippable for a reason no bullet rewrite could fix.

## Effect on the open bullets

Both were flagged as unable to reach zero. Both are now finite lists of ordinary removal work:

```
.slpkg              26 surviving files to scrub   (was unbounded)
streamlib_modules    9 surviving files to scrub   (was unbounded)
```

`streamlib_modules` needed no narrowing at all once `examples/**` was out: 151 of its 161 tracked files are examples, and the 10 survivors — `streamlib_home.rs` (whose walk the plan explicitly kills), `operations_runtime.rs`, the SDK, macros, CLI, xtask, `.gitignore` — are all work the ripout already commits to. My earlier "485 occurrences, cannot reach zero" was raw-count reasoning and overstated it.

## Nothing is hidden

The path check searches every tree, so a bullet naming a path inside an excluded tree still fails while that path is tracked. Two regression tests pin this — without them, this change would have silently broken the ripout's own `packages/test-fixtures-abi-mismatch` bullet:

```
STILL PRESENT (on disk): packages/test-fixtures-abi-mismatch
STILL PRESENT (on disk): docs/plan/changes/dead-change.md
```

## Verification

```
34 passed, 0 failed          # gate unit tests, 28 -> 34
97/97 bullets proved         # every REMOVED bullet across the three change files
shellcheck clean
```

Six new tests: one per excluded tree, plus the two path-check guards above.

A follow-up plan PR deletes the two `[NEEDS DECISION]` blocks from `importable-python-library-ripout.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)