### PR TITLE
refactor(engine): rewire vulkan-jpeg onto the streamlib facade + streamlib_home cwd resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6287,7 +6287,7 @@ version = "0.16.0"
 dependencies = [
  "bytemuck",
  "jpeg-encoder",
- "streamlib-plugin-sdk",
+ "streamlib",
  "thiserror 2.0.18",
  "tracing",
  "zune-jpeg",

--- a/runtime/streamlib-engine/src/core/streamlib_home.rs
+++ b/runtime/streamlib-engine/src/core/streamlib_home.rs
@@ -1,107 +1,47 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use streamlib_idents::app_modules::AppModulesDir;
 use streamlib_idents::PackageRef;
 
-/// The streamlib app root — the install / clone directory, the top level
-/// that holds both the read-only `packages/` source and the generated
-/// `.streamlib/` working tree ([`get_streamlib_data_dir`]).
+/// The streamlib home root — the parent of the generated `.streamlib/`
+/// working tree ([`get_streamlib_data_dir`]).
 ///
 /// Resolution order:
-/// 1. `STREAMLIB_HOME` environment variable (explicit override — the
-///    install/Docker points it at the install location; tests point it
-///    at a tempdir).
-/// 2. The install / clone root found by walking up from the running binary
-///    to the first ancestor containing a `packages/` directory. So
-///    `get_streamlib_home().join("packages")` is the source dir, and each
-///    box / container is one self-contained folder — no global home state
-///    to track across a fleet.
-/// 3. The running binary's own directory as an infallible last resort when
-///    it isn't inside an app tree and no override is set. Never the user
-///    home directory.
-///
-/// ```text
-/// <streamlib-home>/                     ← app root (install / clone)
-/// ├── packages/                         # read-only source (NOT under .streamlib)
-/// ├── streamlib_modules/@org/name/      # installed / built package slots,
-/// │                                     #   co-located under the APP root
-/// │                                     #   (installed_package_slot_dir); each
-/// │                                     #   Python slot carries its own `.venv/`
-/// └── .streamlib/                       # generated working tree — get_streamlib_data_dir()
-///     ├── cache/
-///     │   └── uv/                        # uv PyPI cache      (Python packages only)
-///     ├── logs/<runtime_id>-<ts>.jsonl  # per-runtime JSONL logs
-///     └── resolver-cache/               # git / URL checkouts (Strategy::Git / Url)
-/// ```
-///
-/// Each subdir is created on demand by its consumer — an all-Rust,
-/// `Strategy::Path` graph populates `streamlib_modules/` and `logs/`. Installed
-/// state is NOT a manifest here: a package's presence is its
-/// `streamlib_modules/@org/name` slot, and the app's `streamlib.lock` records
-/// how each was added.
+/// 1. `STREAMLIB_HOME` (explicit override — Docker/tests point it at a fixed
+///    location or a tempdir).
+/// 2. The process working directory, so a `dev`/`run` invocation keeps its
+///    `./.streamlib/` beside the app being run.
+/// 3. `.` as an infallible last resort. Never the running binary's directory
+///    and never the user home directory — home state is project-local, not
+///    collocated across a fleet.
 pub fn get_streamlib_home() -> PathBuf {
-    if let Ok(home) = std::env::var("STREAMLIB_HOME") {
+    resolve_streamlib_home(
+        std::env::var_os("STREAMLIB_HOME"),
+        std::env::current_dir().ok(),
+    )
+}
+
+/// Pure resolver behind [`get_streamlib_home`]: env override → cwd → `.`.
+/// Split out so the resolution order is testable without mutating the process
+/// environment or working directory. An empty `STREAMLIB_HOME` is ignored,
+/// matching [`app_modules_root`]'s treatment of `STREAMLIB_MODULES_DIR`.
+fn resolve_streamlib_home(env_override: Option<OsString>, cwd: Option<PathBuf>) -> PathBuf {
+    if let Some(home) = env_override.filter(|home| !home.is_empty()) {
         return PathBuf::from(home);
     }
-
-    find_app_root().unwrap_or_else(fallback_home)
+    cwd.unwrap_or_else(|| PathBuf::from("."))
 }
 
 /// The generated / regenerable working tree, `<streamlib-home>/.streamlib`.
-/// Counterpart to the read-only `<streamlib-home>/packages` source: holds the
-/// Python uv cache, per-runtime data + logs, and git/URL resolver checkouts. It
-/// is gitignored, so collocating it in a dev workspace doesn't litter the tree.
+/// Holds the Python uv cache, per-runtime data + logs, and git/URL resolver
+/// checkouts. It is gitignored, so collocating it in a dev workspace doesn't
+/// litter the tree.
 pub fn get_streamlib_data_dir() -> PathBuf {
     get_streamlib_home().join(".streamlib")
-}
-
-/// Walk up from the running binary to the first ancestor containing a
-/// `packages/` directory — the streamlib install / workspace root. This
-/// mirrors the runtime binary's package-source resolution; the difference
-/// is that the home root honors the `STREAMLIB_HOME` override (above) while
-/// package-source resolution does not (source is fixed, the working tree is
-/// redirectable).
-fn find_app_root() -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
-    app_root_from(exe.parent()?)
-}
-
-/// Walk up from `start` to the first ancestor containing a `packages/`
-/// directory. Pure helper so the walk-up is testable without depending on
-/// the running binary's location.
-fn app_root_from(start: &std::path::Path) -> Option<PathBuf> {
-    let mut ancestor = Some(start);
-    while let Some(dir) = ancestor {
-        if dir.join("packages").is_dir() {
-            return Some(dir.to_path_buf());
-        }
-        ancestor = dir.parent();
-    }
-    None
-}
-
-/// Infallible last resort: the running binary's own directory. Used only
-/// when the binary isn't inside an app tree and `STREAMLIB_HOME` is unset
-/// (e.g. an external host app that hasn't configured it). Never resolves
-/// to the user home directory — collocated global state is deliberately gone.
-fn fallback_home() -> PathBuf {
-    std::env::current_exe()
-        .ok()
-        .and_then(|exe| exe.parent().map(|dir| dir.to_path_buf()))
-        .unwrap_or_else(|| PathBuf::from("."))
-}
-
-/// Ensure the generated working tree and its standard subdirectories exist.
-pub fn ensure_streamlib_home() -> std::io::Result<PathBuf> {
-    let data = get_streamlib_data_dir();
-
-    std::fs::create_dir_all(data.join("cache/uv"))?;
-    std::fs::create_dir_all(data.join("runtimes"))?;
-
-    Ok(get_streamlib_home())
 }
 
 /// Get the path to the uv cache directory.
@@ -186,28 +126,6 @@ pub fn resolved_app_modules_dir(explicit_app_modules_root: Option<&Path>) -> App
     )
 }
 
