### PR TITLE
feat(engine)!: require an explicit delivery profile on every input port

### DIFF
--- a/examples/hello-streamlib/src/hello_forward.rs
+++ b/examples/hello-streamlib/src/hello_forward.rs
@@ -32,6 +32,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
     input(
         "video_in",
         "@tatolab/core/VideoFrame",
+        delivery_profile = "latest",
         description = "Frames from the upstream camera source"
     ),
     output(

--- a/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -119,9 +119,9 @@ pub fn delivery_profile_for_input_port(
     let Some(declared) = port.delivery_profile.as_deref() else {
         return Err(crate::core::error::Error::Configuration(format!(
             "input port '{port_name}' on '{processor_type}' declares no delivery_profile. \
-             Every input port must declare one — 'latest', 'every_sample', or 'lossless'. \
-             There is no default: channel policy is declared port-locally at the consuming \
-             input port"
+             Every input port must declare one — {}. There is no default: channel policy \
+             is declared port-locally at the consuming input port",
+            crate::iceoryx2::render_delivery_profile_values()
         )));
     };
     DeliveryProfile::from_manifest_str(declared).map_err(|err| {
@@ -638,13 +638,11 @@ mod tests {
         );
     }
 
-    /// The port's own declaration is the whole answer, and a schema that
-    /// declares a competing `flow_class` never enters into it: `lossless` on a
-    /// port whose wire type says `state_stream` (flow-class default `latest`)
-    /// resolves to `Lossless`. Mentally restore the inference chain and this
-    /// still passes — its sibling
-    /// [`delivery_profile_ignores_the_schema_flow_class`] is the one that
-    /// catches a reintroduced fallback.
+    /// The port's own declaration is the whole answer, and a schema declaring
+    /// a competing `flow_class` never enters into it: `lossless` on a port
+    /// whose wire type says `state_stream` resolves to `Lossless`. This one
+    /// passes either way — `delivery_profile_ignores_the_schema_flow_class`
+    /// is the test that goes red if delivery is resolved from the schema.
     #[test]
     fn delivery_profile_reads_the_port_declaration() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
@@ -684,10 +682,9 @@ mod tests {
 
     /// A registered input port carrying no declaration is a wiring error
     /// naming the port — not a profile inferred from its schema's
-    /// `flow_class`. The port's wire type here declares `sample_stream`, which
-    /// the retired inference chain would have resolved to `EverySample`:
-    /// mentally restore that fallback and this test goes green when it must
-    /// fail.
+    /// `flow_class`. This port's wire type declares `sample_stream`, so
+    /// resolving delivery from the schema instead of the port declaration
+    /// yields `EverySample` and this test goes green when it must fail.
     #[test]
     fn delivery_profile_ignores_the_schema_flow_class() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};

--- a/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
+++ b/runtime/streamlib-engine/src/core/embedded_schemas/mod.rs
@@ -87,29 +87,20 @@ pub fn expected_payload_bytes_for_port_spec(
         .map(|opt| opt.unwrap_or(DEFAULT_EXPECTED_PAYLOAD_BYTES))
 }
 
-/// Resolve the effective [`DeliveryProfile`] for a destination input port.
+/// Resolve the [`DeliveryProfile`] a destination input port declares.
 ///
-/// This is the single delivery-resolution primitive. Precedence:
-///
-/// 1. A port-site `delivery_profile` override (the one delivery knob on the
-///    authoring surface) wins outright.
-/// 2. Otherwise the default derived from the wire type's `metadata.flow_class`
-///    ([`flow_class_for_port_spec`]): `sample_stream` → `every_sample`,
-///    `state_stream` → `latest`.
-/// 3. Otherwise (an `any` wildcard port, or a registered schema that declares
-///    no `flow_class`) [`DeliveryProfile::Latest`] — the newest-wins realtime
-///    default.
+/// This is the single delivery-resolution primitive, and it reads exactly one
+/// thing: the port's own declaration. Nothing is inferred — not from the
+/// port's schema, not from a type-level default — so a registered input port
+/// carrying no declaration is a wiring error, not a silent substitution.
 ///
 /// Falls back to [`DeliveryProfile::Latest`] when the destination processor
 /// type isn't registered or the named port doesn't exist (defensive; a Wired
-/// link always resolves both). Returns [`Error::Configuration`] when an
-/// override or `flow_class` string is present but unrecognized, or when the
-/// port's wire schema is absent from the runtime registry — a wire-time error,
-/// not a silent default substitution.
+/// link always resolves both — the wiring path itself reports the missing
+/// processor).
 ///
 /// [`DeliveryProfile`]: crate::iceoryx2::DeliveryProfile
 /// [`DeliveryProfile::Latest`]: crate::iceoryx2::DeliveryProfile::Latest
-/// [`Error::Configuration`]: crate::core::error::Error::Configuration
 pub fn delivery_profile_for_input_port(
     processor_type: &streamlib_idents::SchemaIdent,
     port_name: &str,
@@ -125,18 +116,19 @@ pub fn delivery_profile_for_input_port(
         return Ok(DeliveryProfile::Latest);
     };
 
-    if let Some(declared) = port.delivery_profile.as_deref() {
-        return DeliveryProfile::from_manifest_str(declared).map_err(|err| {
-            crate::core::error::Error::Configuration(format!(
-                "input port '{}' on '{}' declared {}",
-                port_name, processor_type, err
-            ))
-        });
-    }
-
-    Ok(flow_class_for_port_spec(&port.data_type)?
-        .map(|fc| fc.default_profile())
-        .unwrap_or(DeliveryProfile::Latest))
+    let Some(declared) = port.delivery_profile.as_deref() else {
+        return Err(crate::core::error::Error::Configuration(format!(
+            "input port '{port_name}' on '{processor_type}' declares no delivery_profile. \
+             Every input port must declare one — 'latest', 'every_sample', or 'lossless'. \
+             There is no default: channel policy is declared port-locally at the consuming \
+             input port"
+        )));
+    };
+    DeliveryProfile::from_manifest_str(declared).map_err(|err| {
+        crate::core::error::Error::Configuration(format!(
+            "input port '{port_name}' on '{processor_type}' declared {err}"
+        ))
+    })
 }
 
 /// Resolve the [`FlowClass`] declared in a port's wire schema
@@ -646,11 +638,15 @@ mod tests {
         );
     }
 
-    /// A port-site `delivery_profile` override wins over the flow-class
-    /// default — `lossless` on a video input (whose flow_class default is
-    /// `latest`) resolves to `Lossless`.
+    /// The port's own declaration is the whole answer, and a schema that
+    /// declares a competing `flow_class` never enters into it: `lossless` on a
+    /// port whose wire type says `state_stream` (flow-class default `latest`)
+    /// resolves to `Lossless`. Mentally restore the inference chain and this
+    /// still passes — its sibling
+    /// [`delivery_profile_ignores_the_schema_flow_class`] is the one that
+    /// catches a reintroduced fallback.
     #[test]
-    fn delivery_profile_override_wins_over_flow_class() {
+    fn delivery_profile_reads_the_port_declaration() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
         use crate::core::processors::PROCESSOR_REGISTRY;
         use crate::iceoryx2::DeliveryProfile;
@@ -683,17 +679,19 @@ mod tests {
         assert_eq!(
             delivery_profile_for_input_port(&processor_type, "video_in").unwrap(),
             DeliveryProfile::Lossless,
-            "explicit lossless override must beat the state_stream default"
         );
     }
 
-    /// With no override, the flow-class default drives the profile:
-    /// `sample_stream` → `EverySample`.
+    /// A registered input port carrying no declaration is a wiring error
+    /// naming the port — not a profile inferred from its schema's
+    /// `flow_class`. The port's wire type here declares `sample_stream`, which
+    /// the retired inference chain would have resolved to `EverySample`:
+    /// mentally restore that fallback and this test goes green when it must
+    /// fail.
     #[test]
-    fn delivery_profile_defaults_from_flow_class() {
+    fn delivery_profile_ignores_the_schema_flow_class() {
         use crate::core::descriptors::{PortDescriptor, ProcessorDescriptor};
         use crate::core::processors::PROCESSOR_REGISTRY;
-        use crate::iceoryx2::DeliveryProfile;
 
         let processor_type = SchemaIdent::new(
             Org::new("tatolab").unwrap(),
@@ -718,10 +716,15 @@ mod tests {
             .register_descriptor_only(desc)
             .expect("descriptor registration");
 
-        assert_eq!(
-            delivery_profile_for_input_port(&processor_type, "audio_in").unwrap(),
-            DeliveryProfile::EverySample
+        let err = delivery_profile_for_input_port(&processor_type, "audio_in")
+            .expect_err("an undeclared delivery profile must be a wiring error");
+        let msg = err.to_string();
+        assert!(msg.contains("audio_in"), "the error must name the port: {msg}");
+        assert!(
+            msg.contains("declares no delivery_profile"),
+            "got: {msg}"
         );
+        assert!(matches!(err, crate::core::error::Error::Configuration(_)));
     }
 
     /// A typo in a port-site `delivery_profile` override surfaces as a typed

--- a/runtime/streamlib-engine/src/core/graph/nodes/port_info.rs
+++ b/runtime/streamlib-engine/src/core/graph/nodes/port_info.rs
@@ -13,10 +13,9 @@ pub struct PortInfo {
     pub data_type: PortSchemaSpec,
     #[serde(default)]
     pub port_kind: PortKind,
-    /// Delivery-profile override declared by this input port —
-    /// `Some("latest" | "every_sample" | "lossless")`, or `None` for
-    /// output ports / inputs that defer to the wire type's `flow_class`
-    /// default. Mirrors the field on
+    /// Delivery profile declared by this input port —
+    /// `Some("latest" | "every_sample" | "lossless")` on every input, `None`
+    /// on an output. Mirrors the field on
     /// [`crate::core::descriptors::PortDescriptor`] so the compiler op
     /// can resolve a destination's delivery profile at wire time without
     /// locking the processor instance.

--- a/runtime/streamlib-engine/src/core/test_support.rs
+++ b/runtime/streamlib-engine/src/core/test_support.rs
@@ -16,8 +16,8 @@ use crate::core::processors::PROCESSOR_REGISTRY;
 #[crate::processor(
     "@tatolab/streamlib-engine/TestMockProcessor",
     execution = manual,
-    input("in1", any),
-    input("in2", any),
+    input("in1", any, delivery_profile = "latest"),
+    input("in2", any, delivery_profile = "latest"),
     output("out1", any),
     output("out2", any),
 )]
@@ -78,8 +78,8 @@ impl crate::core::ManualProcessor for MockOutputOnlyProcessor::Processor {
 #[crate::processor(
     "@tatolab/streamlib-engine/TestMockInputOnlyProcessor",
     execution = manual,
-    input("in1", any),
-    input("in2", any),
+    input("in1", any, delivery_profile = "latest"),
+    input("in2", any, delivery_profile = "latest"),
 )]
 pub(crate) struct MockInputOnlyProcessor;
 
@@ -110,8 +110,8 @@ impl crate::core::ManualProcessor for MockInputOnlyProcessor::Processor {
 #[crate::processor(
     "@tatolab/streamlib-engine/TestMockReactiveInputOnlyProcessor",
     execution = reactive,
-    input("in1", any),
-    input("in2", any),
+    input("in1", any, delivery_profile = "latest"),
+    input("in2", any, delivery_profile = "latest"),
 )]
 pub(crate) struct MockReactiveInputOnlyProcessor;
 

--- a/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
@@ -8,12 +8,22 @@
 //! three transport settings the engine used to expose as four separate knobs
 //! (`read_mode`, `overflow`, `buffer_size`, `max_queued_messages`): the
 //! consumer-side drain order ([`ReadMode`]), the producer-side overflow policy
-//! ([`Overflow`]), and the ring depth. When a port declares no profile, the
-//! default derives from the wire type's [`FlowClass`], carried in the schema
-//! `metadata` block — so authors mostly never touch it.
+//! ([`Overflow`]), and the ring depth. Every input port declares one and
+//! nothing is inferred — an input port without a profile is a wiring error.
+
+use streamlib_processor_schema::DELIVERY_PROFILE_DECLARATION_VALUES;
 
 use super::overflow::Overflow;
 use super::read_mode::ReadMode;
+
+/// The legal `delivery_profile` values as a quoted, comma-joined list.
+pub(crate) fn render_delivery_profile_values() -> String {
+    DELIVERY_PROFILE_DECLARATION_VALUES
+        .iter()
+        .map(|value| format!("'{value}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 /// The one per-port delivery knob. Each profile bundles a fixed
 /// (drain order, overflow policy, ring depth) triple; see [`DeliveryProfile::resolve`].
@@ -29,7 +39,7 @@ pub enum DeliveryProfile {
     EverySample,
     /// Lossless FIFO: read next in order, the producer blocks rather than
     /// drop, deeper ring. File writers, muxers, loggers where every sample
-    /// must be delivered. Explicit-only — no [`FlowClass`] resolves here.
+    /// must be delivered.
     Lossless,
 }
 
@@ -83,8 +93,8 @@ impl DeliveryProfile {
             "every_sample" => Ok(Self::EverySample),
             "lossless" => Ok(Self::Lossless),
             other => Err(format!(
-                "unknown delivery_profile value '{other}', expected 'latest', \
-                 'every_sample', or 'lossless'"
+                "unknown delivery_profile value '{other}', expected one of {}",
+                render_delivery_profile_values()
             )),
         }
     }
@@ -100,26 +110,22 @@ impl DeliveryProfile {
 }
 
 /// The per-wire-type data class carried in a schema's `metadata.flow_class`.
-/// It sets the *default* [`DeliveryProfile`] for any port carrying that type,
-/// which a port-site profile override still wins over.
+///
+/// Payload-classification vocabulary only: delivery is resolved from the
+/// consuming input port's own declaration, never from the wire type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlowClass {
     /// Ordered samples where every one matters — audio, encoded frames.
-    /// Defaults to [`DeliveryProfile::EverySample`].
     SampleStream,
     /// Latest-state snapshots where a stale sample has no value once a fresher
-    /// one exists — video frames, control state. Defaults to
-    /// [`DeliveryProfile::Latest`].
+    /// one exists — video frames, control state.
     StateStream,
 }
 
 impl FlowClass {
     /// Parse a schema-declared `metadata.flow_class` string.
     ///
-    /// Recognized values: `"sample_stream"` and `"state_stream"`. `lossless`
-    /// is deliberately absent — a lossless profile is an explicit port-site
-    /// choice, never a type-level default (a wire type doesn't know whether a
-    /// given consumer can afford to backpressure its producer).
+    /// Recognized values: `"sample_stream"` and `"state_stream"`.
     pub fn from_manifest_str(value: &str) -> Result<Self, String> {
         match value {
             "sample_stream" => Ok(Self::SampleStream),
@@ -130,8 +136,8 @@ impl FlowClass {
         }
     }
 
-    /// The default [`DeliveryProfile`] a port carrying this flow class resolves
-    /// to when it declares no explicit profile override.
+    /// The [`DeliveryProfile`] this flow class corresponds to. No delivery
+    /// path calls this — a port's profile comes from its own declaration.
     pub fn default_profile(self) -> DeliveryProfile {
         match self {
             FlowClass::SampleStream => DeliveryProfile::EverySample,

--- a/runtime/streamlib-engine/src/iceoryx2/mod.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/mod.rs
@@ -17,6 +17,7 @@ pub use channel_ceiling::{
     ENV_MAX_PAYLOAD_BYTES_PER_CHANNEL_TRUSTED, ENV_MAX_PAYLOAD_BYTES_PER_CHANNEL_UNTRUSTED_SESSION,
     effective_channel_ceiling_bytes,
 };
+pub(crate) use delivery_profile::render_delivery_profile_values;
 pub use delivery_profile::{DeliveryProfile, DeliveryResolution, FlowClass};
 pub use input::{BoundedReadOutcome, InputMailboxes, InputMailboxesInner};
 pub use mailbox::PortMailbox;

--- a/runtime/streamlib-engine/tests/attribute_macro_test.rs
+++ b/runtime/streamlib-engine/tests/attribute_macro_test.rs
@@ -17,7 +17,7 @@ use streamlib_engine::core::{EmptyConfig, Result, RuntimeContextFullAccess};
 #[streamlib::sdk::processor(
     "@tatolab/streamlib-engine/TestProcessor",
     execution = manual,
-    input("video_in", any),
+    input("video_in", any, delivery_profile = "latest"),
     output("video_out", any),
 )]
 pub struct TestProcessor;
@@ -200,7 +200,7 @@ pub struct CfgGatedFieldAlwaysCompiledState {
 #[streamlib::sdk::processor(
     "@tatolab/streamlib-engine/CfgGatedFieldProcessor",
     execution = manual,
-    input("video_in", any),
+    input("video_in", any, delivery_profile = "latest"),
     output("video_out", any),
 )]
 pub struct CfgGatedFieldProcessor {

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -747,13 +747,13 @@ fn generate_iceoryx2_accessors_from_schema(schema: &ProcessorSchema) -> TokenStr
         quote! {}
     };
 
-    // Issue #894: emit `set_iceoryx2_resources` to receive host-
-    // allocated handles + the `iceoryx2_output_writer_inner` /
-    // `iceoryx2_input_mailboxes_inner` accessors so the host's
-    // wiring path can mutate the inner Arc directly. The host owns
-    // per-port registration (`InputMailboxesInner::add_port`) at wire
-    // time, where it resolves the delivery profile from the wire type's
-    // `flow_class` + any port-site override — the macro registers none.
+    // Emit `set_iceoryx2_resources` to receive host-allocated handles +
+    // the `iceoryx2_output_writer_inner` / `iceoryx2_input_mailboxes_inner`
+    // accessors so the host's wiring path can mutate the inner Arc
+    // directly. The host owns per-port registration
+    // (`InputMailboxesInner::add_port`) at wire time, where it reads the
+    // destination input port's declared delivery profile — the macro
+    // registers none.
     let assign_outputs = if has_iceoryx2_outputs {
         quote! {
             if let ::std::option::Option::Some(ow) = output_writer {

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -564,15 +564,13 @@ fn generate_from_config_from_schema(
     config_field_name: &Option<Ident>,
     custom_fields: &[CustomField],
 ) -> TokenStream {
-    // Issue #894: host-allocates iceoryx2 inner Arcs. The macro
-    // emits empty handles; the host's
-    // `ProcessorInstance::install_iceoryx2_resources` patches in
-    // real handles via `GeneratedProcessor::set_iceoryx2_resources`
+    // The macro emits empty handles; the host's
+    // `ProcessorInstance::install_iceoryx2_resources` patches in real
+    // handles via `GeneratedProcessor::set_iceoryx2_resources`
     // immediately after `from_config` returns. Per-port delivery
     // resolution (drain order + ring depth) is owned entirely by the
-    // host wire path, which reads the wire type's `flow_class` and any
-    // port-site `delivery_profile` override at wire time — the macro
-    // registers no ports here.
+    // host wire path, which reads the destination input port's declared
+    // `delivery_profile` at wire time — the macro registers no ports here.
     let ipc_input_init = if !schema.inputs.is_empty() {
         quote! { inputs: __streamlib_sdk::iceoryx2::InputMailboxes::empty(), }
     } else {

--- a/sdk/streamlib-macros/src/grammar.rs
+++ b/sdk/streamlib-macros/src/grammar.rs
@@ -29,9 +29,9 @@
 //! scope here and handled at the runtime layer.
 
 use streamlib_processor_schema::{
-    Org, Package, PortSchemaSpec, ProcessorPortSchema, ProcessorSchema, ProcessorSchemaExecution,
-    ProcessorScheduling, RuntimeConfig, RuntimeOptions, SchemaIdent, SemVer, ThreadPriority,
-    TypeName,
+    DELIVERY_PROFILE_DECLARATION_VALUES, Org, Package, PortSchemaSpec, ProcessorPortSchema,
+    ProcessorSchema, ProcessorSchemaExecution, ProcessorScheduling, RuntimeConfig, RuntimeOptions,
+    SchemaIdent, SemVer, ThreadPriority, TypeName,
 };
 use syn::ext::IdentExt;
 use syn::parse::{ParseStream, Parser};
@@ -427,10 +427,10 @@ fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<P
         return Err(syn::Error::new(
             name_lit.span(),
             format!(
-                "input port `{name}` must declare a `delivery_profile` — add \
-                 `delivery_profile = \"latest\"`, `\"every_sample\"`, or `\"lossless\"`. \
+                "input port `{name}` must declare a `delivery_profile` — one of {}. \
                  There is no default: channel policy is declared port-locally at the \
-                 consuming input port"
+                 consuming input port",
+                render_delivery_profile_values(),
             ),
         ));
     }
@@ -441,6 +441,15 @@ fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<P
         description,
         delivery_profile,
     })
+}
+
+/// The legal `delivery_profile` values as a quoted, comma-joined list.
+fn render_delivery_profile_values() -> String {
+    DELIVERY_PROFILE_DECLARATION_VALUES
+        .iter()
+        .map(|value| format!("`\"{value}\"`"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Reject `delivery_profile` on an `output(...)` with a spanned error — the

--- a/sdk/streamlib-macros/src/grammar.rs
+++ b/sdk/streamlib-macros/src/grammar.rs
@@ -60,6 +60,8 @@ pub struct ParsedPort {
     pub name: String,
     pub schema: PortSchemaSpec,
     pub description: Option<String>,
+    /// Always `Some` on an input and always `None` on an output — the grammar
+    /// requires it on the one and rejects it on the other.
     pub delivery_profile: Option<String>,
 }
 
@@ -372,8 +374,8 @@ fn parse_execution(input: ParseStream<'_>) -> syn::Result<ProcessorSchemaExecuti
 /// where `<schema>` is either the bare identifier `any` or a version-free
 /// `"@org/package/Type"` string.
 ///
-/// `delivery_profile` is a consumer-side setting the destination input port
-/// declares; it is rejected with a spanned error on an `output(...)` rather
+/// `delivery_profile` is a consumer-side setting: **required** on every
+/// `input(...)`, and rejected with a spanned error on an `output(...)` rather
 /// than silently dropped.
 fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<ParsedPort> {
     let content;
@@ -419,6 +421,18 @@ fn parse_port(input: ParseStream<'_>, direction: PortDirection) -> syn::Result<P
                 ));
             }
         }
+    }
+
+    if direction == PortDirection::Input && delivery_profile.is_none() {
+        return Err(syn::Error::new(
+            name_lit.span(),
+            format!(
+                "input port `{name}` must declare a `delivery_profile` — add \
+                 `delivery_profile = \"latest\"`, `\"every_sample\"`, or `\"lossless\"`. \
+                 There is no default: channel policy is declared port-locally at the \
+                 consuming input port"
+            ),
+        ));
     }
 
     Ok(ParsedPort {
@@ -574,7 +588,12 @@ mod tests {
             "@tatolab/camera/Camera",
             description = "Captures video from cameras",
             execution = manual,
-            input("video_in", "@tatolab/core/VideoFrame", description = "Frames to convert"),
+            input(
+                "video_in",
+                "@tatolab/core/VideoFrame",
+                delivery_profile = "latest",
+                description = "Frames to convert"
+            ),
             output("video", "@tatolab/core/VideoFrame", description = "Live video frames"),
         });
         assert_eq!(parsed.description.as_deref(), Some("Captures video from cameras"));
@@ -611,7 +630,7 @@ mod tests {
         let parsed = parse_ok(quote! {
             "@tatolab/testing/Mock",
             execution = manual,
-            input("in1", any),
+            input("in1", any, delivery_profile = "latest"),
             output("out1", any),
         });
         assert!(matches!(parsed.inputs[0].schema, PortSchemaSpec::Any));
@@ -706,8 +725,8 @@ mod tests {
         let msg = parse_err(quote! {
             "@tatolab/testing/Mock",
             execution = manual,
-            input("dup", any),
-            input("dup", any),
+            input("dup", any, delivery_profile = "latest"),
+            input("dup", any, delivery_profile = "latest"),
         });
         assert!(msg.contains("duplicate input port name `dup`"), "got: {msg}");
     }
@@ -754,6 +773,35 @@ mod tests {
             parsed.inputs[0].delivery_profile.as_deref(),
             Some("lossless")
         );
+    }
+
+    #[test]
+    fn input_without_a_delivery_profile_is_an_error() {
+        let msg = parse_err(quote! {
+            "@tatolab/camera/Camera",
+            execution = manual,
+            input("video_in", "@tatolab/core/VideoFrame"),
+        });
+        assert!(
+            msg.contains("input port `video_in` must declare a `delivery_profile`"),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains("latest") && msg.contains("every_sample") && msg.contains("lossless"),
+            "the error must list the valid profiles: {msg}"
+        );
+    }
+
+    #[test]
+    fn output_without_a_delivery_profile_stays_valid() {
+        // The requirement is consumer-side only: an `output(...)` declaring no
+        // profile is the correct shape, not a missing declaration.
+        let parsed = parse_ok(quote! {
+            "@tatolab/camera/Camera",
+            execution = manual,
+            output("video", "@tatolab/core/VideoFrame"),
+        });
+        assert_eq!(parsed.outputs[0].delivery_profile, None);
     }
 
     #[test]

--- a/sdk/streamlib-processor-schema/src/descriptors.rs
+++ b/sdk/streamlib-processor-schema/src/descriptors.rs
@@ -137,10 +137,9 @@ pub struct PortDescriptor {
     /// Whether this port uses iceoryx2 IPC.
     #[serde(default)]
     pub is_iceoryx2: bool,
-    /// Delivery-profile override declared by an *input* port (the
-    /// destination of an iceoryx2 service) — `"latest"`, `"every_sample"`,
-    /// or `"lossless"`. `None` defers to the default derived from the wire
-    /// type's `flow_class` at wire time. Always `None` on output ports.
+    /// Delivery profile declared by an *input* port (the destination of an
+    /// iceoryx2 service) — `"latest"`, `"every_sample"`, or `"lossless"`.
+    /// Required on every input port and always `None` on an output port.
     #[serde(default)]
     pub delivery_profile: Option<String>,
 }

--- a/sdk/streamlib-processor-schema/src/lib.rs
+++ b/sdk/streamlib-processor-schema/src/lib.rs
@@ -22,9 +22,9 @@ pub use thread_priority::ThreadPriority;
 // Processor schema re-exports
 pub use error::{SchemaError, SchemaResult};
 pub use processor_schema::{
-    PortSchemaSpec, ProcessorConfigSchema, ProcessorLanguage, ProcessorPortSchema,
-    ProcessorScheduling, ProcessorSchema, ProcessorSchemaExecution, ProcessorStateField,
-    RuntimeConfig, RuntimeOptions, to_pascal_case, to_snake_case,
+    DELIVERY_PROFILE_DECLARATION_VALUES, PortSchemaSpec, ProcessorConfigSchema, ProcessorLanguage,
+    ProcessorPortSchema, ProcessorScheduling, ProcessorSchema, ProcessorSchemaExecution,
+    ProcessorStateField, RuntimeConfig, RuntimeOptions, to_pascal_case, to_snake_case,
 };
 pub use processor_schema_parser::{parse_processor_yaml, parse_processor_yaml_file};
 pub use schema_ident_output::{SchemaIdentOutput, SemanticVersionOutput};

--- a/sdk/streamlib-processor-schema/src/processor_schema.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema.rs
@@ -525,12 +525,11 @@ pub struct ProcessorPortSchema {
     /// Human-readable description.
     #[serde(default)]
     pub description: Option<String>,
-    /// Delivery-profile override for this input port — `"latest"`,
+    /// Delivery profile declared by this input port — `"latest"`,
     /// `"every_sample"`, or `"lossless"`. The one delivery knob on the
     /// authoring surface: it resolves to the consumer-side drain order,
-    /// the producer-side overflow policy, and the ring depth. `None`
-    /// defers to the default derived from the wire type's `flow_class`.
-    /// Always `None` on output ports.
+    /// the producer-side overflow policy, and the ring depth. Required on
+    /// every input port and always `None` on an output port.
     #[serde(default)]
     pub delivery_profile: Option<String>,
 }

--- a/sdk/streamlib-processor-schema/src/processor_schema.rs
+++ b/sdk/streamlib-processor-schema/src/processor_schema.rs
@@ -513,6 +513,13 @@ impl JsonSchema for ProcessorSchemaExecution {
     }
 }
 
+/// The values an input port's `delivery_profile` declaration may take.
+///
+/// The single Rust-side list: the `#[processor]` grammar, the engine's
+/// wire-time resolver, and `DeliveryProfile::from_manifest_str` all render
+/// their errors from this, so a new profile cannot leave one of them lying.
+pub const DELIVERY_PROFILE_DECLARATION_VALUES: [&str; 3] = ["latest", "every_sample", "lossless"];
+
 /// A port definition within a processor schema.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
@@ -55,9 +55,9 @@ def input(
     The port is named after the method unless `name` overrides it. `schema` is
     a structured carrier — a [`SchemaIdent`] instance or a codegen-emitted
     class carrying `__streamlib_schema_ident__` — never a string.
-    `delivery_profile` is `"latest"`, `"every_sample"`, or `"lossless"`; omit
-    it to default from the wire type's flow class. The decorated method is a
-    declaration only: bags are read with `ctx.inputs.read(port_name)`.
+    `delivery_profile` is required and is `"latest"`, `"every_sample"`, or
+    `"lossless"`. The decorated method is a declaration only: bags are read
+    with `ctx.inputs.read(port_name)`.
     """
     if delivery_profile is not None and delivery_profile not in _DELIVERY_PROFILES:
         raise ValueError(
@@ -67,11 +67,22 @@ def input(
     resolved_schema = _resolve_schema_ident(schema)
 
     def attach_input_port_marker(method: MethodUnderDecoration) -> MethodUnderDecoration:
+        port_name = name or method.__name__
+        # `delivery_profile` defaults to None rather than being a required
+        # keyword so the omission is caught here, where the port's name is
+        # known — a bare TypeError from the call could not name it.
+        if delivery_profile is None:
+            raise ValueError(
+                f"input port {port_name!r} must declare a delivery_profile — pass "
+                f"delivery_profile={'|'.join(repr(p) for p in _DELIVERY_PROFILES)}. "
+                f"There is no default: channel policy is declared port-locally at the "
+                f"consuming input port"
+            )
         setattr(
             method,
             _INPUT_PORT_MARKER_ATTRIBUTE,
             {
-                "name": name or method.__name__,
+                "name": port_name,
                 "schema": resolved_schema,
                 "description": description,
                 "delivery_profile": delivery_profile,

--- a/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/python/streamlib/_processor_declaration.py
@@ -73,10 +73,9 @@ def input(
         # known — a bare TypeError from the call could not name it.
         if delivery_profile is None:
             raise ValueError(
-                f"input port {port_name!r} must declare a delivery_profile — pass "
-                f"delivery_profile={'|'.join(repr(p) for p in _DELIVERY_PROFILES)}. "
-                f"There is no default: channel policy is declared port-locally at the "
-                f"consuming input port"
+                f"input port {port_name!r} must declare a delivery_profile — one of "
+                f"{', '.join(_DELIVERY_PROFILES)}. There is no default: channel policy "
+                f"is declared port-locally at the consuming input port"
             )
         setattr(
             method,

--- a/sdk/streamlib-python-wheel/tests/graph_building_processors.py
+++ b/sdk/streamlib-python-wheel/tests/graph_building_processors.py
@@ -13,7 +13,7 @@ from streamlib import RuntimeContextLimitedAccess, input, output, processor
 
 @processor
 class GraphBuildingFilter:
-    @input()
+    @input(delivery_profile="latest")
     def frames_from_upstream(self) -> None: ...
 
     @output()

--- a/sdk/streamlib-python-wheel/tests/helper_placement_processors.py
+++ b/sdk/streamlib-python-wheel/tests/helper_placement_processors.py
@@ -39,7 +39,7 @@ class ReportsUpstreamProcessSink:
     def __init__(self) -> None:
         self.bags_seen = 0
 
-    @input()
+    @input(delivery_profile="latest")
     def frames_from_upstream(self) -> None: ...
 
     def process(self, ctx) -> None:

--- a/sdk/streamlib-python-wheel/tests/helper_process_probes.py
+++ b/sdk/streamlib-python-wheel/tests/helper_process_probes.py
@@ -19,7 +19,7 @@ class PassThroughProbe:
     def __init__(self, tag: str = "untagged") -> None:
         self.tag = tag
 
-    @input()
+    @input(delivery_profile="latest")
     def frames_from_upstream(self) -> None: ...
 
     @output()

--- a/sdk/streamlib-python-wheel/tests/test_graph_building.py
+++ b/sdk/streamlib-python-wheel/tests/test_graph_building.py
@@ -27,7 +27,7 @@ def graph_building_app(start_app_under_test):
 
 @processor
 class GraphBuildingFilter:
-    @input()
+    @input(delivery_profile="latest")
     def frames_from_upstream(self) -> None: ...
 
     @output()

--- a/sdk/streamlib-python-wheel/tests/test_processor_declaration.py
+++ b/sdk/streamlib-python-wheel/tests/test_processor_declaration.py
@@ -13,11 +13,15 @@ from streamlib import SchemaIdent, input, output, processor
 
 
 def test_a_bare_decorator_needs_no_arguments_at_all():
-    """The zero-ceremony bar: a filter declares nothing but its ports."""
+    """The zero-ceremony bar: a filter declares its ports and nothing else.
+
+    An input's delivery profile is part of declaring the port, not ceremony
+    on top of it — there is no identity, no manifest, no schema to wrangle.
+    """
 
     @processor
     class BrightnessFilter:
-        @input()
+        @input(delivery_profile="latest")
         def frames_from_upstream(self) -> None: ...
 
         @output()
@@ -65,7 +69,7 @@ def test_the_method_name_is_the_port_name():
 def test_an_explicit_name_overrides_the_method_name():
     @processor
     class Renamed:
-        @input(name="video_in")
+        @input(name="video_in", delivery_profile="latest")
         def handle_incoming_video(self) -> None: ...
 
         @output(name="video_out")
@@ -84,7 +88,7 @@ def test_a_schema_ident_instance_is_stored_as_its_wire_dict():
 
     @processor
     class Typed:
-        @input(schema=video_frame, description="frames")
+        @input(schema=video_frame, description="frames", delivery_profile="latest")
         def frames_from_upstream(self) -> None: ...
 
         @output(schema=video_frame)
@@ -106,7 +110,7 @@ def test_a_codegen_class_carrying_a_schema_ident_is_accepted():
 
     @processor
     class Typed:
-        @input(schema=VideoFrame)
+        @input(schema=VideoFrame, delivery_profile="latest")
         def frames_from_upstream(self) -> None: ...
 
     assert Typed.__streamlib_processor_input_ports__[0]["schema"] == {
@@ -142,12 +146,45 @@ def test_an_unknown_delivery_profile_is_refused_at_decoration():
         input(delivery_profile="eventually")
 
 
+def test_an_input_port_without_a_delivery_profile_is_refused():
+    """There is no default, so the omission is a wiring error naming the port."""
+    with pytest.raises(ValueError, match="'frames_from_upstream' must declare a delivery_profile"):
+
+        @processor
+        class Unprofiled:
+            @input()
+            def frames_from_upstream(self) -> None: ...
+
+
+def test_the_refusal_names_the_overriding_port_name():
+    """`name=` renames the port, so the error must name that, not the method."""
+    with pytest.raises(ValueError, match="'video_in' must declare a delivery_profile"):
+
+        @processor
+        class Unprofiled:
+            @input(name="video_in")
+            def frames_from_upstream(self) -> None: ...
+
+
+def test_an_output_port_needs_no_delivery_profile():
+    """Delivery is the consuming port's policy — an output declaring none is correct."""
+
+    @processor(execution="manual")
+    class Source:
+        @output()
+        def frames_to_downstream(self) -> None: ...
+
+    assert Source.__streamlib_processor_output_ports__ == [
+        {"name": "frames_to_downstream", "description": "", "schema": None}
+    ]
+
+
 def test_a_duplicate_port_name_is_refused():
     with pytest.raises(ValueError, match="more than once"):
 
         @processor
         class Clashing:
-            @input(name="frames")
+            @input(name="frames", delivery_profile="latest")
             def frames_in(self) -> None: ...
 
             @output(name="frames")
@@ -219,7 +256,7 @@ def test_a_class_name_that_cannot_be_an_identity_says_so():
 
         @processor
         class lowercase_name:
-            @input()
+            @input(delivery_profile="latest")
             def frames_from_upstream(self) -> None: ...
 
 
@@ -235,7 +272,7 @@ def test_an_unknown_mode_or_priority_is_refused(keyword, value, expected_message
 
         @processor(**{keyword: value})
         class Filter:
-            @input()
+            @input(delivery_profile="latest")
             def frames_from_upstream(self) -> None: ...
 
 


### PR DESCRIPTION
## Summary

Both authoring grammars now refuse an input port that declares no delivery profile, and
the engine's resolution primitive stops inferring one from the port's schema.

- **Rust `#[processor]`** — `input(...)` without `delivery_profile` is a spanned compile
  error naming the port. `output(...)` still rejects one; it is a consumer-side setting
  and was not symmetrized.
- **The wheel's `@input`** — raises `ValueError` naming the port. The keyword keeps its
  `None` default deliberately: the port name is only known once the decorator is applied
  to the method, so a required keyword-only argument could only produce a bare
  `TypeError` that doesn't name it.
- **`delivery_profile_for_input_port`** — no longer consults `flow_class_for_port_spec`.
  A registered input port carrying no declaration is an `Error::Configuration` naming
  the port and its processor.
- Every engine-tree input port gained the `"latest"` it already resolved to, so no
  wiring behavior moves.
- `DELIVERY_PROFILE_DECLARATION_VALUES` in `streamlib-processor-schema` is now the single
  Rust-side list of legal values; the macro, the engine resolver, and
  `DeliveryProfile::from_manifest_str` all render their errors from it.

Scope was the engine tree (`runtime/ sdk/ adapters/ xtask/`). `packages/` and `examples/`
lag by design — roughly 30 input ports there will no longer compile, which is upgrade
backlog for a consumer-upgrade session, not a defect and not ticketed.

## Closes

Closes #1811

## Exit criteria

- [x] `delivery_profile` is required on every input port in both authoring grammars.
- [x] An input port declared without one is a wiring error with an actionable message
      naming the port — at all three gates (macro, decorator, engine resolver).
- [x] Every input port in the engine tree carries an explicit declaration.
- [x] No engine path infers a delivery profile from a port's schema.

## Test plan

New:
- `grammar::tests::input_without_a_delivery_profile_is_an_error` — asserts the message
  names the port and lists the legal values.
- `grammar::tests::output_without_a_delivery_profile_stays_valid` — the consumer-side
  asymmetry stays.
- `test_an_input_port_without_a_delivery_profile_is_refused`,
  `test_the_refusal_names_the_overriding_port_name` (covers the `name=` override path),
  `test_an_output_port_needs_no_delivery_profile`.
- `delivery_profile_ignores_the_schema_flow_class` — replaces
  `delivery_profile_defaults_from_flow_class`. The port's wire type declares
  `sample_stream`; resolving from the schema would yield `EverySample` and turn the test
  green when it must fail.

Each gate was verified by deletion — removing the macro guard, restoring the
`flow_class` fallback, and removing the Python raise each turn the corresponding test
red, then were reverted.

Run: all 11 xtask gates PASS · `cargo test -p streamlib -p streamlib-macros --lib` (46)
· `-p streamlib-engine --test attribute_macro_test` (11) · `-p streamlib-engine --lib`
(1212) · `-p streamlib-python-wheel --lib` (39) · `-p streamlib-processor-schema` (28) ·
wheel `pytest -m "not requires_gpu"` (199 passed, 55 GPU-deselected) · stubtest clean ·
pyright 0 errors · `cargo doc -p streamlib --no-deps` no rustdoc warnings.

Pre-existing and unrelated, verified by reproducing on a clean `origin/main` worktree:
`unknown_processor_type_test::add_processor_with_unknown_type_returns_typed_error` (a
SemVer `0.0.0`-vs-`9.9.9` assertion, nothing to do with ports).

## Notes for owner

1. **One `examples/` file was edited, with your approval in-session.**
   `sdk/streamlib-sdk/src/hello_streamlib_example_e2e.rs:30` `#[path]`-source-includes
   `examples/hello-streamlib/src/hello_forward.rs` into `streamlib-sdk`'s test build, so
   that file is engine build input, not only a downstream consumer. Leaving it broken
   fails `cargo test --lib -p streamlib` — the exact command `.github/workflows/test.yml`
   runs — taking the zero-ceremony E2E gate and the whole crate's tests with it. The edit
   is one line and is the consumer conforming to a newly mandatory engine grammar; no
   design bent toward the example.

2. **`flow_class_for_port_spec` is now orphaned dead code**, left standing on purpose —
   the ticket assigns the inference chain's deletion (`FlowClass`,
   `flow_class_for_port_spec`, `embedded_schemas/`) to the contract ticket this one
   unblocks. It joins ~15 pre-existing dead-code warnings in that crate; no CI job sets
   `-D warnings`, so nothing turns red, and no `#[allow]` shim was added. Accepted by the
   owner in-session.

3. **A third surface can still mint an unprofiled input port, and it is residue.**
   `parse_processor_yaml` (`streamlib-processor-schema`) yields
   `inputs[0].delivery_profile == None`, and `test_input_port_defaults_without_delivery_profile`
   locks that. It has zero callers outside its own `pub use` at `lib.rs:29` — leftover
   from the deleted manifest world — and the ticket names exactly two grammars, so it was
   left alone. Expected to die with `embedded_schemas/` in the contract ticket; worth
   confirming when that ticket is scoped.

4. **The two grammars stay asymmetric on validating the profile *value*** (pre-existing).
   Python rejects `delivery_profile="eventually"` eagerly at decoration; the Rust macro
   accepts any string and defers to `from_manifest_str` at wire time, which
   `delivery_profile_rejects_unknown_override` locks. Now that the macro renders the legal
   values from a shared const, moving that check to compile time is a few lines — but it
   changes error timing the ticket didn't ask about, so it was left out.

5. **`docs/testing-hardware.md`'s tier-1 baseline is stale** — it names 5 `--exclude`
   crates that no longer exist as workspace members. Non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input ports now support explicit delivery profiles: `latest`, `every_sample`, or `lossless`.
  * Output ports remain profile-free.

* **Breaking Changes**
  * Every input port must declare a delivery profile; omitted values now produce a clear configuration error.
  * Delivery behavior is determined by the input port declaration rather than inferred from payload metadata.

* **Bug Fixes**
  * Improved validation messages identify the affected port and list valid profile options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->