### PR TITLE
docs(plan): strike three over-reaching REMOVED bullets from the ripout (surviving subjects)

### DIFF
--- a/docs/plan/changes/importable-python-library-ripout.md
+++ b/docs/plan/changes/importable-python-library-ripout.md
@@ -331,7 +331,13 @@ half still belongs to this ticket.
   > ~~`setup.py`~~ — Corrected 2026-08-08: it is at `sdk/streamlib-python/setup.py`, not
   > under `python/streamlib/`. The bullet named a path that does not exist, so it would
   > have passed green whatever the gate checked.
-- REMOVED: schemas/streamlib.schema.json
+> ~~- REMOVED: schemas/streamlib.schema.json~~ — Superseded 2026-08-09 (owner
+> ratification at the #1715 `/ship-change` gate). This JSON Schema validates
+> `streamlib.yaml`, the package manifest that **survives #1715** (the schema-ident /
+> package surface dies in `schema-free-ports` / `processor-class-identity`, not here).
+> Deleting it in #1715 was premature and left dangling `$schema` refs in the surviving
+> `streamlib.yaml` files. It moves to the successor changes, which retire the manifest
+> and its schema together. Not #1715's residue.
 - REMOVED: scripts/sync-inter-crate-versions.py
 - REMOVED: packages/test-fixtures-abi-mismatch
 - REMOVED: docs/architecture/plugin-abi.md
@@ -339,8 +345,18 @@ half still belongs to this ticket.
 - REMOVED: docs/architecture/package-source.md
 - REMOVED: docs/architecture/package-staging-layout.md
 - REMOVED: docs/architecture/runtime-module-materialization.md
-- REMOVED: docs/architecture/schema-identity-and-packaging.md
-- REMOVED: docs/architecture/subprocess-rhi-parity.md
+> ~~- REMOVED: docs/architecture/schema-identity-and-packaging.md~~ — Superseded
+> 2026-08-09 (owner ratification at the #1715 `/ship-change` gate). This doc describes
+> the schema-ident core in `streamlib-idents` / `streamlib-jtd-codegen`, which this
+> change **carries through unchanged** (see the survivor-rewire bullet: both die in
+> `schema-free-ports` / `processor-class-identity`). 15+ surviving crates link it; per
+> docs-policy an architecture doc describes current shipped state, so it stays until its
+> subject dies in the successor changes.
+> ~~- REMOVED: docs/architecture/subprocess-rhi-parity.md~~ — Superseded 2026-08-09
+> (owner ratification at the #1715 `/ship-change` gate). Its cross-process
+> DMA-BUF / OPAQUE_FD subject lives on in the surviving `streamlib-consumer-rhi`
+> carve-out (6+ surviving-code links, including `check-boundaries`); the cdylib framing
+> is rewritten, not the doc deleted. Per docs-policy it describes current shipped state.
 - REMOVED: docs/architecture/cdylib-reachability.md
 - REMOVED: docs/architecture/zero-ceremony-authoring.md
 


### PR DESCRIPTION
## Summary

The #1715 `/ship-change` gate flagged three `REMOVED:` bullets in `importable-python-library-ripout.md` whose **subjects survive #1715** — they die in the successor changes (`schema-free-ports.md` / `processor-class-identity.md`), not in the ABI/module-system ripout. Each is struck with a supersession annotation.

| Bullet | Why it survives #1715 |
|---|---|
| `docs/architecture/schema-identity-and-packaging.md` | Describes the schema-ident core in `streamlib-idents` / `streamlib-jtd-codegen`, which the change file itself says to **carry through unchanged**. 15+ surviving crates link it. |
| `docs/architecture/subprocess-rhi-parity.md` | Its cross-process DMA-BUF / OPAQUE_FD subject lives on in the surviving `streamlib-consumer-rhi` carve-out (6+ code links, incl. `check-boundaries`). |
| `schemas/streamlib.schema.json` | Validates `streamlib.yaml`, the package manifest that survives #1715. Deleting it early left dangling `$schema` refs; it moves to the successor change with the manifest. |

Per `.claude/rules/docs-policy.md` — an architecture doc describes *current shipped state*, so a doc whose subject still ships is not removed here.

## Why now

`/ship-change` for #1715 is blocked at the removed-gate (exit 1). This correction removes the three false-positive bullets from the checked set so a future gate run is honest. The remaining gate residue is real and tracked separately:
- The engine-tree symbol scrub (`PluginAbiObject`, `.slpkg`, `streamlib_modules`, `HostServices`, `ProcessorVTable`, …) — a follow-up ticket in MVP.
- The `.claude/` ABI-era agents/rules — cleared by the companion PR **#1716**.

## Test plan

`bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/importable-python-library-ripout.md` no longer reports the three struck artifacts (verified locally: they drop out of the STILL PRESENT set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the removal inventory to retain the schema and architecture documentation covering schema identity and cross-process compatibility.
  * Clarified that removal of these materials is deferred to a future change.
  * No changes were made to exported or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->