-/// Get the path to a runtime's directory.
-pub fn get_runtime_dir(runtime_id: &str) -> PathBuf {
-    get_streamlib_data_dir().join("runtimes").join(runtime_id)
-}
-
-/// Get the path to a processor's directory within a runtime.
-pub fn get_processor_dir(runtime_id: &str, processor_id: &str) -> PathBuf {
-    get_runtime_dir(runtime_id)
-        .join("processors")
-        .join(processor_id)
-}
-
-/// Get the path to a processor's venv directory.
-pub fn get_processor_venv_dir(runtime_id: &str, processor_id: &str) -> PathBuf {
-    get_processor_dir(runtime_id, processor_id).join("venv")
-}
-
-/// Get the path to a processor's data directory.
-pub fn get_processor_data_dir(runtime_id: &str, processor_id: &str) -> PathBuf {
-    get_processor_dir(runtime_id, processor_id).join("data")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -249,27 +167,36 @@ mod tests {
         assert_ne!(app_a, other_org, "the org must move the slot");
     }
 
+    /// Pins the D2 resolution order: a non-empty `STREAMLIB_HOME` wins over
+    /// the working directory. The override is the fixed-location path Docker
+    /// and tests rely on.
     #[test]
-    fn app_root_is_first_ancestor_with_packages_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path();
-        // Mark `root` as an app root and nest the "binary" a few levels down.
-        std::fs::create_dir_all(root.join("packages")).unwrap();
-        let bin_dir = root.join("target").join("debug").join("deps");
-        std::fs::create_dir_all(&bin_dir).unwrap();
-
-        assert_eq!(app_root_from(&bin_dir).as_deref(), Some(root));
-        // Resolves from the root itself too.
-        assert_eq!(app_root_from(root).as_deref(), Some(root));
+    fn home_prefers_a_non_empty_env_override_over_cwd() {
+        let home = resolve_streamlib_home(
+            Some(OsString::from("/opt/streamlib")),
+            Some(PathBuf::from("/some/cwd")),
+        );
+        assert_eq!(home, PathBuf::from("/opt/streamlib"));
     }
 
+    /// An empty `STREAMLIB_HOME` is ignored — it names no location, so it
+    /// falls through to the working directory rather than resolving to the
+    /// empty path.
     #[test]
-    fn app_root_is_none_without_a_packages_dir() {
-        // Revert the `packages/` marker check and this would wrongly return
-        // a dir — the walk-up must find nothing when no ancestor qualifies.
-        let tmp = tempfile::tempdir().unwrap();
-        let nested = tmp.path().join("a").join("b");
-        std::fs::create_dir_all(&nested).unwrap();
-        assert_eq!(app_root_from(&nested), None);
+    fn home_ignores_an_empty_env_override_and_uses_cwd() {
+        let home = resolve_streamlib_home(Some(OsString::new()), Some(PathBuf::from("/some/cwd")));
+        assert_eq!(home, PathBuf::from("/some/cwd"));
+    }
+
+    /// No override: the working directory, so `./.streamlib/` lands beside the
+    /// app being run. Never the running binary's directory or the user home.
+    #[test]
+    fn home_falls_back_to_cwd_then_dot() {
+        assert_eq!(
+            resolve_streamlib_home(None, Some(PathBuf::from("/some/cwd"))),
+            PathBuf::from("/some/cwd")
+        );
+        // cwd unresolvable and no override → the infallible last resort.
+        assert_eq!(resolve_streamlib_home(None, None), PathBuf::from("."));
     }
 }

--- a/sdk/vulkan-jpeg/Cargo.toml
+++ b/sdk/vulkan-jpeg/Cargo.toml
@@ -13,13 +13,11 @@ tracing = { workspace = true }
 bytemuck = { version = "1.16", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-# Engine-free authoring SDK — provides the FullAccess GPU surface the
-# Vulkan-compute backend builds against (VulkanComputeKernel, StorageBuffer,
-# TextureRing, RhiCommandRecorder, ComputeKernelDescriptor, the color-math
-# types, and the GpuContext{Full,Limited}Access views) under
-# `streamlib_plugin_sdk::sdk::*`. Depending on the SDK by its real name keeps
-# this crate engine-free, so it is safe to compile into a `.slpkg` cdylib.
-streamlib-plugin-sdk = { path = "../streamlib-plugin-sdk", version = "0.16.0" }
+# The streamlib facade — provides the FullAccess GPU surface the Vulkan-compute
+# backend builds against (VulkanComputeKernel, StorageBuffer, TextureRing,
+# ComputeKernelDescriptor, the color-math types, and the GpuContextFullAccess
+# view) under `streamlib::sdk::*` and its `sdk::engine::host_rhi` tier.
+streamlib = { path = "../streamlib-sdk", version = "0.16.0" }
 
 [dev-dependencies]
 jpeg-encoder = "0.6"

--- a/sdk/vulkan-jpeg/src/backend.rs
+++ b/sdk/vulkan-jpeg/src/backend.rs
@@ -23,7 +23,7 @@
 //! [`SimpleJpegDecoder`]: crate::simple_decoder::SimpleJpegDecoder
 //! [`VulkanComputeBackend`]: crate::vulkan_compute_backend::VulkanComputeBackend
 
-use streamlib_plugin_sdk::sdk::error::Result;
+use streamlib::sdk::error::Result;
 
 use crate::simple_decoder::JpegDecodeOutput;
 
@@ -58,7 +58,7 @@ impl JpegBackendKind {
 /// Limited-safe — no `vkAllocateMemory`, no pipeline / fence creation in
 /// steady state.
 ///
-/// [`TextureRing`]: streamlib_plugin_sdk::sdk::rhi::TextureRing
+/// [`TextureRing`]: streamlib::sdk::context::TextureRing
 pub trait JpegDecodeBackend: Send + std::fmt::Debug {
     /// Decode `jpeg_bytes` into the backend's next output slot. Returns
     /// the slot's [`JpegDecodeOutput`] (texture + surface_id + dimensions
@@ -66,11 +66,11 @@ pub trait JpegDecodeBackend: Send + std::fmt::Debug {
     /// through the normal `surface_id` contract.
     ///
     /// Errors:
-    /// - [`streamlib_plugin_sdk::sdk::error::Error::GpuError`] for parser /
+    /// - [`streamlib::sdk::error::Error::GpuError`] for parser /
     ///   Huffman failures, dimension overflows past the backend's declared
     ///   maxima, colorimetry-resolution failures, and backend-specific GPU
     ///   failures.
-    /// - [`streamlib_plugin_sdk::sdk::error::Error::NotSupported`] for inputs
+    /// - [`streamlib::sdk::error::Error::NotSupported`] for inputs
     ///   the backend cannot handle (e.g. non-4:2:0 sampling on the
     ///   Vulkan-compute backend).
     fn decode(&mut self, jpeg_bytes: &[u8]) -> Result<JpegDecodeOutput>;

--- a/sdk/vulkan-jpeg/src/color.rs
+++ b/sdk/vulkan-jpeg/src/color.rs
@@ -5,7 +5,7 @@
 //!
 //! Parsed-as-bytes inside the crate's marker walker and surfaced on
 //! [`crate::DecodedJpeg::color_info`]. Resolution to the engine's
-//! `streamlib_plugin_sdk::sdk::color::ResolvedColorInfo` lives in
+//! `streamlib::sdk::color::ResolvedColorInfo` lives in
 //! [`JpegColorInfo::resolve`] (Linux-only).
 
 use crate::error::{JpegError, JpegResult};
@@ -425,7 +425,7 @@ pub(crate) fn parse_app14_adobe(payload: &[u8]) -> JpegResult<Option<AdobeMetada
 #[derive(Debug, Clone, Copy)]
 pub struct ResolvedJpegColor {
     /// Engine-shaped 4-tuple the kernel consumes via push constants.
-    pub info: streamlib_plugin_sdk::sdk::color::ResolvedColorInfo,
+    pub info: streamlib::sdk::color::ResolvedColorInfo,
     /// Why this resolution was picked — useful for logging and tests
     /// that need to verify which branch fired without inspecting the
     /// numeric 4-tuple.
@@ -461,7 +461,7 @@ impl JpegColorInfo {
     /// rejected with a typed error (the 4-component decode path
     /// doesn't exist today).
     pub fn resolve(&self) -> JpegResult<ResolvedJpegColor> {
-        use streamlib_plugin_sdk::sdk::color::{
+        use streamlib::sdk::color::{
             MatrixId, PrimariesId, RangeId, ResolvedColorInfo, TransferId,
         };
 
@@ -698,13 +698,13 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Resolution tests (Linux-only — depend on streamlib_plugin_sdk::sdk::color).
+    // Resolution tests (Linux-only — depend on streamlib::sdk::color).
     // -----------------------------------------------------------------
 
     #[cfg(target_os = "linux")]
     #[test]
     fn resolve_empty_color_info_returns_jfif_default() {
-        use streamlib_plugin_sdk::sdk::color::{MatrixId, PrimariesId, RangeId, TransferId};
+        use streamlib::sdk::color::{MatrixId, PrimariesId, RangeId, TransferId};
         let info = JpegColorInfo::default();
         let resolved = info.resolve().expect("resolve");
         assert_eq!(resolved.source, JpegColorSource::JfifDefault);
@@ -717,7 +717,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn resolve_adobe_rgb_direct_collapses_matrix_to_identity() {
-        use streamlib_plugin_sdk::sdk::color::MatrixId;
+        use streamlib::sdk::color::MatrixId;
         let info = JpegColorInfo {
             adobe: Some(AdobeMetadata {
                 transform: AdobeTransform::Direct,
@@ -732,7 +732,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn resolve_adobe_ycbcr_equals_jfif_default() {
-        use streamlib_plugin_sdk::sdk::color::MatrixId;
+        use streamlib::sdk::color::MatrixId;
         let info = JpegColorInfo {
             adobe: Some(AdobeMetadata {
                 transform: AdobeTransform::YCbCr,

--- a/sdk/vulkan-jpeg/src/kernel.rs
+++ b/sdk/vulkan-jpeg/src/kernel.rs
@@ -15,12 +15,13 @@
 //! construction. No raw `vulkanalia` calls; no hand-rolled descriptor
 //! sets, pipeline layouts, or command buffers.
 
-use streamlib_plugin_sdk::sdk::color::{ResolvedColorInfo, TransferId};
-use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
-use streamlib_plugin_sdk::sdk::error::{Error, Result};
-use streamlib_plugin_sdk::sdk::rhi::{
+use streamlib::sdk::color::{ResolvedColorInfo, TransferId};
+use streamlib::sdk::context::GpuContextFullAccess;
+use streamlib::sdk::engine::host_rhi::VulkanComputeKernel;
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{
     ColorConverterPushConstants, ComputeBindingSpec, ComputeKernelDescriptor, SourceLayoutInfo,
-    StorageBuffer, Texture, VulkanComputeKernel,
+    StorageBuffer, Texture,
 };
 
 use crate::header::DecodedJpeg;

--- a/sdk/vulkan-jpeg/src/simple_decoder.rs
+++ b/sdk/vulkan-jpeg/src/simple_decoder.rs
@@ -7,10 +7,10 @@
 //!
 //! [`VulkanComputeBackend`]: crate::vulkan_compute_backend::VulkanComputeBackend
 
-use streamlib_plugin_sdk::sdk::color::ResolvedColorInfo;
-use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
-use streamlib_plugin_sdk::sdk::error::Result;
-use streamlib_plugin_sdk::sdk::rhi::Texture;
+use streamlib::sdk::color::ResolvedColorInfo;
+use streamlib::sdk::context::GpuContextFullAccess;
+use streamlib::sdk::error::Result;
+use streamlib::sdk::rhi::Texture;
 
 use crate::backend::{JpegBackendKind, JpegDecodeBackend};
 use crate::color::JpegColorSource;
@@ -22,7 +22,7 @@ pub const MAX_FRAMES_IN_FLIGHT: usize = 2;
 
 /// Output produced by [`SimpleJpegDecoder::decode`]: the GPU texture the
 /// decode wrote into, its `surface_id` (registered in
-/// [`streamlib_plugin_sdk::sdk::context::GpuContextFullAccess`]'s texture
+/// [`streamlib::sdk::context::GpuContextFullAccess`]'s texture
 /// cache so downstream in-process consumers can resolve it), and the
 /// decoded frame's actual pixel dimensions.
 #[derive(Debug, Clone)]
@@ -77,7 +77,7 @@ impl SimpleJpegDecoder {
     /// `(max_width, max_height)` pixels.
     ///
     /// Must be called inside a
-    /// [`streamlib_plugin_sdk::sdk::context::GpuContextFullAccess`] scope
+    /// [`streamlib::sdk::context::GpuContextFullAccess`] scope
     /// (the only way crate-external code obtains a `&GpuContextFullAccess`).
     /// The processor-setup mutex is held for the duration of `new`,
     /// serializing this work against any other concurrent

--- a/sdk/vulkan-jpeg/src/vulkan_compute_backend.rs
+++ b/sdk/vulkan-jpeg/src/vulkan_compute_backend.rs
@@ -18,12 +18,10 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use streamlib_plugin_sdk::sdk::context::GpuContextFullAccess;
-use streamlib_plugin_sdk::sdk::error::{Error, Result};
-use streamlib_plugin_sdk::sdk::rhi::{
-    StorageBuffer, TextureFormat, TextureRing, TextureUsages, VulkanAccess, VulkanLayout,
-    VulkanStage,
-};
+use streamlib::sdk::context::{GpuContextFullAccess, TextureRing};
+use streamlib::sdk::engine::host_rhi::{VulkanAccess, VulkanStage};
+use streamlib::sdk::error::{Error, Result};
+use streamlib::sdk::rhi::{StorageBuffer, TextureFormat, TextureUsages, VulkanLayout};
 
 use crate::JpegColorSource;
 use crate::backend::{JpegBackendKind, JpegDecodeBackend};


### PR DESCRIPTION
## Summary

The two survivor-rewire bullets that remain on #1713 after the 2026-08-08 re-scope (plan PR #1793 moved the other three to #1715):

- **`sdk/vulkan-jpeg`** drops the doomed `streamlib-plugin-sdk` dependency for the `streamlib` facade. The remap is not a uniform prefix swap: `color` / `context` / `error` and most `rhi` types land on `streamlib::sdk::*`, but `VulkanComputeKernel` / `VulkanAccess` / `VulkanStage` are in `streamlib::sdk::engine::host_rhi` and `TextureRing` in `streamlib::sdk::context`. The cdylib-safety constraint drops with the plugin/cdylib world.
- **`core/streamlib_home.rs`** (owner ruling D2): the `packages/` install-root walk-up (`find_app_root` / `app_root_from`) and the exe-dir fallback die. `get_streamlib_home()` now resolves `STREAMLIB_HOME` → process working directory → `.`, so logs land project-local at `./.streamlib/`. "Never the user home directory" is reaffirmed. Resolution is split into a pure `resolve_streamlib_home()` so the order is testable without mutating process env/cwd. Five callerless helpers are removed.

The `streamlib_modules` app-modules machinery (`app_modules_root`, `installed_package_slot_dir`, …) is deliberately **left in place** — it re-sequences to #1715 with its `module_loader/` + `install.rs` consumers.

## Closes

Closes #1713

## Exit criteria

- `vulkan-jpeg` compiles against the `streamlib` facade with no residual `streamlib_plugin_sdk` references; every symbol resolves at its correct facade tier (compile-verified).
- No dependency cycle: neither `streamlib` nor `streamlib-engine` depends back on `vulkan-jpeg`.
- `get_streamlib_home()` resolves `STREAMLIB_HOME` → cwd → `.`; the exe-dir/`packages`-walk resolution is gone.
- The five callerless helpers and both walk-up functions are removed with no dangling references.
- Local gate battery green.

## Test plan

- `cargo test -p vulkan-jpeg --lib` (30) + integration (18) — the CPU color-resolution suite is the rewire's behaviour-preserving regression guard.
- `cargo test -p streamlib-engine --lib streamlib_home::` (5) — 3 new resolution-order tests (env override wins, empty ignored, cwd→`.` fallback) + 2 surviving slot tests.
- `cargo clippy -p streamlib-engine -p vulkan-jpeg -p streamlib` — clean (no new warnings in touched files).
- Full xtask lint battery (check-boundaries, lint-logging, check-no-in-process-placement, …) — pass.
- `cargo doc --no-deps` with `-D rustdoc::broken_intra_doc_links` — no broken links after the doc-path rewire.

## Notes for owner

- **Downstream consumers break by design.** `packages/jpeg` **and** `packages/frame-tap` both depend on `vulkan-jpeg` and won't compile against the rewired crate until re-authored. Expected lag-by-design per the runtime-first doctrine — not tracked here. (My earlier "only consumer" note undercounted; `frame-tap` also consumes it. No cycle either way — both are `packages/` leaves.)
- **GPU decode correctness is rig-only.** This is a pure import rewire — the facade tiers are compile-verified and the CPU color-resolution path is runtime-verified — so pixel output should be unchanged. A `/verify-live` rig pass would fully confirm the JPEG decode still produces correct pixels through the remapped `sdk::engine::host_rhi` kernel path. Not MVP-gating for a refactor.
- **Pre-existing `cargo fmt --check` drift** in `streamlib_home.rs` (the `streamlib_idents` import-pair order + the `APP_MODULES_ROOT_OVERRIDE` static line) sits on lines this branch did not modify — byte-identical on `main`. Left untouched per engine-doctrine (don't auto-fix unrelated surfaced issues). No CI workflow runs `cargo fmt --check` today (#1310 tracks restoring it).
- **~50 pre-existing engine warnings** (module-loader / RHI dead code) are the `main` baseline, slated for #1715 deletion — the branch actually nets 5 fewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * StreamLib home resolution now prioritizes `STREAMLIB_HOME`, then the current working directory, with a fallback to `.`.
  * Removed automatic application-root discovery and related runtime directory helpers.
  * Updated Vulkan JPEG integration to use the unified StreamLib SDK interface.
  * Refreshed SDK references and documentation without changing decoder or color-resolution behavior.
* **Tests**
  * Added coverage for home-directory precedence and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->