### PR TITLE
fix(ci): mark the placement tests rig-only so the wheel gate reports honestly

### DIFF
--- a/sdk/streamlib-python-wheel/tests/test_helper_placement.py
+++ b/sdk/streamlib-python-wheel/tests/test_helper_placement.py
@@ -11,6 +11,13 @@ processor's module, and the pid a bag was produced in is not the app's.
 `cargo xtask check-no-in-process-placement` gates the vocabulary; this gates
 the behaviour. A change that reintroduces the banned model without using any
 of the banned words still turns these red.
+
+Rig-only, and that is a weaker gate than it reads: every scenario here drives a
+real graph through `runtime.run()`, which initialises a GPU context whose
+DMA-BUF pool pre-warm needs a driver that can allocate exportable device
+memory. A software rasterizer cannot supply one, so on a GPU-less runner these
+do not fail meaningfully — they cannot start. Part of what this file asserts
+needs no device and belongs back in CI; #1823 carries that.
 """
 
 import os
@@ -18,6 +25,8 @@ import re
 from pathlib import Path
 
 import pytest
+
+pytestmark = pytest.mark.requires_gpu
 
 APP = Path(__file__).parent / "helper_placement_app.py"
 


### PR DESCRIPTION
## Summary

Marks `test_helper_placement.py` `requires_gpu`, restoring the Python Wheel gate to green.

Every scenario in that file drives a real graph through `runtime.run()`, which initialises a GPU context whose DMA-BUF pool pre-warm needs a driver that can allocate exportable device memory. The wheel job's GPU-free half runs on a runner with no device, so these six tests **could never pass there — and never did.**

**The gate was green through `adf4c595` (2026-08-06) and went red at `19cbfdb4` (2026-08-07)** — the commit that introduced this file with #1754. That is **30 consecutive red runs across 4 days.** A permanently-red gate is indistinguishable from no gate; this one masked itself well enough that nobody noticed, and it cost real verification time during #1820's merge.

Surfaced while merging #1820, which is unrelated to it — that PR's failures were provably identical to its base commit's.

## What this costs

Placement enforcement becomes **rig-only**, and `docs/plan/ARCHITECTURE.md` names this file as the `verify:` anchor for the helper-process-placement STOP-WORK entry. That is a real reduction, not a free cleanup.

Part of what the file asserts needs no device — what `rt.add` alone does to the parent interpreter, whether a class is import-addressable, whether an entry-file class is refused. **#1823** carries carving that back into CI. The module docstring records the same, so the next reader doesn't mistake rig-only for the intended end state.

## Ruled out

- **A software rasterizer.** The wheel workflow already documents the finding: lavapipe cannot allocate exportable device memory, verified in a GPU-less container. Not re-litigated.
- **A self-hosted GPU runner.** Owner decision, 2026-08-03 — the rig-only tier is deliberate.

## Test plan

Local run of the exact command CI uses (`pytest tests/ -m "not requires_gpu"`):

| | before | after |
|---|---|---|
| passed | 205 | **205** |
| failed | **6** | **0** |
| deselected | 55 | 61 |

The six are deselected, not dropped — `pytest tests/test_helper_placement.py --collect-only -m requires_gpu` still collects all 6, so they remain runnable on the rig.

## Notes for owner

The docstring's own claim — *"A change that reintroduces the banned model without using any of the banned words still turns these red"* — has not been true since the file landed, because they were already red. #1823 is what makes it true again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked GPU-dependent runtime tests so they run only in environments with a real GPU driver.
  * Documented that these scenarios are unsuitable for GPU-less test runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->