### PR TITLE
fix(build): realign intra-workspace version pins to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4882,7 +4882,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "streamlib"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "iceoryx2",
  "serde",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-cpu-readback"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "serde",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-cuda"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cudarc",
  "dlpark",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-opengl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "gl",
  "khronos-egl",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-skia"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "libloading 0.8.9",
@@ -4977,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-adapter-vulkan"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "serde",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-consumer-rhi"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "streamlib-surface-client",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-error"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "streamlib-consumer-rhi",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-idents"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "flate2",
  "schemars 0.8.22",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-ipc-types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "iceoryx2",
  "tracing",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-macros"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "crossbeam-channel",
  "proc-macro-crate",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-media-builtins"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "raw-window-handle",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-moq"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytes",
  "moq-transport",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-processor-schema"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "rmp-serde",
  "schemars 0.8.22",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-python-wheel"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cudarc",
  "libc",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-surface-adapter"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-surface-client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "serde_json",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "streamlib-test-fixtures"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5982,7 +5982,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vulkan-jpeg"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bytemuck",
  "jpeg-encoder",

--- a/adapters/streamlib-adapter-cpu-readback/Cargo.toml
+++ b/adapters/streamlib-adapter-cpu-readback/Cargo.toml
@@ -15,13 +15,13 @@ name = "streamlib_adapter_cpu_readback"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.16.0" }
+streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.17.0" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.17.0" }
 vulkanalia.workspace = true
 libc.workspace = true
 serde = { workspace = true }

--- a/adapters/streamlib-adapter-cuda/Cargo.toml
+++ b/adapters/streamlib-adapter-cuda/Cargo.toml
@@ -33,13 +33,13 @@ cuda = ["dep:cudarc"]
 # spec's `#[repr(C)]` types, and off-Linux consumers (the wheel's CPU
 # capsule path) need exactly it.
 dlpark.workspace = true
-streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.16.0" }
+streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.17.0" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.17.0" }
 vulkanalia.workspace = true
 libc.workspace = true
 cudarc = { workspace = true, optional = true }

--- a/adapters/streamlib-adapter-opengl/Cargo.toml
+++ b/adapters/streamlib-adapter-opengl/Cargo.toml
@@ -15,14 +15,14 @@ name = "streamlib_adapter_opengl"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.16.0" }
+streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.17.0" }
 parking_lot = "0.12"
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.17.0" }
 khronos-egl = { version = "6.0", features = ["dynamic"] }
 gl = "0.14"
 libc.workspace = true

--- a/adapters/streamlib-adapter-skia/Cargo.toml
+++ b/adapters/streamlib-adapter-skia/Cargo.toml
@@ -15,14 +15,14 @@ name = "streamlib_adapter_skia"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.16.0" }
+streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.17.0" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.16.0" }
-streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.16.0" }
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
+streamlib-adapter-vulkan = { path = "../streamlib-adapter-vulkan", version = "0.17.0" }
+streamlib-adapter-opengl = { path = "../streamlib-adapter-opengl", version = "0.17.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
 vulkanalia.workspace = true
 skia-safe = { workspace = true }
 # vkGetInstanceProcAddr lives on vulkanalia's private StaticCommands;
@@ -36,7 +36,7 @@ libloading = "0.8"
 # live under regular `[dependencies]` rather than `[dev-dependencies]`
 # because Cargo's `[[bin]]` targets don't see dev-deps. Same shape as
 # `streamlib-adapter-opengl/Cargo.toml`.
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.16.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.17.0" }
 serde = { workspace = true }
 serde_json.workspace = true
 libc.workspace = true

--- a/adapters/streamlib-adapter-vulkan/Cargo.toml
+++ b/adapters/streamlib-adapter-vulkan/Cargo.toml
@@ -15,13 +15,13 @@ name = "streamlib_adapter_vulkan"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.16.0" }
+streamlib-surface-adapter = { path = "../streamlib-surface-adapter", version = "0.17.0" }
 thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.17.0" }
 vulkanalia.workspace = true
 libc.workspace = true
 serde = { workspace = true }

--- a/packages/test-fixtures/Cargo.toml
+++ b/packages/test-fixtures/Cargo.toml
@@ -18,11 +18,11 @@ crate-type = ["rlib"]
 
 [dependencies]
 # Engine substrate — runtime context and processor traits.
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.16.0" }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.17.0" }
 
 # Procedural macros — `#[streamlib::sdk::processor("...")]` reads the
 # crate's own `streamlib.yaml` at `CARGO_MANIFEST_DIR`.
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.16.0" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.17.0" }
 
 
 # Serialization (config dataclass ships as serde-derived).

