### PR TITLE
feat(python): add read(port, into=T) — the opt-in strictness dial

### DIFF
--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -77,7 +77,7 @@ jobs:
           # deselects every test that would use it. pydantic is what proves a
           # model is a legal `read(port, into=T)` target; the wheel never
           # imports it.
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy numpy pydantic
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy numpy pydantic typing_extensions
           VIRTUAL_ENV="$PWD/.venv" uvx maturin@1.9.6 develop
 
       # The crate's own unit tests link libpython rather than building as an
@@ -138,7 +138,7 @@ jobs:
         working-directory: sdk/streamlib-python-wheel
         run: |
           uv venv --python 3.12 .venv
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest numpy pydantic
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest numpy pydantic typing_extensions
           # CPU torch: the exchange tests type-check against torch's API, and
           # pyright reports a missing import as an error. The cpu wheel keeps
           # the download tractable for a no-build job.

--- a/.github/workflows/python-wheel.yml
+++ b/.github/workflows/python-wheel.yml
@@ -74,8 +74,10 @@ jobs:
           uv venv --python 3.12 .venv
           # numpy rides along because the exchange-surface tests import it at
           # module scope — collection needs it even when `requires_gpu`
-          # deselects every test that would use it.
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy numpy
+          # deselects every test that would use it. pydantic is what proves a
+          # model is a legal `read(port, into=T)` target; the wheel never
+          # imports it.
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest mypy numpy pydantic
           VIRTUAL_ENV="$PWD/.venv" uvx maturin@1.9.6 develop
 
       # The crate's own unit tests link libpython rather than building as an
@@ -136,7 +138,7 @@ jobs:
         working-directory: sdk/streamlib-python-wheel
         run: |
           uv venv --python 3.12 .venv
-          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest numpy
+          VIRTUAL_ENV="$PWD/.venv" uv pip install pytest numpy pydantic
           # CPU torch: the exchange tests type-check against torch's API, and
           # pyright reports a missing import as an error. The cpu wheel keeps
           # the download tractable for a no-build job.

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -35,8 +35,10 @@ streamlib = "streamlib.cli:main"
 [project.optional-dependencies]
 # numpy and torch are test-and-types dependencies, not runtime ones — the
 # wheel itself never imports either; the exchange surface hands frames to
-# whichever consumer the user installed.
-dev = ["pytest>=7.0", "numpy>=2.1", "torch>=2.0"]
+# whichever consumer the user installed. pydantic is the same: `read(port,
+# into=T)` constructs whatever target it is handed and names no library, so
+# pydantic is here to prove that a model is one of them.
+dev = ["pytest>=7.0", "numpy>=2.1", "torch>=2.0", "pydantic>=2.0"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sdk/streamlib-python-wheel/pyproject.toml
+++ b/sdk/streamlib-python-wheel/pyproject.toml
@@ -38,7 +38,14 @@ streamlib = "streamlib.cli:main"
 # whichever consumer the user installed. pydantic is the same: `read(port,
 # into=T)` constructs whatever target it is handed and names no library, so
 # pydantic is here to prove that a model is one of them.
-dev = ["pytest>=7.0", "numpy>=2.1", "torch>=2.0", "pydantic>=2.0"]
+dev = [
+    "pytest>=7.0",
+    "numpy>=2.1",
+    "torch>=2.0",
+    "pydantic>=2.0",
+    # `assert_type` at the 3.10 floor, and the stub's own `disjoint_base`.
+    "typing_extensions>=4.6",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
+++ b/sdk/streamlib-python-wheel/python/streamlib/_engine.pyi
@@ -16,11 +16,12 @@ binary no longer exports still reads as complete.
 from pathlib import Path
 from types import TracebackType
 from collections.abc import Callable, Mapping
-from typing import Any, Literal, TypeVar, final
+from typing import Any, Literal, TypeVar, final, overload
 
 from typing_extensions import disjoint_base
 
 _EscalateResult = TypeVar("_EscalateResult")
+_BagReadTarget = TypeVar("_BagReadTarget")
 
 __all__ = [
     "AddedProcessor",
@@ -235,7 +236,14 @@ class ProcessorLinkDataAccess:
     def input_listener_fd(self) -> int | None: ...
     def drain_input_listener(self) -> None: ...
     def any_input_port_has_data(self) -> bool: ...
-    def read_from_input_port(self, port_name: str) -> Any | None: ...
+    @overload
+    def read_from_input_port(
+        self, port_name: str, *, into: None = None
+    ) -> Any | None: ...
+    @overload
+    def read_from_input_port(
+        self, port_name: str, *, into: Callable[..., _BagReadTarget]
+    ) -> _BagReadTarget | None: ...
     def read_from_input_port_with_timestamp(
         self, port_name: str
     ) -> tuple[Any, int] | tuple[None, None]: ...
@@ -313,7 +321,20 @@ class RuntimeContextLimitedAccess:
 class LinkInputDataReader:
     """A processor's input ports, as `ctx.inputs`."""
 
-    def read(self, port_name: str) -> Any | None: ...
+    @overload
+    def read(self, port_name: str, *, into: None = None) -> Any | None: ...
+    @overload
+    def read(
+        self, port_name: str, *, into: Callable[..., _BagReadTarget]
+    ) -> _BagReadTarget | None:
+        """The next bag on `port_name`, read into `into`.
+
+        The opt-in strictness dial. A TypedDict casts for free — the bag
+        arrives as itself, unvalidated. A dataclass or pydantic model is
+        constructed from the bag's entries, so a bag that does not fit raises
+        here, at the consuming read.
+        """
+
     def read_with_timestamp(
         self, port_name: str
     ) -> tuple[Any, int] | tuple[None, None]: ...

--- a/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
+++ b/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
@@ -9,6 +9,7 @@
 //! as a handle, and the payload here is the named map describing it.
 
 use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple, PyType};
 use rmpv::Value;
@@ -27,9 +28,7 @@ pub(crate) fn encode_bag_to_msgpack(bag: &Bound<'_, PyAny>) -> PyResult<Vec<u8>>
             "a bag is a dict with string keys — the wire carries a named map, and a \
              {} cannot be read as one by a processor in another language. Wrap it: \
              `{{\"value\": …}}`.",
-            bag.get_type()
-                .name()
-                .map_or_else(|_| "value".to_string(), |type_name| type_name.to_string())
+            python_type_name_for_error_message(bag, "value")
         ))
     })?;
 
