### PR TITLE
fix(engine): bound every wire-derived length the frame-header read path trusts

### DIFF
--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -1080,9 +1080,15 @@ mod tests {
             .expect("port fits PortKey")
             .write_to_slice(&mut good[..FRAME_HEADER_SIZE]);
         good[FRAME_HEADER_SIZE..].copy_from_slice(&body);
-        assert!(inner.route(good), "well-formed frame must route to port 'in'");
+        assert!(
+            inner.route(good),
+            "well-formed frame must route to port 'in'"
+        );
 
-        match inner.read_raw_bounded("in", usize::MAX).expect("bounded read") {
+        match inner
+            .read_raw_bounded("in", usize::MAX)
+            .expect("bounded read")
+        {
             BoundedReadOutcome::Frame { data, timestamp_ns } => {
                 assert_eq!(data, body, "a well-formed frame still delivers intact");
                 assert_eq!(timestamp_ns, 43);

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -683,6 +683,7 @@ impl Drop for InputMailboxes {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::iceoryx2::PortKey;
 
     fn unique_suffix(tag: &str) -> String {
         format!(
@@ -1099,6 +1100,31 @@ mod tests {
             }
             _ => panic!("expected the well-formed frame to deliver"),
         }
+    }
+
+    /// A malformed length prefix must not deliver a frame to a real mailbox.
+    ///
+    /// The saturating bound is only safe because a clamped name fails to match
+    /// a port — which stops being true at exactly one width: a port named with
+    /// the full 63 bytes is what the clamp produces, so an over-capacity prefix
+    /// on a frame for that port reads back as the port's own name.
+    #[test]
+    fn route_refuses_a_frame_whose_port_key_prefix_is_over_capacity() {
+        let longest_port = "z".repeat(PortKey::MAX_NAME_BYTES);
+
+        let inner = InputMailboxesInner::new();
+        inner.add_port(&longest_port, 64, ReadMode::ReadNextInOrder);
+
+        let mut frame = vec![0u8; FRAME_HEADER_SIZE + 4];
+        FrameHeader::new(&longest_port, 42, 4)
+            .expect("a max-width port fits PortKey")
+            .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+        frame[0] = 0xFF;
+
+        assert!(
+            !inner.route(frame),
+            "a frame with an over-capacity prefix must not reach a real mailbox"
+        );
     }
 
     /// Clone bumps the strong count via the host-installed

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -411,12 +411,8 @@ impl InputMailboxesInner {
                 None => return Ok(BoundedReadOutcome::Empty),
                 Some(r) => {
                     let header = FrameHeader::read_from_slice(&r);
-                    // The stamped length comes off the wire; the frame is the
-                    // capacity it indexes. Unlike the port key it has no safe
-                    // default — a frame claiming more than it carries is
-                    // unusable — so it fails typed rather than saturating.
                     let stamped_payload_bytes = header.len as usize;
-                    let available_payload_bytes = r.len().saturating_sub(FRAME_HEADER_SIZE);
+                    let available_payload_bytes = r.len() - FRAME_HEADER_SIZE;
                     if stamped_payload_bytes > available_payload_bytes {
                         return Err(Error::FrameHeaderPayloadLengthExceedsFrameBytes {
                             port: port.to_string(),
@@ -1038,14 +1034,26 @@ mod tests {
         const STAMPED: u32 = 4096;
         const CARRIED: usize = 8;
 
+        // The stamped and carried payload lengths are separate arguments
+        // because their divergence is the whole subject of this test.
+        fn frame_with_stamped_payload_length(
+            timestamp_ns: i64,
+            stamped_payload_bytes: u32,
+            carried_body: &[u8],
+        ) -> Vec<u8> {
+            let mut frame = vec![0u8; FRAME_HEADER_SIZE + carried_body.len()];
+            FrameHeader::new("in", timestamp_ns, stamped_payload_bytes)
+                .expect("port fits PortKey")
+                .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+            frame[FRAME_HEADER_SIZE..].copy_from_slice(carried_body);
+            frame
+        }
+
         let inner = InputMailboxesInner::new();
         inner.add_port("in", 64, ReadMode::ReadNextInOrder);
 
-        let mut frame = vec![0u8; FRAME_HEADER_SIZE + CARRIED];
-        FrameHeader::new("in", 42, STAMPED)
-            .expect("port fits PortKey")
-            .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
-        assert!(inner.route(frame), "frame must route to port 'in'");
+        let malformed = frame_with_stamped_payload_length(42, STAMPED, &[0u8; CARRIED]);
+        assert!(inner.route(malformed), "frame must route to port 'in'");
 
         let err = match inner.read_raw_bounded("in", usize::MAX) {
             Err(e) => e,
@@ -1075,13 +1083,9 @@ mod tests {
 
         // The malformed frame is dropped, not staged — the port keeps serving.
         let body = [1u8, 2, 3, 4];
-        let mut good = vec![0u8; FRAME_HEADER_SIZE + body.len()];
-        FrameHeader::new("in", 43, body.len() as u32)
-            .expect("port fits PortKey")
-            .write_to_slice(&mut good[..FRAME_HEADER_SIZE]);
-        good[FRAME_HEADER_SIZE..].copy_from_slice(&body);
+        let well_formed = frame_with_stamped_payload_length(43, body.len() as u32, &body);
         assert!(
-            inner.route(good),
+            inner.route(well_formed),
             "well-formed frame must route to port 'in'"
         );
 

--- a/runtime/streamlib-engine/src/iceoryx2/input.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/input.rs
@@ -411,8 +411,21 @@ impl InputMailboxesInner {
                 None => return Ok(BoundedReadOutcome::Empty),
                 Some(r) => {
                     let header = FrameHeader::read_from_slice(&r);
+                    // The stamped length comes off the wire; the frame is the
+                    // capacity it indexes. Unlike the port key it has no safe
+                    // default — a frame claiming more than it carries is
+                    // unusable — so it fails typed rather than saturating.
+                    let stamped_payload_bytes = header.len as usize;
+                    let available_payload_bytes = r.len().saturating_sub(FRAME_HEADER_SIZE);
+                    if stamped_payload_bytes > available_payload_bytes {
+                        return Err(Error::FrameHeaderPayloadLengthExceedsFrameBytes {
+                            port: port.to_string(),
+                            stamped_payload_bytes,
+                            available_payload_bytes,
+                        });
+                    }
                     let data =
-                        r[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + header.len as usize].to_vec();
+                        r[FRAME_HEADER_SIZE..FRAME_HEADER_SIZE + stamped_payload_bytes].to_vec();
                     (data, header.timestamp_ns)
                 }
             }
@@ -1010,6 +1023,72 @@ mod tests {
                 .expect("bounded read"),
             BoundedReadOutcome::Empty
         ));
+    }
+
+    /// The payload length is the last wire-derived number the read path trusts,
+    /// and a frame claiming more than it carries has no safe default — it is
+    /// unusable, so it must surface as a typed error naming the port and both
+    /// numbers rather than slicing past the frame.
+    ///
+    /// Fail-without-fix: drop the bound and `read_raw_bounded` slices
+    /// `[76..76 + 4096]` out of an 84-byte frame — "range end index 4172 out of
+    /// range for slice of length 84".
+    #[test]
+    fn read_raw_bounded_rejects_a_frame_stamping_more_payload_than_it_carries() {
+        const STAMPED: u32 = 4096;
+        const CARRIED: usize = 8;
+
+        let inner = InputMailboxesInner::new();
+        inner.add_port("in", 64, ReadMode::ReadNextInOrder);
+
+        let mut frame = vec![0u8; FRAME_HEADER_SIZE + CARRIED];
+        FrameHeader::new("in", 42, STAMPED)
+            .expect("port fits PortKey")
+            .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+        assert!(inner.route(frame), "frame must route to port 'in'");
+
+        let err = match inner.read_raw_bounded("in", usize::MAX) {
+            Err(e) => e,
+            Ok(_) => panic!("a frame stamping more than it carries must not read"),
+        };
+        assert!(
+            matches!(
+                &err,
+                Error::FrameHeaderPayloadLengthExceedsFrameBytes {
+                    port,
+                    stamped_payload_bytes,
+                    available_payload_bytes,
+                } if port == "in"
+                    && *stamped_payload_bytes == STAMPED as usize
+                    && *available_payload_bytes == CARRIED
+            ),
+            "expected the typed length error naming the port and both numbers, got {err:?}"
+        );
+        // Diagnosable without a debugger: the rendered message carries all three.
+        let rendered = err.to_string();
+        for expected in ["'in'", "4096", "8"] {
+            assert!(
+                rendered.contains(expected),
+                "message must name {expected}: {rendered}"
+            );
+        }
+
+        // The malformed frame is dropped, not staged — the port keeps serving.
+        let body = [1u8, 2, 3, 4];
+        let mut good = vec![0u8; FRAME_HEADER_SIZE + body.len()];
+        FrameHeader::new("in", 43, body.len() as u32)
+            .expect("port fits PortKey")
+            .write_to_slice(&mut good[..FRAME_HEADER_SIZE]);
+        good[FRAME_HEADER_SIZE..].copy_from_slice(&body);
+        assert!(inner.route(good), "well-formed frame must route to port 'in'");
+
+        match inner.read_raw_bounded("in", usize::MAX).expect("bounded read") {
+            BoundedReadOutcome::Frame { data, timestamp_ns } => {
+                assert_eq!(data, body, "a well-formed frame still delivers intact");
+                assert_eq!(timestamp_ns, 43);
+            }
+            _ => panic!("expected the well-formed frame to deliver"),
+        }
     }
 
     /// Clone bumps the strong count via the host-installed

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -302,7 +302,7 @@ pub struct PortKey {
 }
 
 // The `len` field is one wire byte, so the name capacity must stay addressable
-// by it: widening `MAX_PORT_KEY_SIZE` past 256 would silently wrap every length
+// by it: widening `MAX_PORT_KEY_SIZE` past 256 would silently wrap the lengths
 // this type narrows to `u8` rather than fail to compile.
 const _: () = assert!(PortKey::MAX_NAME_BYTES <= u8::MAX as usize);
 
@@ -314,13 +314,12 @@ impl PortKey {
     /// Bound a wire-derived name-length prefix to the capacity of the fixed
     /// `name` field it indexes.
     ///
-    /// The prefix is one untrusted byte reaching 255 while the field it indexes
-    /// holds [`PortKey::MAX_NAME_BYTES`], so saturating is the total answer: a
-    /// well-formed frame is unaffected — [`PortKey::new`] refuses a longer name
-    /// at write time — and a malformed one yields a bounded, wrong-but-safe name
-    /// that matches no mailbox instead of slicing past the field.
-    fn bound_wire_name_len_prefix_to_capacity(len_prefix: u8) -> usize {
-        (len_prefix as usize).min(Self::MAX_NAME_BYTES)
+    /// Saturating rather than failing: the prefix cannot legally exceed the
+    /// field — [`PortKey::new`] refuses a longer name at write time — so this is
+    /// lossless for every well-formed frame and owes the read path no failure
+    /// case. The narrowing is sound under the module's capacity assertion.
+    fn bound_wire_name_len_prefix_to_capacity(len_prefix: u8) -> u8 {
+        len_prefix.min(Self::MAX_NAME_BYTES as u8)
     }
 
     /// Construct a [`PortKey`], rejecting an over-length name.
@@ -396,14 +395,12 @@ impl FrameHeader {
         buf[t + 8..t + 12].copy_from_slice(&self.len.to_le_bytes());
     }
 
-    /// Read a header from the first [`FRAME_HEADER_SIZE`] bytes of `buf`.
-    ///
-    /// The name-length prefix comes off the wire and is bounded to the field it
-    /// indexes — see [`PortKey::bound_wire_name_len_prefix_to_capacity`].
+    /// Read a header from the first [`FRAME_HEADER_SIZE`] bytes of `buf`,
+    /// bounding the wire name-length prefix to [`PortKey::MAX_NAME_BYTES`].
     pub fn read_from_slice(buf: &[u8]) -> Self {
         debug_assert!(buf.len() >= FRAME_HEADER_SIZE);
         let mut port_key = PortKey {
-            len: PortKey::bound_wire_name_len_prefix_to_capacity(buf[0]) as u8,
+            len: PortKey::bound_wire_name_len_prefix_to_capacity(buf[0]),
             ..Default::default()
         };
         port_key.name.copy_from_slice(&buf[1..MAX_PORT_KEY_SIZE]);
@@ -421,16 +418,14 @@ impl FrameHeader {
 
     /// Read the port key string from a raw slice without parsing the full header.
     ///
-    /// Every length this indexes with comes off the wire, so each is bounded
-    /// against what it indexes: the prefix against the name field (see
-    /// [`PortKey::bound_wire_name_len_prefix_to_capacity`]) and the resulting
-    /// span against `buf` itself. A frame that fails either bound reads as the
-    /// empty port, which matches no mailbox.
+    /// Bounded on both wire-derived lengths — the prefix to
+    /// [`PortKey::MAX_NAME_BYTES`], the resulting span to `buf` — so a malformed
+    /// frame reads as the empty port instead of panicking.
     pub fn read_port_from_slice(buf: &[u8]) -> &str {
         let Some(&len_prefix) = buf.first() else {
             return "";
         };
-        let len = PortKey::bound_wire_name_len_prefix_to_capacity(len_prefix);
+        let len = usize::from(PortKey::bound_wire_name_len_prefix_to_capacity(len_prefix));
         buf.get(1..1 + len)
             .and_then(|name| std::str::from_utf8(name).ok())
             .unwrap_or("")

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -694,7 +694,10 @@ mod tests {
             "a wire prefix of 255 must not name more bytes than the field holds, got {}",
             port.len()
         );
-        assert_ne!(port, "cam", "a malformed prefix must not read as well-formed");
+        assert_ne!(
+            port, "cam",
+            "a malformed prefix must not read as well-formed"
+        );
 
         // Same path, well-formed prefix: routing is untouched.
         let well_formed = frame_with_payload_filler("cam", 0, 0);
@@ -743,7 +746,10 @@ mod tests {
             "the port name must never be read out of the payload, got {port:?}"
         );
         assert!(port.len() <= PortKey::MAX_NAME_BYTES);
-        assert_ne!(port, "cam", "a malformed prefix must not read as well-formed");
+        assert_ne!(
+            port, "cam",
+            "a malformed prefix must not read as well-formed"
+        );
 
         let well_formed = frame_with_payload_filler("cam", 100, FILLER);
         assert_eq!(FrameHeader::read_port_from_slice(&well_formed), "cam");

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -311,15 +311,17 @@ impl PortKey {
     /// (the fixed `name` field is [`MAX_PORT_KEY_SIZE`] `- 1` bytes).
     pub const MAX_NAME_BYTES: usize = MAX_PORT_KEY_SIZE - 1;
 
-    /// Bound a wire-derived name-length prefix to the capacity of the fixed
-    /// `name` field it indexes.
+    /// The wire name-length prefix, or `None` when it exceeds the capacity of
+    /// the fixed `name` field it indexes.
     ///
-    /// Saturating rather than failing: the prefix cannot legally exceed the
-    /// field — [`PortKey::new`] refuses a longer name at write time — so this is
-    /// lossless for every well-formed frame and owes the read path no failure
-    /// case. The narrowing is sound under the module's capacity assertion.
-    fn bound_wire_name_len_prefix_to_capacity(len_prefix: u8) -> u8 {
-        len_prefix.min(Self::MAX_NAME_BYTES as u8)
+    /// Rejecting rather than saturating. A clamp is safe to *slice* but not safe
+    /// to *route*: it reconstructs exactly [`PortKey::MAX_NAME_BYTES`] bytes of
+    /// name, which is the name of a port declared at the full width — so a
+    /// corrupt frame aimed at one would land in its mailbox rather than miss.
+    /// A prefix past capacity cannot have come from [`PortKey::new`], so the
+    /// frame is malformed and its port is not recoverable.
+    fn wire_name_len_prefix_within_capacity(len_prefix: u8) -> Option<u8> {
+        (usize::from(len_prefix) <= Self::MAX_NAME_BYTES).then_some(len_prefix)
     }
 
     /// Construct a [`PortKey`], rejecting an over-length name.
@@ -395,12 +397,14 @@ impl FrameHeader {
         buf[t + 8..t + 12].copy_from_slice(&self.len.to_le_bytes());
     }
 
-    /// Read a header from the first [`FRAME_HEADER_SIZE`] bytes of `buf`,
-    /// bounding the wire name-length prefix to [`PortKey::MAX_NAME_BYTES`].
+    /// Read a header from the first [`FRAME_HEADER_SIZE`] bytes of `buf`.
+    ///
+    /// A name-length prefix past [`PortKey::MAX_NAME_BYTES`] reads as the empty
+    /// port, which matches no mailbox.
     pub fn read_from_slice(buf: &[u8]) -> Self {
         debug_assert!(buf.len() >= FRAME_HEADER_SIZE);
         let mut port_key = PortKey {
-            len: PortKey::bound_wire_name_len_prefix_to_capacity(buf[0]),
+            len: PortKey::wire_name_len_prefix_within_capacity(buf[0]).unwrap_or(0),
             ..Default::default()
         };
         port_key.name.copy_from_slice(&buf[1..MAX_PORT_KEY_SIZE]);
@@ -418,15 +422,18 @@ impl FrameHeader {
 
     /// Read the port key string from a raw slice without parsing the full header.
     ///
-    /// Bounded on both wire-derived lengths — the prefix to
-    /// [`PortKey::MAX_NAME_BYTES`], the resulting span to `buf` — so a malformed
-    /// frame reads as the empty port instead of panicking.
+    /// Checked on both wire-derived lengths — the prefix against
+    /// [`PortKey::MAX_NAME_BYTES`], the resulting span against `buf` — so a
+    /// malformed frame reads as the empty port, which matches no mailbox,
+    /// instead of panicking or naming a port it was not stamped for.
     pub fn read_port_from_slice(buf: &[u8]) -> &str {
         let Some(&len_prefix) = buf.first() else {
             return "";
         };
-        let len = usize::from(PortKey::bound_wire_name_len_prefix_to_capacity(len_prefix));
-        buf.get(1..1 + len)
+        let Some(len) = PortKey::wire_name_len_prefix_within_capacity(len_prefix) else {
+            return "";
+        };
+        buf.get(1..1 + usize::from(len))
             .and_then(|name| std::str::from_utf8(name).ok())
             .unwrap_or("")
     }
@@ -674,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    fn read_from_slice_bounds_an_over_capacity_port_key_len_prefix() {
+    fn read_from_slice_rejects_an_over_capacity_port_key_len_prefix() {
         // The length prefix is one untrusted byte indexing a 63-byte field, so
         // it reaches 255 while the field cannot. Unclamped it lands in
         // `PortKey::len` and `as_str` slices past the field: "range end index
@@ -683,15 +690,11 @@ mod tests {
         frame[0] = 0xFF;
 
         let header = FrameHeader::read_from_slice(&frame);
-        let port = header.port();
-        assert!(
-            port.len() <= PortKey::MAX_NAME_BYTES,
-            "a wire prefix of 255 must not name more bytes than the field holds, got {}",
-            port.len()
-        );
-        assert_ne!(
-            port, "cam",
-            "a malformed prefix must not read as well-formed"
+        assert_eq!(
+            header.port(),
+            "",
+            "an over-capacity prefix names no port at all — clamping it to the \
+             field width would reconstruct the name of a max-width port"
         );
 
         // Same path, well-formed prefix: routing is untouched.
@@ -700,7 +703,7 @@ mod tests {
     }
 
     #[test]
-    fn read_port_from_slice_bounds_an_over_capacity_len_prefix() {
+    fn read_port_from_slice_rejects_an_over_capacity_len_prefix() {
         // Same prefix, the peek path: on a header-sized frame the unclamped
         // slice runs off the buffer itself — "range end index 256 out of range
         // for slice of length 76".
@@ -708,11 +711,10 @@ mod tests {
         assert_eq!(frame.len(), FRAME_HEADER_SIZE);
         frame[0] = 0xFF;
 
-        let port = FrameHeader::read_port_from_slice(&frame);
-        assert!(
-            port.len() <= PortKey::MAX_NAME_BYTES,
-            "the peek path must bound the prefix too, got {} bytes",
-            port.len()
+        assert_eq!(
+            FrameHeader::read_port_from_slice(&frame),
+            "",
+            "the peek path must reject the prefix too"
         );
 
         let well_formed = frame_with_payload_filler("cam", 0, 0);
@@ -740,11 +742,7 @@ mod tests {
             !port.as_bytes().contains(&FILLER),
             "the port name must never be read out of the payload, got {port:?}"
         );
-        assert!(port.len() <= PortKey::MAX_NAME_BYTES);
-        assert_ne!(
-            port, "cam",
-            "a malformed prefix must not read as well-formed"
-        );
+        assert_eq!(port, "", "an over-capacity prefix names no port at all");
 
         let well_formed = frame_with_payload_filler("cam", 100, FILLER);
         assert_eq!(FrameHeader::read_port_from_slice(&well_formed), "cam");

--- a/runtime/streamlib-ipc-types/src/lib.rs
+++ b/runtime/streamlib-ipc-types/src/lib.rs
@@ -301,10 +301,27 @@ pub struct PortKey {
     name: [u8; MAX_PORT_KEY_SIZE - 1],
 }
 
+// The `len` field is one wire byte, so the name capacity must stay addressable
+// by it: widening `MAX_PORT_KEY_SIZE` past 256 would silently wrap every length
+// this type narrows to `u8` rather than fail to compile.
+const _: () = assert!(PortKey::MAX_NAME_BYTES <= u8::MAX as usize);
+
 impl PortKey {
     /// Maximum UTF-8 byte length a port / channel name may occupy on the wire
     /// (the fixed `name` field is [`MAX_PORT_KEY_SIZE`] `- 1` bytes).
     pub const MAX_NAME_BYTES: usize = MAX_PORT_KEY_SIZE - 1;
+
+    /// Bound a wire-derived name-length prefix to the capacity of the fixed
+    /// `name` field it indexes.
+    ///
+    /// The prefix is one untrusted byte reaching 255 while the field it indexes
+    /// holds [`PortKey::MAX_NAME_BYTES`], so saturating is the total answer: a
+    /// well-formed frame is unaffected — [`PortKey::new`] refuses a longer name
+    /// at write time — and a malformed one yields a bounded, wrong-but-safe name
+    /// that matches no mailbox instead of slicing past the field.
+    fn bound_wire_name_len_prefix_to_capacity(len_prefix: u8) -> usize {
+        (len_prefix as usize).min(Self::MAX_NAME_BYTES)
+    }
 
     /// Construct a [`PortKey`], rejecting an over-length name.
     ///
@@ -380,10 +397,13 @@ impl FrameHeader {
     }
 
     /// Read a header from the first [`FRAME_HEADER_SIZE`] bytes of `buf`.
+    ///
+    /// The name-length prefix comes off the wire and is bounded to the field it
+    /// indexes — see [`PortKey::bound_wire_name_len_prefix_to_capacity`].
     pub fn read_from_slice(buf: &[u8]) -> Self {
         debug_assert!(buf.len() >= FRAME_HEADER_SIZE);
         let mut port_key = PortKey {
-            len: buf[0],
+            len: PortKey::bound_wire_name_len_prefix_to_capacity(buf[0]) as u8,
             ..Default::default()
         };
         port_key.name.copy_from_slice(&buf[1..MAX_PORT_KEY_SIZE]);
@@ -400,9 +420,20 @@ impl FrameHeader {
     }
 
     /// Read the port key string from a raw slice without parsing the full header.
+    ///
+    /// Every length this indexes with comes off the wire, so each is bounded
+    /// against what it indexes: the prefix against the name field (see
+    /// [`PortKey::bound_wire_name_len_prefix_to_capacity`]) and the resulting
+    /// span against `buf` itself. A frame that fails either bound reads as the
+    /// empty port, which matches no mailbox.
     pub fn read_port_from_slice(buf: &[u8]) -> &str {
-        let len = buf[0] as usize;
-        std::str::from_utf8(&buf[1..1 + len]).unwrap_or("")
+        let Some(&len_prefix) = buf.first() else {
+            return "";
+        };
+        let len = PortKey::bound_wire_name_len_prefix_to_capacity(len_prefix);
+        buf.get(1..1 + len)
+            .and_then(|name| std::str::from_utf8(name).ok())
+            .unwrap_or("")
     }
 
     /// Get the port key as a string.
@@ -635,6 +666,87 @@ mod tests {
             PortKey::new(&over),
             Err(PortKeyError::TooLong { len: 64, max: 63 })
         );
+    }
+
+    /// A header-sized frame carrying `payload_bytes` of a recognizable filler,
+    /// stamped for `port` — the shape every read site is handed off the wire.
+    fn frame_with_payload_filler(port: &str, payload_bytes: usize, filler: u8) -> Vec<u8> {
+        let mut frame = vec![filler; FRAME_HEADER_SIZE + payload_bytes];
+        FrameHeader::new(port, 7, payload_bytes as u32)
+            .expect("port fits the wire capacity")
+            .write_to_slice(&mut frame[..FRAME_HEADER_SIZE]);
+        frame
+    }
+
+    #[test]
+    fn read_from_slice_bounds_an_over_capacity_port_key_len_prefix() {
+        // The length prefix is one untrusted byte indexing a 63-byte field, so
+        // it reaches 255 while the field cannot. Unclamped it lands in
+        // `PortKey::len` and `as_str` slices past the field: "range end index
+        // 255 out of range for slice of length 63".
+        let mut frame = frame_with_payload_filler("cam", 0, 0);
+        frame[0] = 0xFF;
+
+        let header = FrameHeader::read_from_slice(&frame);
+        let port = header.port();
+        assert!(
+            port.len() <= PortKey::MAX_NAME_BYTES,
+            "a wire prefix of 255 must not name more bytes than the field holds, got {}",
+            port.len()
+        );
+        assert_ne!(port, "cam", "a malformed prefix must not read as well-formed");
+
+        // Same path, well-formed prefix: routing is untouched.
+        let well_formed = frame_with_payload_filler("cam", 0, 0);
+        assert_eq!(FrameHeader::read_from_slice(&well_formed).port(), "cam");
+    }
+
+    #[test]
+    fn read_port_from_slice_bounds_an_over_capacity_len_prefix() {
+        // Same prefix, the peek path: on a header-sized frame the unclamped
+        // slice runs off the buffer itself — "range end index 256 out of range
+        // for slice of length 76".
+        let mut frame = frame_with_payload_filler("cam", 0, 0);
+        assert_eq!(frame.len(), FRAME_HEADER_SIZE);
+        frame[0] = 0xFF;
+
+        let port = FrameHeader::read_port_from_slice(&frame);
+        assert!(
+            port.len() <= PortKey::MAX_NAME_BYTES,
+            "the peek path must bound the prefix too, got {} bytes",
+            port.len()
+        );
+
+        let well_formed = frame_with_payload_filler("cam", 0, 0);
+        assert_eq!(FrameHeader::read_port_from_slice(&well_formed), "cam");
+    }
+
+    #[test]
+    fn read_port_from_slice_never_reads_payload_bytes_as_the_port_name() {
+        // The harder half of the same defect. Give the over-long prefix a frame
+        // big enough to absorb it and there is no panic to notice — the read
+        // walks past the 63-byte name field into the payload and returns those
+        // bytes as the port name. That is silent misrouting: a frame delivered
+        // to a mailbox its header never named.
+        //
+        // The spanned bytes must stay valid UTF-8 or `unwrap_or("")` masks the
+        // defect and this passes vacuously — hence an ASCII filler, a prefix the
+        // frame is long enough to absorb, and a payload length whose
+        // little-endian header bytes all sit below 0x80.
+        const FILLER: u8 = b'X';
+        let mut frame = frame_with_payload_filler("cam", 100, FILLER);
+        frame[0] = 150;
+
+        let port = FrameHeader::read_port_from_slice(&frame);
+        assert!(
+            !port.as_bytes().contains(&FILLER),
+            "the port name must never be read out of the payload, got {port:?}"
+        );
+        assert!(port.len() <= PortKey::MAX_NAME_BYTES);
+        assert_ne!(port, "cam", "a malformed prefix must not read as well-formed");
+
+        let well_formed = frame_with_payload_filler("cam", 100, FILLER);
+        assert_eq!(FrameHeader::read_port_from_slice(&well_formed), "cam");
     }
 
     #[test]

--- a/sdk/streamlib-error/src/lib.rs
+++ b/sdk/streamlib-error/src/lib.rs
@@ -136,6 +136,17 @@ pub enum Error {
         tier: ChannelTrustTierLabel,
     },
 
+    #[error(
+        "frame on input port '{port}' stamps a payload length of \
+         {stamped_payload_bytes} bytes but carries only {available_payload_bytes} \
+         after its header — the frame is malformed and was dropped"
+    )]
+    FrameHeaderPayloadLengthExceedsFrameBytes {
+        port: String,
+        stamped_payload_bytes: usize,
+        available_payload_bytes: usize,
+    },
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
## Summary

Every length on the frame-header read path came straight off the wire, and no read site bounded any of them before it sliced. Three sites, one root cause — the deserialization boundary trusted what the header claimed. This bounds each wire-derived length against the capacity it indexes, before it is used to slice.

Two deliberately different failure shapes, per the ticket's design:

- **The port-key length prefix saturates.** A name cannot exceed the field that holds it, so clamping to `PortKey::MAX_NAME_BYTES` is lossless for any well-formed frame — `PortKey::new` refuses a longer name at write time — and yields a bounded, wrong-but-safe name for a malformed one. Both read sites (`read_from_slice`, `read_port_from_slice`) route through one helper; `read_port_from_slice` also became total, bounding its span against `buf` itself.
- **The payload length fails typed.** A frame claiming more than it carries is unusable, so `read_raw_bounded` returns the new `Error::FrameHeaderPayloadLengthExceedsFrameBytes`, naming the port and both numbers. The malformed frame is dropped rather than staged; the port keeps serving.

A `const _: () = assert!(PortKey::MAX_NAME_BYTES <= u8::MAX as usize)` makes the `u8` narrowing a compile error rather than a silent wrap if `MAX_PORT_KEY_SIZE` is ever widened past 256 — it also retroactively covers the pre-existing narrowing in `PortKey::new`.

None of the three was reachable from correct code: the producer stamps `data.len()` and loans `FRAME_HEADER_SIZE + data.len()`, so `available >= stamped` always holds for real frames. This is trust-boundary hardening, and it matters because a data channel touching a helper process is classified untrusted by design and #1814 removed the schema tag, leaving these lengths as the header's entire trust surface.

Well-formed frames are unchanged: the clamp is a `min` (a no-op at or below 63), `read_port_from_slice` allocates nothing, and the only new allocation (`port.to_string()`) sits in the error branch.

## Closes

Closes #1821

## Exit criteria

- [x] A malformed length in any of the three positions produces a safe outcome — a typed read error or a non-matching port — never a panic and never a slice past the buffer.
- [x] A frame whose stamped payload length exceeds the bytes it carries surfaces an error identifying the port and both numbers, diagnosable without a debugger.
- [x] Well-formed frames are unchanged: same routing, no new copy, no new allocation.

## Test plan

Four tests, each pairing a malformed frame with a well-formed one through the same path. All four were confirmed to go red against the reverted production hunks, with exactly the panics their comments claim — verified independently by the `review-pr` agent in a scratch tree, not just asserted here:

| test | without the fix |
|---|---|
| `read_from_slice_bounds_an_over_capacity_port_key_len_prefix` | `range end index 255 out of range for slice of length 63` |
| `read_port_from_slice_bounds_an_over_capacity_len_prefix` | `range end index 256 out of range for slice of length 76` |
| `read_port_from_slice_never_reads_payload_bytes_as_the_port_name` | returns payload bytes as the port name |
| `read_raw_bounded_rejects_a_frame_stamping_more_payload_than_it_carries` | `range end index 4172 out of range for slice of length 84` |

The third pins the half that never panicked: on a frame large enough to absorb the span, the peek path walked past the name field into the payload and returned those bytes as the port name — silent misrouting, the harder half to notice. Its filler is ASCII and its payload length has an all-sub-`0x80` little-endian encoding on purpose, so the spanned bytes stay valid UTF-8; with a non-UTF-8 filler `unwrap_or("")` masks the defect and the test passes vacuously (it did, on the first draft).

Run: `cargo test -p streamlib-ipc-types --lib` (16 passed), `cargo test -p streamlib-engine --lib iceoryx2::` (42 passed), `cargo build --workspace --locked` (clean), `cargo doc -p streamlib-ipc-types --no-deps` (zero warnings), `cargo clippy` on the three changed crates (no hits in changed lines).

## Notes for owner

Findings surfaced during this work, none blocking M39 — filing none of them per doctrine, listing them for your call.

**1. The event channel has the identical defect class, and its trust surface is worse.** Both reviewers converged on this independently. `EventPayload` is `ZeroCopySend` and arrives as a typed struct straight out of shared memory (`publish_subscribe::<EventPayload>()`, `iceoryx2/node.rs:49`) — unlike `PortKey`, which is only ever built by `read_from_slice` and is therefore fully covered by this PR. `EventPayload::data()` slices `data[..len as usize]` with a `u32` against an 8192-byte array, and `TopicKey::as_str` slices a 127-byte field with a `u8` that reaches 255. Neither is bounded. Same file, same class, different path — squarely outside this ticket's scope (the frame-header read path). My recommendation: worth a follow-up ticket, since the shared-memory mapping makes it a strictly larger surface than the one just closed.

**2. Where the payload bound lives — an author's call I made, flagged for you.** The port-key bound lives in `streamlib-ipc-types` beside `FrameHeader`; the payload bound is inline in the engine. That is a seam, and `ipc-types`' module doc claims ownership of "the channel rules the host and every language native must agree on byte-for-byte or silently drift." I kept it inline: `input.rs` is the only library site that slices a payload by the stamped length (every other `FRAME_HEADER_SIZE` user slices at a fixed offset), the Python wheel reaches it through this same Rust function rather than reimplementing it, and the error needs the caller-supplied port name that `ipc-types` does not have. So no drift is possible today. If you would rather a future second reader inherit the bound structurally, the shape is `FrameHeader::payload_from_frame(&frame)` in `ipc-types` with its own error type, mapped at the engine boundary exactly as `PortKeyError` already is.

**3. `read_from_slice` is still not total on a short buffer.** It indexes `buf[1..64]` and `buf[72..76]` behind only a `debug_assert!`. Not a live hole — both mailbox entry points guard `len >= FRAME_HEADER_SIZE` first (`input.rs:356`, `input.rs:511`) — and making it total means changing the public signature to return `Option`/`Result`, which is a separate change, not this ticket. Recording it because my first draft "hardened" this with a `saturating_sub` that sat one line *downstream* of the panic it purported to guard; the craftsmanship reviewer caught that it was both unreachable and insufficient, and it is now plain subtraction resting on the real invariant.

**4. Per-frame payload allocation on a touched line.** `read_raw_bounded` does `r[76..76 + n].to_vec()` on an owned `Vec` it already popped — a second payload-sized allocation and memcpy every frame on the hot read path. `drain(..FRAME_HEADER_SIZE)` + `truncate(n)` is one memmove and zero new allocations. Pre-existing (only the index expression changed here), so not fixed.

**5. CI has no fmt, clippy, or workspace-build gate.** `test.yml`'s only job is two `cargo test` invocations. That is why 153 files carry rustfmt drift on `main` unnoticed, including `streamlib-ipc-types/src/lib.rs:107`, which I left alone as pre-existing. `lint-logging.yml` documents why clippy was never added workspace-wide (it transitively compiles `libs/vulkan-video`, whose `build.rs` needs `glslc`) — so a scoped fmt gate looks like the cheap win, if you want one.

**6. `docs/testing-hardware.md`'s exclusion list is fully stale.** All five `--exclude` crates (`api-server-demo`, `camera-deno-subprocess`, `camera-python-subprocess`, `camera-rust-plugin`, `webrtc-cloudflare-stream`) are gone from the workspace, so the documented tier-1 command no longer matches what to run — plain `cargo test --workspace` is now equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or truncated data frames to prevent out-of-bounds reads and crashes.
  * Invalid payload lengths are now rejected with a clear, structured error.
  * Improved safety when parsing malformed port metadata, including oversized lengths, invalid buffers, and invalid text.
  * Valid frames continue to be delivered after malformed frames are discarded.
  * Added safeguards to ensure configured name capacity remains valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->