### PR TITLE
docs(plan): ship importable-python-library-ripout

### DIFF
--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -306,7 +306,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   stdio server, or bridge process stands between a host and that endpoint — an MCP
   host is configured with a running node's URL.
   [importable-python-library; mcp-served-with-the-node — SHIPPED #1712]
-  <!-- verify: sdk/streamlib-python-wheel/tests/test_cli_observation_verbs.py::test_the_wheel_serves_no_mcp_verb -->
+  <!-- verify: sdk/streamlib-python-wheel/tests/test_cli.py::test_the_wheel_serves_no_mcp_verb -->
 - **DECIDED** — `dev` and `run` bind the control plane identically: all interfaces
   (`0.0.0.0`) by default, narrowed per invocation by `--host`. There is no dev-only
   exposure posture — a node another host can reach is bound wide by definition, so

--- a/docs/plan/ARCHITECTURE.md
+++ b/docs/plan/ARCHITECTURE.md
@@ -42,10 +42,17 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   package source, the `add`/`install`/`link`/`pkg` verbs, `BuildOrchestrator` and all
   runtime downloading or compiling. Compilation happens at publish time, by the
   author, with standard tools (maturin/CI for wheels, cargo for crates) — StreamLib
-  never compiles user code. [importable-python-library]
+  never compiles user code.
+  [importable-python-library; importable-python-library-ripout — SHIPPED #1715 for the
+  verbs, `BuildOrchestrator` and every runtime build path; the `.slpkg`, lockfile and
+  package-source residue rides `streamlib-idents` and `streamlib-jtd-codegen` into
+  processor-class-identity, which deletes them whole]
+  <!-- verify: bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/archive/2026-08-10-importable-python-library-ripout.md -->
 - **DECIDED** — The plugin ABI is deleted: no dlopen'd processor cdylibs, no `repr(C)`
   vtable surface, no load handshake, no build fingerprints. The extension paths are
-  Python packages and Rust source crates only. [importable-python-library]
+  Python packages and Rust source crates only.
+  [importable-python-library; importable-python-library-ripout — SHIPPED #1715]
+  <!-- verify: bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/archive/2026-08-10-importable-python-library-ripout.md -->
 - **DECIDED** — Third-party native code (closed-source included) ships as an ordinary
   Python package whose native internals expose capabilities to Python as handles —
   frames, FDs, exportable device allocations, buffers — wrapped by a Python
@@ -244,7 +251,10 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   deleted with the module system they are built on. TypeScript authoring is paused,
   not rejected — a future TypeScript SDK follows this same importable-library model
   (a native module a TypeScript app imports; Deno itself optional), aimed at the
-  hobbyist / video-creator audience when it is scheduled. [importable-python-library]
+  hobbyist / video-creator audience when it is scheduled.
+  [importable-python-library; importable-python-library-ripout — SHIPPED #1715 for the
+  deletion clause]
+  <!-- verify: bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/archive/2026-08-10-importable-python-library-ripout.md -->
 - **DECIDED** — The Python SDK carries a GIL-release contract: every native binding
   that can block releases the GIL around the blocking call, and pixels never cross
   into Python as Python-owned objects — frames travel as handles / surface ids, and
@@ -296,7 +306,7 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   stdio server, or bridge process stands between a host and that endpoint — an MCP
   host is configured with a running node's URL.
   [importable-python-library; mcp-served-with-the-node — SHIPPED #1712]
-  <!-- verify: cargo test -p streamlib-cli --bins the_rust_cli_owns_no_observation_verb -->
+  <!-- verify: sdk/streamlib-python-wheel/tests/test_cli_observation_verbs.py::test_the_wheel_serves_no_mcp_verb -->
 - **DECIDED** — `dev` and `run` bind the control plane identically: all interfaces
   (`0.0.0.0`) by default, narrowed per invocation by `--host`. There is no dev-only
   exposure posture — a node another host can reach is bound wide by definition, so
@@ -311,7 +321,8 @@ Legend: **DECIDED** — build exactly this. **OPEN** — do not build; needs an 
   provisioning, and codegen verbs are deleted. The standalone streamlib-runtime
   binary retires. Python embeds the engine in-process via the wheel; the control
   plane exists to observe and drive *running* nodes, not to embed.
-  [importable-python-library]
+  [importable-python-library; importable-python-library-ripout — SHIPPED #1715]
+  <!-- verify: sdk/streamlib-python-wheel/tests/test_cli.py::test_this_wheel_is_the_only_streamlib_cli -->
 - **DECIDED** — Node discovery is a per-user on-disk registry — one JSON file per live
   node in the OS's standard per-user runtime directory — written only by
   control-plane-hosting runtimes, pruned only when both liveness signals (control

--- a/docs/plan/changes/archive/2026-08-10-importable-python-library-ripout.md
+++ b/docs/plan/changes/archive/2026-08-10-importable-python-library-ripout.md
@@ -44,6 +44,17 @@ where a bullet says otherwise)
   not around the named traits — they are defined in terms of the guards and the
   surface descriptor, so the whole non-cross-DSO half travels with them, leaving
   `streamlib-adapter-abi` as exactly the cross-DSO half this change deletes.
+
+  > ~~the cores' dev-deps on doomed `-helpers` crates drop with their subprocess-parity
+  > tests~~ — Half-superseded 2026-08-09 by #1715 / PR #1804 (owner ruling, after an
+  > independent audit). `streamlib-adapter-cpu-readback-helpers` died whole and the clause
+  > holds for it — its bin was a placeholder and its only consumer a "cannot fail by
+  > design" test. `streamlib-adapter-vulkan-helpers` died too, but its four
+  > subprocess-parity tests **survive**: the helper bin re-homed into
+  > `adapters/streamlib-adapter-vulkan/tests/bin/vulkan_adapter_subprocess_helper.rs`,
+  > rewritten against the `streamlib-consumer-rhi` carve-out — the same import path the
+  > wheel's helper children use, which tightens those tests' fidelity rather than
+  > retiring them.
 - **`sdk/streamlib-python-native` retires into the wheel**: helper processes import
   the wheel itself (one native artifact, per §Distribution); the iceoryx2 transport
   and `escalate`/`subprocess_bridge` re-scope to same-interpreter spawns
@@ -140,6 +151,26 @@ where a bullet says otherwise)
   `check-no-inventory-submit`, `check-no-reverse-dns` (doc pointer), `test.yml`,
   `schemas.yml`. Keep — device-wait-idle, no-escalate-in-lifecycle,
   vendored-vulkanalia, license-check, pr-title, release-please.
+
+  > ~~Re-scope — `check-consumer-rhi-repr` (owner call: rationale was plugin FFI)~~ —
+  > Superseded 2026-08-08 (owner ruling at #1715's `/implement` plan gate). It is
+  > **deleted**, not re-scoped. The gate's own header states its entire rationale as
+  > cross-DSO transit — adapter vtables passing POD discriminants across the plugin DSO
+  > boundary — and that boundary dies here. `streamlib-consumer-rhi` survives and the
+  > wheel statically links it, but nothing passes its PODs across a DSO any more. The
+  > surviving cross-process boundary is `streamlib-ipc-types`, which carries its own
+  > `#[repr(C)]` discipline and layout regression tests and which this gate never
+  > covered; re-pointing the xtask at it would be a *new* gate, which this change does
+  > not commission. `xtask/src/check_consumer_rhi_repr.rs` and
+  > `.github/workflows/check-consumer-rhi-repr.yml` are both gone.
+  >
+  > ~~die — … `check-no-streamlib-metadata`, … `check-schema-versions`~~ — Superseded
+  > 2026-08-09 by #1715 / PR #1804. Both are **kept**: `streamlib.yaml` survives this
+  > change — 30 manifests on disk (17 under `packages/`, 11 under `examples/`, 2 under
+  > `runtime/`), named by 74 tracked files — so both gates still guard live subjects, and
+  > deleting them would leave surviving-package metadata discipline unguarded. They retire
+  > with the manifest in `schema-free-ports` / `processor-class-identity`, alongside
+  > `schemas/streamlib.schema.json`, which is struck below for the same reason.
 - The contract-deletion ticket lands as a **pre-approved stacked-PR structure** — its
   blast radius is unreviewable as one diff. **Four more stack levels joined it 2026-08-08**
   (owner ruling, #1713 plan gate), each for the same reason the host-services strip moved:


### PR DESCRIPTION
Ships `importable-python-library-ripout` — Change B of the pivot pair. Folds it into
`ARCHITECTURE.md`, archives it as `2026-08-10-importable-python-library-ripout.md` (the
merge date of the last ticket, PR #1808), and corrects three claims in the change file
before the archive enshrines them.

## Step 1 — the removed gate, clean run

```
$ bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/importable-python-library-ripout.md
clean: 69 REMOVED bullets, none referenced and none on disk.
EXIT=0
```

Re-run against the archived path after the `git mv`, since three of the new `verify:`
markers depend on it working there:

```
$ bash .claude/scripts/ship-change-removed-gate.sh docs/plan/changes/archive/2026-08-10-importable-python-library-ripout.md
clean: 69 REMOVED bullets, none referenced and none on disk.
EXIT=0
```

No residue, so no follow-up ticket and no `MALFORMED BULLET` to correct — #1788's grammar
rewrite and #1791's scope fix did that work ahead of time, and #1806's scrub finished it.

## Precondition — every ticket merged

| Ticket | State | Delivered by |
|---|---|---|
| #1712 api-server relocation + observation-only trim | closed | #1782, #1785 |
| #1743 survivor rewires A | closed | #1751 |
| #1714 helper-process placement | closed | shipped with the placement change |
| #1713 survivor rewires B | closed | #1794 |
| #1715 the contract deletion | **open** | #1795–#1801, #1804 (10 levels, all merged) |
| #1716 companion operating-model PR | closed | #1807 |
| #1806 residue scrub | closed | #1808 |
| gate fixtures | — | #1809 |

**#1715 is still open with its entire stack merged** — a tracker projection gap, not
unfinished work. It wants closing; that is `/reconcile-tracker`'s call, not this PR's.

## Step 3 — the fold

Four bullets gain shipped markers. No section header flips: every section this change
touches also carries `importable-python-library`, which has not shipped (see below), so
the markers go on bullets — the convention `helper-process-placement-only` set and
`mcp-served-with-the-node` followed.

- **§Packages — the plugin ABI bullet.** Marked without qualification. `export_plugin!`,
  `ProcessorVTable`, `PluginAbiObject`, `HostServices`, `install_host_services`,
  `build_fingerprint`, `core/plugin/`, the plugin-abi and plugin-sdk crates and all six
  adapter `-abi` crates are at zero.
- **§Language SDKs — the deletion clause.** Marked for that clause only; the
  "Python is the sole focus runtime" half belongs to Change A.
- **§Control plane — the CLI bullet.** Marked; `tools/streamlib-cli` and
  `runtime/streamlib-runtime` are both gone and the verbs live in the wheel.
- **§Packages — the module-system bullet.** Marked *partially*, and this is the one worth
  reading. The verbs, `BuildOrchestrator` and every runtime build path are gone, but
  `.slpkg`, the lockfile and the package source are still live subsystems inside
  `streamlib-idents` and `streamlib-jtd-codegen` — two crates this change carries
  unchanged by its own survivor-rewire bullet. Those two REMOVED bullets were deferred at
  the #1806 scrub for exactly that reason, so the marker names the shipped half and the
  successor (`processor-class-identity`) that takes the rest. Marking it flatly SHIPPED
  would have claimed a deletion the tree does not show.

**A stale marker this change created:** the MCP bullet verified with
`cargo test -p streamlib-cli --bins the_rust_cli_owns_no_observation_verb`, and #1715
deleted that crate. Re-pointed at `test_the_wheel_serves_no_mcp_verb`, where #1804 moved
the guard.

The three deletion markers verify by re-running the gate against the archived file. It
accepts any path, so the check keeps working after the move — proven by the second run
above.

## Step 4 — diagrams

`diagrams/system.mmd` needs no edit. It already draws the post-ripout world: no ABI, no
module system, no Deno, `new / dev / run · nodes / graph / tap / logs` on the CLI node,
and the interop adapters as app-process Rust. The only match for the retired vocabulary
is the word "packages" in its PyPI sense.

## Corrections made before archiving

All three are implementation findings the `docs/plan/**` hook kept out of the plan; #1804
and #1715's thread carried them as notes owed to `/ship-change`.

1. **`check-consumer-rhi-repr` — deleted, not re-scoped.** The change file lists it under
   Re-scope; the owner ruled deletion at #1715's plan gate. Verified: neither
   `xtask/src/check_consumer_rhi_repr.rs` nor its workflow exists.
2. **`check-no-streamlib-metadata` and `check-schema-versions` — kept, not deleted.** The
   change file lists both to die. 30 `streamlib.yaml` manifests survive (17 `packages/`,
   11 `examples/`, 2 `runtime/`), named across 74 tracked files, so both still guard live
   subjects. #1804's note said 102 files; the measured number is 74 references over 30
   manifests. They retire with the manifest in the successor changes.
3. **The `-helpers` clause is half-true.** `streamlib-adapter-cpu-readback-helpers` died
   whole, as written. `streamlib-adapter-vulkan-helpers` died, but its four
   subprocess-parity tests *survive* on a helper bin re-homed into
   `adapters/streamlib-adapter-vulkan/tests/bin/` and rewritten against the
   `streamlib-consumer-rhi` carve-out — the wheel helpers' own import path, which tightens
   those tests rather than retiring them.

## For the owner

**Change A never shipped.** `importable-python-library.md` is still in `changes/` with all
five of its tickets (#1707–#1711) closed. Change B's own header says it is "blocked on
Change A shipping", so the pair archived out of order. Nothing here depends on it — B's
gate is green and its tickets are merged — but the sections tagged
`(→ importable-python-library)` stay IN-FLIGHT until A is run through `/ship-change`, and
that is the next plan-session candidate.

Per the change file's closing section, #1715 landing also unblocks
`/derive-tickets docs/plan/changes/schema-free-ports.md`, then
`docs/plan/changes/processor-class-identity.md` — tracked as #1730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect completed library cleanup and verification steps.
  * Revised language SDK, control-plane, and CLI guidance with current validation procedures.
  * Recorded updated ownership, sequencing, and testing decisions in the archived change plan.
  * Preserved relevant helper parity tests and clarified which verification checks remain active.
  * Replaced an obsolete CLI verification step with a Python wheel test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->