@@ -66,16 +65,24 @@ pub(crate) fn cast_decoded_bag_into_read_target<'py>(
         PyTypeError::new_err(format!(
             "the bag on input port {port_name:?} decoded as a {}, and `into=` builds its target \
              from a named map's entries. Read it without `into=` to see what arrived.",
-            decoded_bag
-                .get_type()
-                .name()
-                .map_or_else(|_| "value".to_string(), |type_name| type_name.to_string())
+            python_type_name_for_error_message(&decoded_bag, "value")
         ))
     })?;
     if read_target_is_a_typed_dict(read_target_type)? {
         return Ok(decoded_bag);
     }
-    read_target_type.call((), Some(named_map))
+    read_target_type
+        .call((), Some(named_map))
+        .map_err(|construction_failure| {
+            if read_target_type.is_callable() {
+                return construction_failure;
+            }
+            PyTypeError::new_err(format!(
+                "`into=` on input port {port_name:?} was handed a {}, which cannot be called to \
+                 build anything — name a TypedDict, a dataclass, or a model class.",
+                python_type_name_for_error_message(read_target_type, "value")
+            ))
+        })
 }
 
 /// Whether `read_target_type` is a TypedDict class.
@@ -89,7 +96,22 @@ fn read_target_is_a_typed_dict(read_target_type: &Bound<'_, PyAny>) -> PyResult<
     let Ok(target_class) = read_target_type.cast::<PyType>() else {
         return Ok(false);
     };
-    Ok(target_class.is_subclass_of::<PyDict>()? && target_class.hasattr("__required_keys__")?)
+    // Interned: this is the per-frame free-cast path, and a plain `&str` here
+    // allocates a Python string per read.
+    Ok(target_class.is_subclass_of::<PyDict>()?
+        && target_class.hasattr(intern!(target_class.py(), "__required_keys__"))?)
+}
+
+/// The type name to name in a refusal, or `unknown_type_placeholder` when even
+/// that cannot be read.
+fn python_type_name_for_error_message(
+    value: &Bound<'_, PyAny>,
+    unknown_type_placeholder: &str,
+) -> String {
+    value.get_type().name().map_or_else(
+        |_| unknown_type_placeholder.to_string(),
+        |type_name| type_name.to_string(),
+    )
 }
 
 /// Convert a processor's JSON configuration into the keyword arguments its