--- a/runtime/streamlib-api-server/Cargo.toml
+++ b/runtime/streamlib-api-server/Cargo.toml
@@ -29,9 +29,9 @@ default = []
 moq = ["dep:streamlib-moq"]
 
 [dependencies]
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.16.0" }
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.16.0" }
-streamlib-moq = { path = "../../runtime/streamlib-moq", version = "0.16.0", optional = true }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.17.0" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.17.0" }
+streamlib-moq = { path = "../../runtime/streamlib-moq", version = "0.17.0", optional = true }
 
 tower-http = { version = "0.6", features = ["trace"] }
 futures-util = "0.3"
@@ -58,7 +58,7 @@ constant_time_eq = "0.3"
 # Enables the engine's `test-support` in-memory `TapSubscription` constructor
 # for the MCP/REST tap-tool tests. A dev-dep feature: active for tests, absent
 # from the production `cargo build` dependency graph.
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.16.0", features = ["test-support"] }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.17.0", features = ["test-support"] }
 tempfile = "3"
 tower = {version = "0.5", features = ["util"]}
 serial_test = "3.2"

--- a/runtime/streamlib-consumer-rhi/Cargo.toml
+++ b/runtime/streamlib-consumer-rhi/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.16.0" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.17.0" }
 vulkanalia.workspace = true
 libc.workspace = true
 

--- a/runtime/streamlib-engine/Cargo.toml
+++ b/runtime/streamlib-engine/Cargo.toml
@@ -45,18 +45,18 @@ clear_bitstream_buffers_on_create = []
 
 [dependencies]
 # Processor schema types (shared with macros for code generation)
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.16.0", features = ["utoipa"] }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.17.0", features = ["utoipa"] }
 
 # Canonical Error / Result / PortDirection, shared with the plugin-SDK so
 # plugin cdylibs author against them without linking the engine. The engine
 # re-exports them at `core::error`.
-streamlib-error = { path = "../../sdk/streamlib-error", version = "0.16.0" }
+streamlib-error = { path = "../../sdk/streamlib-error", version = "0.17.0" }
 
 # Schema identity + manifest types (one source of truth for the
 # structured `dependencies:` shape consumed at runtime).
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.16.0" }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.17.0" }
 # Procedural macros
-streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.16.0" }
+streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.17.0" }
 
 # Plugin ABI wire-protocol header. Dep direction reversed in #877:
 # streamlib-plugin-abi no longer depends on streamlib (the SDK), so the
@@ -65,7 +65,7 @@ streamlib-macros = { path = "../../sdk/streamlib-macros", version = "0.16.0" }
 # `STREAMLIB_ABI_VERSION` from this crate directly.
 
 # Shared iceoryx2 payload types (for cross-process IPC)
-streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.16.0" }
+streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.17.0" }
 
 # Consumer-side carve-out — owns the format primitives
 # (TextureFormat / TextureUsages / PixelFormat), the trait machinery
@@ -73,7 +73,7 @@ streamlib-ipc-types = { path = "../streamlib-ipc-types", version = "0.16.0" }
 # Consumer* RHI types (Linux), and a slim ConsumerRhiError. streamlib
 # re-exports the primitives so existing in-tree call sites (e.g.
 # `crate::core::rhi::TextureFormat`) keep working unchanged.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.17.0" }
 
 # Core dependencies (always included)
 thiserror.workspace = true
