### PR TITLE
chore(flow): path guards ask instead of deny — the owner overrides at the prompt

### DIFF
--- a/.claude/hooks/plan-gate.sh
+++ b/.claude/hooks/plan-gate.sh
@@ -8,9 +8,10 @@
 #   xtask/                       requires .claude/state/active-ticket.json
 #                                (set by /implement after the owner confirms the plan)
 #
-# Contract: exit 0 + JSON permissionDecision:"deny" blocks the edit with the reason;
-# plain exit 0 defers to the normal permission flow. Owner escape hatch: create the
-# marker file by hand.
+# Contract: exit 0 + JSON permissionDecision:"ask" routes the edit to the owner with the
+# reason; plain exit 0 defers to the normal permission flow. The gate informs and slows
+# down — it does not wall off. An edit the owner approves at the prompt proceeds without
+# a marker file, so a stale scope can never strand work that has to land.
 
 input="$(cat)"
 fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
@@ -19,8 +20,8 @@ fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
 root="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 state="$root/.claude/state"
 
-deny() {
-  jq -n --arg r "$1" '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+ask() {
+  jq -n --arg r "$1" '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "ask", permissionDecisionReason: $r}}'
   exit 0
 }
 
@@ -33,11 +34,11 @@ esac
 case "$rel" in
   docs/plan/*)
     [ -f "$state/plan-session" ] && exit 0
-    deny 'docs/plan/ is the locked decision source. Plan edits happen only inside /align, /propose-change, /ship-change, or /pivot — those skills create .claude/state/plan-session for the session. Owner escape hatch: touch .claude/state/plan-session yourself.'
+    ask 'docs/plan/ is the decision source. Plan edits belong inside /align, /propose-change, /ship-change, or /pivot — those skills create .claude/state/plan-session for the session. Approve to edit anyway, or decline and run the skill.'
     ;;
   runtime/*|sdk/*|adapters/*|xtask/*)
     [ -f "$state/active-ticket.json" ] && exit 0
-    deny 'Source edits happen only inside /implement with an owner-confirmed ticket (.claude/state/active-ticket.json is missing). Run /implement — or, as the owner escape hatch, create the marker by hand.'
+    ask 'Source edits belong inside /implement with an owner-confirmed ticket (.claude/state/active-ticket.json is missing). Approve to edit anyway — the change lands without ticket traceability — or decline and run /implement.'
     ;;
 esac
 

--- a/.claude/rules/flow.md
+++ b/.claude/rules/flow.md
@@ -11,6 +11,13 @@ paths:
   agents, skills, hooks, settings) or the issue templates changes in a dedicated PR that explains
   why — never mixed into feature work. A session never edits the agents, rules, or skills it is
   itself using.
+- **Path guards ask; they never deny.** `permissions.deny` and a hook's `"deny"` decision are both
+  banned — use `ask` and let the owner resolve it at the prompt. A hard wall cannot be overridden
+  in the moment, so a scope written months ago outlives the reason for it and blocks a removal the
+  plan already committed to; the session then routes around the wall, which is where the damage
+  happens. Prompting keeps the friction and the reason while leaving the owner a way through.
+  This is not permission to bend doctrine: the rules still say what is right, and an approved
+  prompt only means the owner judged this edit to be the exception.
 - **A new agent definition PR must state three things:** the non-derivable knowledge the agent
   captures, why the existing agents don't already cover it, and its model tier.
 - **Model tiers:** implementation and reasoning agents run `opus`; mechanical / prescribed-steps

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,9 +18,7 @@
     ],
     "ask": [
       "Edit(./docs/plan/**)",
-      "Write(./docs/plan/**)"
-    ],
-    "deny": [
+      "Write(./docs/plan/**)",
       "Edit(./examples/**)",
       "Edit(./packages/audio/**)",
       "Edit(./packages/camera/**)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,10 +21,13 @@ ONE core system per concern — extend the existing system, never build a parall
 
 - All work enters through `/plan` — it reads the plan statuses and the tracker and says
   which skill is next.
-- Source edits (`runtime/ sdk/ adapters/ xtask/`) happen only inside `/implement`
-  with an owner-confirmed ticket — hook-enforced via `.claude/state/active-ticket.json`.
-- Plan edits (`docs/plan/**`) happen only inside `/align`, `/propose-change`,
-  `/ship-change`, or `/pivot` — hook- and ask-rule-enforced.
+- Source edits (`runtime/ sdk/ adapters/ xtask/`) belong inside `/implement` with an
+  owner-confirmed ticket — the hook prompts via `.claude/state/active-ticket.json`.
+- Plan edits (`docs/plan/**`) belong inside `/align`, `/propose-change`,
+  `/ship-change`, or `/pivot` — the hook and the ask rules prompt.
+- **Guardrails prompt; they never wall off.** Every path guard routes to the owner rather
+  than refusing, so a scope written months ago can't strand work that has to land. The
+  doctrine still decides what is *right* — a prompt is not permission to bend a rule.
 - Lifecycle: `/align` (decide) → `/propose-change` (delta) → `/derive-tickets` (as few
   tracer bullets as the change honestly needs) →
   `/implement` (build) → `/ship-change` (fold + prove removals). `/pivot` for direction


### PR DESCRIPTION
Operating-model change, its own PR per `.claude/rules/flow.md`. No feature work rides along.

## Why

A `deny` cannot be overridden in the moment. That is fine while the scope is current and
actively harmful once it is not — the guard outlives the reason for it, and the work either
stops or goes around.

It went around, on 2026-08-11:

`Edit(docs/architecture/schema-identity-and-packaging.md)` was frozen 2026-07-14 in #1352,
batched in as a "frozen doc" alongside `docs/logging-schema.md` and `docs/testing-hardware.md`.
A month later, #1833's entire job was scrubbing the schema-free-ports removals out of that exact
file — the last thing standing between `schema-free-ports.md` and its archive. The freeze had
nothing to say about that; it simply predated it.

What followed is the part worth keeping:

- The session could not edit the file, so it produced a patch for the owner to apply by hand.
  The patch's path rewrite silently no-opped, making it a **rename** — delete the doc, create
  `tmp/scrubbed-copy.md`. `git apply --check` passed, because the patch was valid; it just
  targeted the wrong path.
- Applied, it deleted 643 lines. The `/ship-change` removed-gate then reported
  `clean: 12 REMOVED bullets` — **green because the file was gone**. That is precisely the
  self-certification the gate exists to prevent, reached by a different road, and it would have
  archived the change on that evidence.
- The same manual edit collapsed the `deny` array into `ask`, downgrading
  `Edit(vendor/tatolab-vulkanalia*/**)`, `Edit(LICENSE)`, `Edit(LICENSES/**)` and
  `docs/license/**` — the guards CLAUDE.md calls load-bearing — without anyone intending it.

The wall prevented no bad edit. It relocated one somewhere worse, where nothing was watching.

## What changes

- **`.claude/settings.json`** — all 22 `permissions.deny` entries move to `ask`. The `deny` key
  is gone; `ask` goes 2 → 24.
- **`.claude/hooks/plan-gate.sh`** — `permissionDecision` becomes `"ask"` on both gated paths
  (`docs/plan/**` without `plan-session`; `runtime|sdk|adapters|xtask` without
  `active-ticket.json`). Reasons rewritten to state the tradeoff of approving.
- **`CLAUDE.md`** / **`.claude/rules/flow.md`** — record the posture so a later session doesn't
  re-harden it, and state plainly that a prompt is not permission to bend doctrine.

## What does not change

Same paths, same reasons, same marker-file short-circuit — `plan-session` and
`active-ticket.json` still pass silently. Only the verdict changes: refusal becomes a prompt
carrying the reason. The doctrine that decides what is *right* is untouched: consumers are still
not contract sources, engine defects are still not bandaided downstream, BUSL is still not
negotiable.

The `/ship-change` removed-gate is **not** touched. It is the one guard that caught the real
problem here, and it gates evidence rather than access.

## Verification

```
$ python3 -c "import json;p=json.load(open('.claude/settings.json'))['permissions'];print('deny present:',' deny' in p, '| ask:',len(p['ask']))"
deny present: False | ask: 24
$ bash -n .claude/hooks/plan-gate.sh && echo OK
OK
$ echo '{"tool_input":{"file_path":"'$PWD'/runtime/streamlib-engine/src/lib.rs"}}' | CLAUDE_PROJECT_DIR=$PWD bash .claude/hooks/plan-gate.sh
  "permissionDecision": "ask",
$ touch .claude/state/plan-session   # marker still short-circuits
  (no output, exit 0)
$ # unrelated path defers silently
  (no output, exit 0)
```

## For your call

**Licensing.** CLAUDE.md already says `LICENSE`, `LICENSES/` and `docs/license/` are not modified
"without explicit approval" — an `ask` rule *is* that approval, so `deny` was stricter than the
written bar. If you want those four plus `vendor/tatolab-vulkanalia*` to stay unconditionally
hard, say so and I'll restore a `deny` array holding only those five. Everything else still
reaches `ask`.

**Ticket traceability.** The `runtime|sdk|adapters|xtask` guard now lets a source edit land on
approval without an `active-ticket.json`. That is the point, and it is also the one place this
trades away an audit trail. The prompt says so explicitly.

**Scope.** You asked for this "for the rest of the MVP." A permissions file can't express an
expiry, so this is simply the posture until changed. Worth a revisit when M39 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive approval prompts for gated edits to plans and source files.
  * Owners can approve or decline changes directly without creating marker files.
* **Documentation**
  * Updated guidance to clarify that path guardrails prompt for approval while preserving enforcement.
  * Clarified routing behavior and the distinction between guarded and unguarded operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->