@@ -212,10 +234,7 @@ fn named_map_to_msgpack_value(mapping: &Bound<'_, PyDict>) -> PyResult<Value> {
         let key = key.cast::<PyString>().map_err(|_| {
             PyTypeError::new_err(format!(
                 "bag keys must be strings — the wire carries a named map; got a {} key",
-                key.get_type().name().map_or_else(
-                    |_| "non-string".to_string(),
-                    |type_name| type_name.to_string()
-                )
+                python_type_name_for_error_message(&key, "non-string")
             ))
         })?;
         entries.push((
@@ -451,6 +470,42 @@ mod tests {
         });
     }
 
+    /// The free cast has to survive a TypedDict `typing.is_typeddict` does not
+    /// recognize — a `typing_extensions.TypedDict` is one on every interpreter
+    /// this wheel supports, and the predicate answers `False` for it.
+    ///
+    /// Spelled here as the structure every TypedDict class shares rather than
+    /// by importing typing_extensions: the interpreter these tests link is the
+    /// system one, which carries no third-party packages.
+    #[test]
+    fn a_typed_dict_the_stdlib_predicate_misses_still_casts_for_free() {
+        Python::initialize();
+        Python::attach(|python| {
+            let target = read_target_from_source(
+                python,
+                "class Detection(dict):\n    __required_keys__ = frozenset({'name'})\n    \
+                 __optional_keys__ = frozenset()\n",
+                "Detection",
+            );
+            assert!(
+                !python
+                    .import("typing")
+                    .unwrap()
+                    .call_method1("is_typeddict", (&target,))
+                    .unwrap()
+                    .is_truthy()
+                    .unwrap(),
+                "this target must be one the stdlib predicate rejects, or it proves nothing"
+            );
+
+            let bag = bag_with_one_name(python, "cat");
+            let read =
+                cast_decoded_bag_into_read_target("detections", bag.clone(), &target).unwrap();
+
+            assert!(read.is(&bag), "the free cast must not copy the bag");
+        });
+    }
+
     /// A dataclass is the constructing half of the dial: a good bag builds an
     /// instance, and construction is the validation.
     #[test]
@@ -516,6 +571,26 @@ mod tests {
             assert!(
                 refusal.to_string().contains("detections")
                     && refusal.to_string().contains("named map"),
+                "got: {refusal}"
+            );
+        });
+    }
+
+    /// A target that is not a class at all cannot build anything, and CPython's
+    /// own "not callable" names neither the port nor `into=`.
+    #[test]
+    fn a_target_that_cannot_be_called_is_refused_by_port_name() {
+        Python::initialize();
+        Python::attach(|python| {
+            let not_a_class = "Detection".into_pyobject(python).unwrap().into_any();
+            let refusal = cast_decoded_bag_into_read_target(
+                "detections",
+                bag_with_one_name(python, "cat"),
+                &not_a_class,
+            )
+            .unwrap_err();
+            assert!(
+                refusal.to_string().contains("detections") && refusal.to_string().contains("into="),
                 "got: {refusal}"
             );
         });

--- a/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
+++ b/sdk/streamlib-python-wheel/src/python_bag_conversion.rs
@@ -10,7 +10,7 @@
 
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
+use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple, PyType};
 use rmpv::Value;
 
 /// Encode a bag to the msgpack bytes the wire carries.
@@ -47,6 +47,49 @@ pub(crate) fn decode_msgpack_to_python_object<'py>(
     let value = rmpv::decode::read_value(&mut &encoded[..])
         .map_err(|decode_failure| PyValueError::new_err(decode_failure.to_string()))?;
     msgpack_value_to_python_object(python, &value)
+}
+
+/// Cast or construct a decoded bag into the type an author named with
+/// `read(port, into=T)`.
+///
+/// A TypedDict is a dict at runtime, so the decoded bag already is one and
+/// travels back untouched — that is the free cast. Every other target is
+/// constructed from the bag's entries as keyword arguments, and whatever the
+/// constructor raises is what the author sees: a pydantic `ValidationError`
+/// says more about the mismatch than any wrapper here could.
+pub(crate) fn cast_decoded_bag_into_read_target<'py>(
+    port_name: &str,
+    decoded_bag: Bound<'py, PyAny>,
+    read_target_type: &Bound<'py, PyAny>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let named_map = decoded_bag.cast::<PyDict>().map_err(|_| {
+        PyTypeError::new_err(format!(
+            "the bag on input port {port_name:?} decoded as a {}, and `into=` builds its target \
+             from a named map's entries. Read it without `into=` to see what arrived.",
+            decoded_bag
+                .get_type()
+                .name()
+                .map_or_else(|_| "value".to_string(), |type_name| type_name.to_string())
+        ))
+    })?;
+    if read_target_is_a_typed_dict(read_target_type)? {
+        return Ok(decoded_bag);
+    }
+    read_target_type.call((), Some(named_map))
+}
+
+/// Whether `read_target_type` is a TypedDict class.
+///
+/// Structural rather than `typing.is_typeddict`, which knows only the stdlib's
+/// TypedDict and answers `False` for one built from `typing_extensions` — the
+/// spelling a package supporting several interpreter versions uses. Every
+/// TypedDict class, from either module, is a `dict` subclass carrying
+/// `__required_keys__`.
+fn read_target_is_a_typed_dict(read_target_type: &Bound<'_, PyAny>) -> PyResult<bool> {
+    let Ok(target_class) = read_target_type.cast::<PyType>() else {
+        return Ok(false);
+    };
+    Ok(target_class.is_subclass_of::<PyDict>()? && target_class.hasattr("__required_keys__")?)
 }
 
 /// Convert a processor's JSON configuration into the keyword arguments its