@@ -150,10 +150,10 @@ raw-window-handle = "0.6"  # Raw window handle types for Vulkan surface creation
 # privileged syscall on the requesting thread's behalf.
 zbus = "5"
 # Wire-format helpers for the per-runtime surface-sharing socket
-streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.16.0" }
+streamlib-surface-client = { path = "../streamlib-surface-client", version = "0.17.0" }
 # Surface descriptor types referenced by the host-side CpuReadbackBridge
 # trait (linux-only; the cpu-readback adapter is linux-only).
-streamlib-surface-adapter = { path = "../../adapters/streamlib-surface-adapter", version = "0.16.0" }
+streamlib-surface-adapter = { path = "../../adapters/streamlib-surface-adapter", version = "0.17.0" }
 # The extern "C" panic net (run_host_extern_c) every host_services callback
 # routes through.
 # Consumer-side carve-out — defines the trait machinery
@@ -162,7 +162,7 @@ streamlib-surface-adapter = { path = "../../adapters/streamlib-surface-adapter",
 # host side. streamlib re-exports for in-tree consumers; subprocess
 # cdylibs depend on it directly so the FullAccess capability boundary
 # is enforced by the type system.
-streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../streamlib-consumer-rhi", version = "0.17.0" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
@@ -184,7 +184,7 @@ serial_test = "3.2"  # Run tests sequentially to avoid global PUBSUB interferenc
 tempfile = "3.14"  # Temporary directories for config tests
 # Package-archive fixture authoring lives in the crate that owns the reader —
 # the engine neither reads nor writes containers except through it.
-streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.16.0", features = ["archive-test-fixtures"] }
+streamlib-idents = { path = "../../sdk/streamlib-idents", version = "0.17.0", features = ["archive-test-fixtures"] }
 criterion = { version = "0.5", features = ["html_reports"] }  # Benches for logging hot path (#447)
 png = "0.17"  # PNG decoding for shader-output fixture comparisons
 

--- a/runtime/streamlib-media-builtins/Cargo.toml
+++ b/runtime/streamlib-media-builtins/Cargo.toml
@@ -15,7 +15,7 @@ name = "streamlib_media_builtins"
 path = "src/lib.rs"
 
 [dependencies]
-streamlib = { path = "../../sdk/streamlib-sdk", version = "0.16.0", default-features = false }
+streamlib = { path = "../../sdk/streamlib-sdk", version = "0.17.0", default-features = false }
 serde = { workspace = true }
 tracing = { workspace = true }
 

--- a/runtime/streamlib-moq/Cargo.toml
+++ b/runtime/streamlib-moq/Cargo.toml
@@ -21,8 +21,8 @@ path = "src/lib.rs"
 # links this transport lib, so pulling the facade here would statically bundle
 # a second copy of streamlib-engine into the host process (the direct-dep grep
 # in check-boundaries does not see this transitive path).
-streamlib-error = { path = "../../sdk/streamlib-error", version = "0.16.0" }
-streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.16.0" }
+streamlib-error = { path = "../../sdk/streamlib-error", version = "0.17.0" }
+streamlib-processor-schema = { path = "../../sdk/streamlib-processor-schema", version = "0.17.0" }
 
 # MoQ-over-QUIC transport stack.
 moq-transport = "0.14.1"

--- a/sdk/streamlib-error/Cargo.toml
+++ b/sdk/streamlib-error/Cargo.toml
@@ -17,10 +17,10 @@ path = "src/lib.rs"
 [dependencies]
 thiserror.workspace = true
 anyhow.workspace = true
-streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.16.0" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.17.0" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-macros/Cargo.toml
+++ b/sdk/streamlib-macros/Cargo.toml
@@ -23,13 +23,13 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 
 # Execution types (shared with streamlib for code generation)
-streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.16.0" }
+streamlib-processor-schema = { path = "../streamlib-processor-schema", version = "0.17.0" }
 # The `#[processor(...)]` attribute grammar — shared with the source-scan
 # extractor so both parse the attribute through one parser (#1411).
 # Manifest resolver — used to walk the enclosing manifest's `schemas:` map
 # and resolve bare-name `PortSchemaSpec::Named` references to fully-
 # qualified `SchemaIdent`s at proc-macro expansion time (#767).
-streamlib-idents = { path = "../streamlib-idents", version = "0.16.0" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.17.0" }
 
 
 [dev-dependencies]

--- a/sdk/streamlib-processor-schema/Cargo.toml
+++ b/sdk/streamlib-processor-schema/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }  # used by schemars for enum_values literals
 serde_yaml = { workspace = true }
-streamlib-idents = { path = "../streamlib-idents", version = "0.16.0" }
+streamlib-idents = { path = "../streamlib-idents", version = "0.17.0" }
 thiserror = { workspace = true }
 schemars = "0.8"  # JSON Schema generation for streamlib.yaml editor support
 # Host-only OpenAPI schema derive for the wire-output DTOs, behind the

--- a/sdk/streamlib-python-wheel/Cargo.toml
+++ b/sdk/streamlib-python-wheel/Cargo.toml
@@ -38,7 +38,7 @@ extension-module = ["pyo3/extension-module"]
 # exist for them.
 pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 
-streamlib = { path = "../streamlib-sdk", version = "0.16.0" }
+streamlib = { path = "../streamlib-sdk", version = "0.17.0" }
 
 # The one control plane, hosted in-process by a runtime that enables it
 # (`rt.host_control_plane(...)`) — what makes a Python-launched app show up in
@@ -49,14 +49,14 @@ streamlib-api-server = { path = "../../runtime/streamlib-api-server" }
 # The native media built-ins the wheel exports as pre-built named blocks
 # (`rt.add(TestPatternSource)`), statically linked so they are current by
 # construction.
-streamlib-media-builtins = { path = "../../runtime/streamlib-media-builtins", version = "0.16.0" }
+streamlib-media-builtins = { path = "../../runtime/streamlib-media-builtins", version = "0.17.0" }
 
 # The workspace's single DLPack home: the `#[repr(C)]` v0.8 ABI mirrors, the
 # managed-tensor builders, and the layout regression test that pins them. The
 # pixel-exchange surface builds its capsules here rather than growing a second
 # copy of the spec — the CUDA half of the same adapter is what the device-memory
 # export path uses.
-streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.16.0" }
+streamlib-adapter-cuda = { path = "../../adapters/streamlib-adapter-cuda", version = "0.17.0" }
 
 # The bag's value tree. A bag crosses into Python as ordinary Python data, and
 # `rmpv`'s native `bin` variant is what keeps a byte payload from decoding as
@@ -90,8 +90,8 @@ cudarc = { workspace = true }
 # consumer-side Vulkan import that turns its DMA-BUF plane fds into mapped
 # memory. Both already ride in the binary via the engine; named here so the
 # wheel can call them.
-streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.16.0" }
-streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.16.0" }
+streamlib-surface-client = { path = "../../runtime/streamlib-surface-client", version = "0.17.0" }
+streamlib-consumer-rhi = { path = "../../runtime/streamlib-consumer-rhi", version = "0.17.0" }
 
 [lints]
 workspace = true

--- a/sdk/streamlib-sdk/Cargo.toml
+++ b/sdk/streamlib-sdk/Cargo.toml
@@ -27,7 +27,7 @@ hardware-tests = ["streamlib-engine/hardware-tests"]
 test-support = ["streamlib-engine/test-support"]
 
 [dependencies]
-streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.16.0" }
+streamlib-engine = { path = "../../runtime/streamlib-engine", version = "0.17.0" }
 # `App` sugar takes `impl Serialize` configs and encodes them to the JSON the
 # runtime carries.
 serde = { workspace = true }

--- a/sdk/vulkan-jpeg/Cargo.toml
+++ b/sdk/vulkan-jpeg/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = { version = "1.16", features = ["derive"] }
 # backend builds against (VulkanComputeKernel, StorageBuffer, TextureRing,
 # ComputeKernelDescriptor, the color-math types, and the GpuContextFullAccess
 # view) under `streamlib::sdk::*` and its `sdk::engine::host_rhi` tier.
-streamlib = { path = "../streamlib-sdk", version = "0.16.0" }
+streamlib = { path = "../streamlib-sdk", version = "0.17.0" }
 
 [dev-dependencies]
 jpeg-encoder = "0.6"


### PR DESCRIPTION
## Summary

`main` does not compile. The 0.17.0 release commit (`63666170`) bumped `[workspace.package] version` but left every intra-workspace path-dependency pin at `version = "0.16.0"`, so Cargo cannot resolve the workspace and no crate builds.

This realigns those pins. Mechanical only — no dependency added, dropped, or re-pointed.

Scoped to the **17 workspace-member manifests** that carry a stale pin (49 pins total). The vendored vulkanalia crates are workspace members but carry no pins and are untouched.

## What was broken

| Probe | Before | After |
| --- | --- | --- |
| `cargo metadata --format-version 1` | fails — `failed to select a version for the requirement streamlib-processor-schema = "^0.16.0"` | resolves |
| `cargo check --workspace --all-targets` | cannot start | clean |
| `cargo xtask check-boundaries` | red | pass |
| `cargo xtask check-schema-versions` | red | pass |
| `cargo xtask check-device-wait-idle` | red | pass |
| `cargo xtask check-processor-spec-new` | red | pass |
| `cargo xtask check-no-escalate-in-lifecycle` | red | pass |
| `cargo xtask check-no-streamlib-metadata` | red | pass |

The commit immediately before the release (`f27cf414`) resolves fine, which isolates the break to the release commit. The only two green checks on `63666170` — License Header Check and Ship-Change Removed Gate — are the two that never invoke cargo.

## Closes

None — this is the mechanical unblock, not the fix.

Refs #1825.

## Exit criteria

- [x] `cargo metadata --format-version 1` resolves
- [x] `cargo check --workspace --all-targets` finishes clean (warnings pre-existing, 0 errors)
- [x] All six previously-red cargo-based xtask gates pass
- [x] `vendor/tatolab-vulkanalia*` untouched
- [x] No dependency added, removed, or re-pointed — version strings only

## Test plan

Ran locally on the branch: `cargo metadata`, `cargo check --workspace --all-targets`, and each of the six xtask checks individually. Results in the table above. Nothing here is behavioural, so there is no new test — the gates that could not run are the test.

## Notes for owner

- **This is not the fix.** The root cause is release configuration: `release-please-config.json` declares a single package (`"."`) and sets no `plugins`, so nothing is aware of the 49 pins. 0.18.0 breaks identically. Filed as #1825 with the two candidate fixes (add the `cargo-workspace` plugin, or drop the redundant `version` key from path deps) — that is a distribution decision against `ARCHITECTURE.md` §Distribution & versioning, so I did not pick one.
- **Diagnostic trap worth knowing:** `cargo metadata --no-deps` reports *success* on the broken tree because it skips resolution. The failure also names an unrelated crate pair, so it reads as "the branch I just cut is broken" rather than "main is broken". Cost me a detour; recorded in #1825.
- `packages/test-fixtures` is edited here. It is a workspace member and is one of the three `packages/` entries CLAUDE.md exempts from the consumer deny-list, so this is engine-tree work, not a consumer edit.
- `Cargo.lock` moves with the pins, as expected.
- Found while starting #1815 (delete the embedded schema registry); that work is branched and waiting on this to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Streamlib components and adapters to version 0.17.0.
  - Updated SDK, runtime, media, graphics, CUDA, Vulkan, OpenGL, Skia, and test-support integrations.
  - Aligned Linux-specific and optional integrations with the 0.17.0 release.
  - No user-facing API or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->