@@ -360,6 +403,121 @@ mod tests {
             let nested_int_keyed = PyDict::new(python);
             nested_int_keyed.set_item("inner", &int_keyed).unwrap();
             assert!(encode_bag_to_msgpack(nested_int_keyed.as_any()).is_err());
+        });
+    }
+
+    /// Build a target class the way an author's module would, so the runtime
+    /// carries whatever CPython actually assigns rather than attributes a test
+    /// set by hand.
+    fn read_target_from_source<'py>(
+        python: Python<'py>,
+        source: &str,
+        class_name: &str,
+    ) -> Bound<'py, PyAny> {
+        let namespace = PyDict::new(python);
+        python
+            .run(
+                &std::ffi::CString::new(source).unwrap(),
+                Some(&namespace),
+                None,
+            )
+            .unwrap();
+        namespace.get_item(class_name).unwrap().unwrap()
+    }
+
+    fn bag_with_one_name<'py>(python: Python<'py>, name: &str) -> Bound<'py, PyAny> {
+        let bag = PyDict::new(python);
+        bag.set_item("name", name).unwrap();
+        bag.into_any()
+    }
+
+    /// The free cast: a TypedDict is a dict at runtime, so the bag arrives as
+    /// itself — the same object, not a copy, and nothing validated. A bag
+    /// missing a declared key still reads, which is what "free" means.
+    #[test]
+    fn a_typed_dict_target_hands_back_the_bag_without_constructing() {
+        Python::initialize();
+        Python::attach(|python| {
+            let target = read_target_from_source(
+                python,
+                "from typing import TypedDict\nclass Detection(TypedDict):\n    name: str\n    \
+                 score: float\n",
+                "Detection",
+            );
+            let bag = bag_with_one_name(python, "cat");
+            let read = cast_decoded_bag_into_read_target("detections", bag.clone(), &target)
+                .expect("a TypedDict target validates nothing, so a partial bag must read");
+            assert!(read.is(&bag), "the free cast must not copy the bag");
+        });
+    }
+
+    /// A dataclass is the constructing half of the dial: a good bag builds an
+    /// instance, and construction is the validation.
+    #[test]
+    fn a_dataclass_target_is_constructed_from_the_bag() {
+        Python::initialize();
+        Python::attach(|python| {
+            let target = read_target_from_source(
+                python,
+                "from dataclasses import dataclass\n@dataclass\nclass Detection:\n    name: str\n",
+                "Detection",
+            );
+            let read = cast_decoded_bag_into_read_target(
+                "detections",
+                bag_with_one_name(python, "cat"),
+                &target,
+            )
+            .unwrap();
+            assert!(read.is_instance(&target).unwrap());
+            assert_eq!(
+                read.getattr("name").unwrap().extract::<String>().unwrap(),
+                "cat"
+            );
+        });
+    }
+
+    /// The dial's whole point: a bag that does not fit the declared target
+    /// raises at the consuming read rather than travelling on as a mapping.
+    #[test]
+    fn a_bag_the_target_cannot_be_built_from_raises_at_the_read() {
+        Python::initialize();
+        Python::attach(|python| {
+            let target = read_target_from_source(
+                python,
+                "from dataclasses import dataclass\n@dataclass\nclass Detection:\n    name: str\n",
+                "Detection",
+            );
+            let bag = PyDict::new(python);
+            bag.set_item("label", "cat").unwrap();
+            let refusal = cast_decoded_bag_into_read_target("detections", bag.into_any(), &target)
+                .unwrap_err();
+            assert!(
+                refusal.to_string().contains("label"),
+                "the constructor's own refusal must reach the author: {refusal}"
+            );
+        });
+    }
+
+    /// `into=` builds its target from a named map's entries, so a bag that is
+    /// not one has to say so — the alternative is CPython's bare "argument
+    /// after ** must be a mapping", which names neither the port nor the bag.
+    #[test]
+    fn a_bag_that_is_not_a_named_map_is_refused_by_port_name() {
+        Python::initialize();
+        Python::attach(|python| {
+            let target = read_target_from_source(
+                python,
+                "from dataclasses import dataclass\n@dataclass\nclass Detection:\n    name: str\n",
+                "Detection",
+            );
+            let not_a_bag = PyList::new(python, [1i64, 2, 3]).unwrap().into_any();
+            let refusal =
+                cast_decoded_bag_into_read_target("detections", not_a_bag, &target).unwrap_err();
+            assert!(
+                refusal.to_string().contains("detections")
+                    && refusal.to_string().contains("named map"),
+                "got: {refusal}"
+            );
         });
     }
 

--- a/sdk/streamlib-python-wheel/src/python_processor_context.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_context.rs
@@ -1024,14 +1024,20 @@ pub(crate) struct PythonLinkInputDataReader {
 #[pymethods]
 impl PythonLinkInputDataReader {
     /// The next bag on `port_name`, or `None` when the mailbox is empty.
+    ///
+    /// `into` is the opt-in strictness dial: a TypedDict casts for free, a
+    /// dataclass or pydantic model constructs and validates, and a bag that
+    /// does not fit raises here rather than travelling on.
+    #[pyo3(signature = (port_name, *, into = None))]
     fn read<'py>(
         &self,
         python: Python<'py>,
         port_name: &str,
+        into: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Option<Bound<'py, PyAny>>> {
         self.link_data_access
             .get()
-            .read_from_input_port(python, port_name)
+            .read_from_input_port(python, port_name, into)
     }
 
     /// The next bag with its stamp, or `(None, None)` when empty.

--- a/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_link_data_access.rs
@@ -25,7 +25,9 @@ use streamlib::sdk::iceoryx2::{
     ReadMode, SchemaIdentWire,
 };
 
-use crate::python_bag_conversion::{decode_msgpack_to_python_object, encode_bag_to_msgpack};
+use crate::python_bag_conversion::{
+    cast_decoded_bag_into_read_target, decode_msgpack_to_python_object, encode_bag_to_msgpack,
+};
 use crate::python_logging::monotonic_clock_now_ns;
 
 /// One processor's links, as seen from Python.
@@ -293,10 +295,16 @@ impl PythonProcessorLinkDataAccess {
     }
 
     /// The next bag on `port_name`, or `None` when the mailbox is empty.
+    ///
+    /// `into` is the opt-in strictness dial: without it the bag arrives as a
+    /// mapping, and with it the bag is cast or constructed into the type named
+    /// — so a mismatch surfaces here, at the consuming read, and nowhere else.
+    #[pyo3(signature = (port_name, *, into = None))]
     pub(crate) fn read_from_input_port<'py>(
         &self,
         python: Python<'py>,
         port_name: &str,
+        into: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Option<Bound<'py, PyAny>>> {
         let Some(input_mailboxes) = self.input_mailboxes.get() else {
             return Err(unwired_port_error("input", port_name));
@@ -306,7 +314,14 @@ impl PythonProcessorLinkDataAccess {
             .map_err(|read_failure| PyRuntimeError::new_err(read_failure.to_string()))?;
         match read {
             Some((encoded, _timestamp_ns)) => {
-                decode_msgpack_to_python_object(python, &encoded).map(Some)
+                let bag = decode_msgpack_to_python_object(python, &encoded)?;
+                match into {
+                    Some(read_target_type) => {
+                        cast_decoded_bag_into_read_target(port_name, bag, read_target_type)
+                            .map(Some)
+                    }
+                    None => Ok(Some(bag)),
+                }
             }
             None => Ok(None),
         }
@@ -453,7 +468,7 @@ mod tests {
                 .unwrap();
 
             let received = destination
-                .read_from_input_port(python, "frames_from_upstream")
+                .read_from_input_port(python, "frames_from_upstream", None)
                 .unwrap()
                 .expect("the wired input received nothing");
             assert_eq!(

--- a/sdk/streamlib-python-wheel/tests/test_read_into_target.py
+++ b/sdk/streamlib-python-wheel/tests/test_read_into_target.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""`read(port, into=T)` — the opt-in strictness dial, over a live link.
+
+The engine has no type layer, so nothing between two processors ever compares
+a type: a bag is delivered and the consumer decides how strictly to read it.
+That decision is what these tests drive, and they drive it over real wired
+iceoryx2 ports rather than a stand-in — the bag has to survive the wire before
+`into=` has anything to cast.
+
+Both ends live on this thread because iceoryx2's ports are `!Send`, and the
+destination is wired first because a send with no subscriber attached is
+dropped.
+"""
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, TypedDict
+
+import pydantic
+import pytest
+from typing_extensions import assert_type
+
+from streamlib import ProcessorLinkDataAccess
+
+OUTPUT_PORT = "detections_to_downstream"
+INPUT_PORT = "detections_from_upstream"
+
+
+class DetectionTypedDict(TypedDict):
+    """The free-cast target: a TypedDict is a dict at runtime."""
+
+    label: str
+    score: float
+
+
+@dataclass
+class DetectionDataclass:
+    """The constructing target: construction is the validation."""
+
+    label: str
+    score: float
+
+
+class DetectionModel(pydantic.BaseModel):
+    """The validating target: pydantic checks the field types a dataclass
+    would take on trust."""
+
+    label: str
+    score: float
+
+
+class WiredLinkUnderTest:
+    """One live link, from the writing end to the reading end."""
+
+    def __init__(
+        self, source: ProcessorLinkDataAccess, destination: ProcessorLinkDataAccess
+    ) -> None:
+        self.source = source
+        self.destination = destination
+
+    def deliver(self, bag: dict[str, Any]) -> None:
+        self.source.write_to_output_port(OUTPUT_PORT, bag)
+
+
+@pytest.fixture
+def wired_link(request: pytest.FixtureRequest) -> Iterator[WiredLinkUnderTest]:
+    """A source and a destination joined by one link.
+
+    Service names carry the pid and the test's own name because iceoryx2
+    service state is machine-global and outlives a crashed process — a fixed
+    name would let one bad run poison every later one.
+    """
+    unique = f"pinto{os.getpid()}_{request.node.name}"
+    channel_service_name = f"{unique}/detections"
+    notify_service_name = f"{unique}_dest/notify"
+    link_id = f"L-{unique}"
+
+    destination = ProcessorLinkDataAccess()
+    destination.wire_input_link(
+        INPUT_PORT,
+        channel_service_name,
+        notify_service_name,
+        "read_next_in_order",
+        8,
+        2,
+        1,
+        True,
+        link_id,
+    )
+    source = ProcessorLinkDataAccess()
+    source.wire_output_link(
+        OUTPUT_PORT,
+        channel_service_name,
+        notify_service_name,
+        1024,
+        1 << 20,
+        8,
+        2,
+        1,
+        True,
+        link_id,
+    )
+    yield WiredLinkUnderTest(source, destination)
+
+
+def test_a_read_without_into_yields_the_bag_as_a_mapping(
+    wired_link: WiredLinkUnderTest,
+):
+    """The unchanged default: no target named, so nothing is cast and the bag
+    arrives as the mapping it is."""
+    wired_link.deliver({"label": "cat", "score": 0.9})
+
+    bag = wired_link.destination.read_from_input_port(INPUT_PORT)
+
+    assert bag == {"label": "cat", "score": 0.9}
+    assert type(bag) is dict
+
+
+def test_an_empty_mailbox_reads_as_none_with_a_target_named(
+    wired_link: WiredLinkUnderTest,
+):
+    """`into=` is a dial on how a bag is read, not a promise that one arrived —
+    an empty mailbox still reads as `None` rather than constructing an empty
+    target."""
+    assert wired_link.destination.read_from_input_port(INPUT_PORT, into=DetectionModel) is None
+
+
+def test_a_typed_dict_target_casts_for_free(wired_link: WiredLinkUnderTest):
+    """The bag comes back as the dict it already is — nothing constructed."""
+    wired_link.deliver({"label": "cat", "score": 0.9})
+
+    detection = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionTypedDict
+    )
+
+    assert detection == {"label": "cat", "score": 0.9}
+    assert type(detection) is dict
+
+
+def test_a_typed_dict_target_validates_nothing(wired_link: WiredLinkUnderTest):
+    """What "for free" costs: a bag missing a declared key and carrying one
+    nobody declared reads without complaint. An author who wants the check
+    names a dataclass or a model instead."""
+    wired_link.deliver({"label": "cat", "unexpected": True})
+
+    detection = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionTypedDict
+    )
+
+    assert detection == {"label": "cat", "unexpected": True}
+
+
+def test_a_dataclass_target_is_constructed_from_the_bag(
+    wired_link: WiredLinkUnderTest,
+):
+    wired_link.deliver({"label": "cat", "score": 0.9})
+
+    detection = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionDataclass
+    )
+
+    assert detection == DetectionDataclass(label="cat", score=0.9)
+
+
+def test_a_dataclass_target_raises_at_the_read_on_a_mismatch(
+    wired_link: WiredLinkUnderTest,
+):
+    """The whole point of the dial: the producer published something else and
+    nothing in the engine noticed, so the consumer's own read is where that
+    surfaces."""
+    wired_link.deliver({"label": "cat", "confidence": 0.9})
+
+    with pytest.raises(TypeError, match="confidence"):
+        wired_link.destination.read_from_input_port(INPUT_PORT, into=DetectionDataclass)
+
+
+def test_a_pydantic_model_target_is_constructed_from_the_bag(
+    wired_link: WiredLinkUnderTest,
+):
+    wired_link.deliver({"label": "cat", "score": 0.9})
+
+    detection = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionModel
+    )
+
+    assert detection == DetectionModel(label="cat", score=0.9)
+
+
+def test_a_pydantic_model_target_raises_at_the_read_on_a_bad_field(
+    wired_link: WiredLinkUnderTest,
+):
+    """A model checks the field types a dataclass takes on trust, and its own
+    `ValidationError` is what reaches the author — naming the field and what
+    it got, which no wrapper of ours could."""
+    wired_link.deliver({"label": "cat", "score": "very"})
+
+    with pytest.raises(pydantic.ValidationError, match="score"):
+        wired_link.destination.read_from_input_port(INPUT_PORT, into=DetectionModel)
+
+
+def test_the_named_target_is_what_a_type_checker_sees(wired_link: WiredLinkUnderTest):
+    """Half of what `into=` buys is static: the annotation on a port method is
+    read by humans and type checkers only, so a read that names a target has
+    to come back as that target rather than `Any`.
+
+    `assert_type` is checked by pyright and is a no-op at runtime — the reason
+    this asserts nothing else.
+    """
+    detection = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionDataclass
+    )
+    assert_type(detection, DetectionDataclass | None)
+
+    entries = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionTypedDict
+    )
+    assert_type(entries, DetectionTypedDict | None)

--- a/sdk/streamlib-python-wheel/tests/test_read_into_target.py
+++ b/sdk/streamlib-python-wheel/tests/test_read_into_target.py
@@ -21,6 +21,7 @@ from typing import Any, TypedDict
 
 import pydantic
 import pytest
+from typing_extensions import TypedDict as TypedDictFromTypingExtensions
 from typing_extensions import assert_type
 
 from streamlib import ProcessorLinkDataAccess
@@ -31,6 +32,13 @@ INPUT_PORT = "detections_from_upstream"
 
 class DetectionTypedDict(TypedDict):
     """The free-cast target: a TypedDict is a dict at runtime."""
+
+    label: str
+    score: float
+
+
+class DetectionTypedDictFromTypingExtensions(TypedDictFromTypingExtensions):
+    """The spelling `typing.is_typeddict` does not recognize."""
 
     label: str
     score: float
@@ -151,6 +159,26 @@ def test_a_typed_dict_target_validates_nothing(wired_link: WiredLinkUnderTest):
     )
 
     assert detection == {"label": "cat", "unexpected": True}
+
+
+def test_a_typing_extensions_typed_dict_is_an_accepted_target(
+    wired_link: WiredLinkUnderTest,
+):
+    """A package supporting several interpreter versions spells its TypedDicts
+    this way, and the read has to accept one rather than raise.
+
+    It cannot show whether the bag was copied on the way through — both
+    spellings return an equal dict when constructed, so only the Rust unit test
+    can see the difference. What this pins is that the target is accepted at
+    all.
+    """
+    wired_link.deliver({"label": "cat", "score": 0.9})
+
+    detection = wired_link.destination.read_from_input_port(
+        INPUT_PORT, into=DetectionTypedDictFromTypingExtensions
+    )
+
+    assert detection == {"label": "cat", "score": 0.9}
 
 
 def test_a_dataclass_target_is_constructed_from_the_bag(


### PR DESCRIPTION
## Summary

The engine has no type layer, so nothing between two processors compares a type. `read(port, into=T)` is what replaces engine-side schema agreement: the consumer decides how strictly to read, and a mismatch surfaces at its own read — not at connect, not at publish.

- **No `into=`** — unchanged. The bag arrives as a mapping.
- **A TypedDict** — casts for free. A TypedDict is a dict at runtime, so the decoded bag travels back as the *same object*; nothing is constructed and nothing is validated.
- **A dataclass or pydantic model** — constructed from the bag's entries. The constructor's own exception is what the author sees: flattening pydantic's `ValidationError` into a StreamLib error would destroy the field-level message that is the whole reason to name a model.

The dial lands on both read surfaces — `ctx.inputs.read` and the `ProcessorLinkDataAccess.read_from_input_port` a helper drives — as a keyword-only parameter, with overloaded stub entries so a named target comes back typed rather than as `Any`.

Purely additive. No engine surface is removed; the wire tag and the per-read comparison die in the ticket this one unblocks.

Two implementation notes worth the owner's eye:

**TypedDict detection is structural** — a `dict` subclass carrying `__required_keys__` — rather than `typing.is_typeddict`, which returns `False` for a `typing_extensions.TypedDict` (verified on 3.12). That spelling is what a package supporting several interpreter versions uses, and the stdlib predicate would silently drop it into the constructing branch.

**pydantic and typing_extensions are test-only.** The wheel imports neither; `into=` constructs whatever target it is handed and names no library. They are in the dev extras and the two CI venvs so that a model is *proven* to be a legal target.

## Closes

Closes #1812

## Exit criteria

- [x] `read(port, into=T)` exists on the Python reader; omitting `into=` yields the bag as a mapping, unchanged
- [x] A TypedDict target casts without constructing — asserted as object identity, which is the only place the difference is observable
- [x] A dataclass and a pydantic model each construct on a good bag and raise on a bad one
- [x] The `_engine.pyi` stub entries ship in the same PR; stubtest and pyright (standard) gate them

## Test plan

| gate | result |
|---|---|
| `cargo test -p streamlib-python-wheel --lib` | 45 passed (6 new in `python_bag_conversion`) |
| `pytest tests/ -m "not requires_gpu"` | 209 passed (10 new in `test_read_into_target.py`) |
| `python -m mypy.stubtest streamlib._engine` | clean |
| `uvx pyright@1.1.411` | 0 errors |
| full xtask check suite + `cargo test -p xtask` | 11 checks pass, 215 tests |
| license headers, lint-logging, `cargo check --workspace --all-targets`, `cargo fmt --check` | pass |

The pytest cases drive real wired iceoryx2 ports rather than a stand-in — the bag has to survive the wire before `into=` has anything to cast — which is why they need no GPU and run in CI.

Two negative proofs, since a green gate that cannot go red proves nothing:
- Deleting `into` from the `read` stub makes stubtest red (`stub does not have parameter "into"`).
- `assert_type` in `test_the_named_target_is_what_a_type_checker_sees` is a runtime no-op, so I confirmed pyright reports `"assert_type" mismatch` when the expected type is wrong. It is what catches a future stub edit widening the return back to `Any` — something stubtest cannot see.

## Notes for owner

**1. The dial is on `read` only; `read_with_timestamp` keeps its plain shape.** The plan (`ARCHITECTURE.md:88`) and the change file both attach the dial to `read` and say nothing about the timestamp read, so adding it would have been undeclared scope. Both reviewers agreed with the scoping and both asked that the asymmetry be a decision rather than a leftover: an author who needs the stamp today hand-writes `DetectionModel(**bag)`. No sibling ticket in this change picks it up. Your call — "plan means `read` only" or a follow-up.

**2. The plan's phrase "a dataclass or pydantic model constructs and validates" overstates the dataclass half.** A dataclass validates key *shape* only — `DetectionDataclass(label="cat", score="very")` constructs happily. Only a model checks field types. The tests say so honestly rather than overclaiming; flagging in case the plan wording wants a hedge.

**3. One `into=` failure still does not name the port.** A decoded map with non-string keys reaches the constructor and surfaces as CPython's bare `keywords must be strings`. Unreachable from a Python publisher — the wheel's own encoder refuses to publish one — so it needs a Rust or foreign producer emitting a non-string-keyed top-level map. Left alone deliberately.

**4. Scope note on a DRY fix.** The type-name-for-a-refusal idiom appeared twice in `python_bag_conversion.rs` already and this change would have made it a third. I extracted `python_type_name_for_error_message` and moved all three sites onto it, including the two pre-existing ones — one helper plus two hand-rolled survivors read worse than either extreme. No behaviour change; say the word and I will unwind the two pre-existing sites.

**5. Pre-existing, untouched.** `python_processor_link_data_access.rs` trips clippy's `items_after_test_module` (two free functions sit after `mod tests`, both from before this branch; no workflow runs clippy). And `docs/testing-hardware.md` carries a workspace-baseline exclude list naming five crates the ripout deleted — fully stale.

## Review

`review-pr` **APPROVE**; `rust-craftsmanship-reviewer` **REJECT → APPROVE** after round 2 (grade A-). Both verified the gates themselves rather than taking my word.

One reviewer claim I checked rather than accepted: it argued that regressing the predicate to `typing.is_typeddict` would make a `typing_extensions` target *raise*. It doesn't — calling either TypedDict spelling returns an equal `dict` copy, so a Python-level test of that path passes either way and would have been vacuous. The lock therefore lives in a Rust unit test asserting `read.is(&bag)` against a target `typing.is_typeddict` provably rejects; a pytest pins the weaker, still-real claim that the spelling is an accepted target. The reviewer verified both claims live and agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Python SDK reads can now convert incoming data directly into supported typed targets, including dataclasses, TypedDicts, and Pydantic models.
  - Added optional `into` parameters for input-port reading APIs.
  - Reads continue to return mappings by default, while empty reads return `None`.
- **Bug Fixes**
  - Improved validation and error reporting for incompatible data and invalid typed targets.
- **Tests**
  - Added coverage for typed conversions, validation failures, empty reads, and static type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->