### PR TITLE
chore(flow): recording a fact is not a decision — drop the doc-edit ceremony

### DIFF
--- a/.claude/hooks/plan-gate.sh
+++ b/.claude/hooks/plan-gate.sh
@@ -2,8 +2,6 @@
 # plan-gate (PreToolUse / Edit|Write): the enforcement layer of the plan-first
 # operating model (docs/plan/OPERATING-MODEL.md).
 #
-#   docs/plan/**                 requires .claude/state/plan-session
-#                                (set by /align, /propose-change, /ship-change, /pivot)
 #   runtime/ sdk/ adapters/
 #   xtask/                       requires .claude/state/active-ticket.json
 #                                (set by /implement after the owner confirms the plan)
@@ -12,6 +10,12 @@
 # reason; plain exit 0 defers to the normal permission flow. The gate informs and slows
 # down — it does not wall off. An edit the owner approves at the prompt proceeds without
 # a marker file, so a stale scope can never strand work that has to land.
+#
+# docs/plan/** is deliberately NOT gated here. A hook sees a path, never an intent, so it
+# cannot tell recording a fact from making a decision — it prompted on both, and the
+# every-time prompt on the factual majority is what taught sessions to escalate trivia.
+# That line is doctrine the session applies (CLAUDE.md §Recording facts vs deciding), not
+# a path match: facts land with the work, decisions go through the lifecycle skills.
 
 input="$(cat)"
 fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')"
@@ -32,10 +36,6 @@ case "$rel" in
 esac
 
 case "$rel" in
-  docs/plan/*)
-    [ -f "$state/plan-session" ] && exit 0
-    ask 'docs/plan/ is the decision source. Plan edits belong inside /align, /propose-change, /ship-change, or /pivot — those skills create .claude/state/plan-session for the session. Approve to edit anyway, or decline and run the skill.'
-    ;;
   runtime/*|sdk/*|adapters/*|xtask/*)
     [ -f "$state/active-ticket.json" ] && exit 0
     ask 'Source edits belong inside /implement with an owner-confirmed ticket (.claude/state/active-ticket.json is missing). Approve to edit anyway — the change lands without ticket traceability — or decline and run /implement.'

--- a/.claude/rules/flow.md
+++ b/.claude/rules/flow.md
@@ -18,6 +18,16 @@ paths:
   happens. Prompting keeps the friction and the reason while leaving the owner a way through.
   This is not permission to bend doctrine: the rules still say what is right, and an approved
   prompt only means the owner judged this edit to be the exception.
+- **Guard only what a wrong edit makes expensive to undo** — source without ticket traceability,
+  consumer trees, vendored sources, licence files. Never guard prose. A guard fires on a path and
+  cannot see intent, so guarding a directory whose edits are mostly routine records trains the
+  session to escalate trivia and the owner to click through without reading — which costs the
+  guard its meaning everywhere else. Judgement the session must exercise belongs in an always-on
+  rule (`CLAUDE.md`), not in an `ask` entry; a path-scoped rule file loads too late to govern the
+  decision to ask.
+- **Adding an `ask` entry or a hook branch needs the same justification as an agent.** State what
+  a wrong edit costs, why an always-on rule can't carry it, and what the session should do when it
+  fires. An entry no one can justify in those terms is friction, and friction is not free.
 - **A new agent definition PR must state three things:** the non-derivable knowledge the agent
   captures, why the existing agents don't already cover it, and its model tier.
 - **Model tiers:** implementation and reasoning agents run `opus`; mechanical / prescribed-steps

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,8 +17,6 @@
       "Bash(docker info *)"
     ],
     "ask": [
-      "Edit(./docs/plan/**)",
-      "Write(./docs/plan/**)",
       "Edit(./examples/**)",
       "Edit(./packages/audio/**)",
       "Edit(./packages/camera/**)",
@@ -37,10 +35,7 @@
       "Edit(vendor/tatolab-vulkanalia*/**)",
       "Edit(LICENSE)",
       "Edit(LICENSES/**)",
-      "Edit(docs/license/**)",
-      "Edit(docs/logging-schema.md)",
-      "Edit(docs/testing-hardware.md)",
-      "Edit(docs/architecture/schema-identity-and-packaging.md)"
+      "Edit(docs/license/**)"
     ]
   },
   "hooks": {

--- a/.claude/skills/align/SKILL.md
+++ b/.claude/skills/align/SKILL.md
@@ -10,20 +10,18 @@ The only skill that flips a plan section OPEN → DECIDED.
 
 1. Pick ONE section of `docs/plan/ARCHITECTURE.md` — the owner's choice. While §Product
    is OPEN, recommend it first: every ticket traces to that sentence or does not exist.
-2. `mkdir -p .claude/state && touch .claude/state/plan-session` — opens the plan-edit
-   gate for this session.
-3. Run `batch-grilling` over the section's open decisions, with the `glossary` skill
+2. Run `batch-grilling` over the section's open decisions, with the `glossary` skill
    active for term drift.
-4. As each decision lands, edit immediately (don't batch):
+3. As each decision lands, edit immediately (don't batch):
    - The section entry: DECIDED entries state WHAT, never why. Rationale goes to a
      `docs/decisions/` ADR that the entry links as `[ADR-name]`.
    - `docs/plan/diagrams/*.mmd` in the same breath, when the decision changes structure.
-   - Every plan edit surfaces a permission prompt — that is the owner gate working, not
-     an error.
-5. Done when the owner says the section is decided: restate the whole section back and
+   - Nothing prompts on a plan edit. The gate is this skill's own contract — the owner's
+     spoken yes, step 4 — not a permission dialog.
+4. Done when the owner says the section is decided: restate the whole section back and
    get the explicit yes.
-6. `rm -f .claude/state/plan-session`. Commit on a branch, open the PR — plan changes
-   merge only with the owner's review (CODEOWNERS).
+5. Commit on a branch, open the PR — plan changes merge only with the owner's review
+   (CODEOWNERS).
 
 Hard rule: no code, no tickets, no `changes/` files from this skill. Deciding and
 building never share a session.

--- a/.claude/skills/pivot/SKILL.md
+++ b/.claude/skills/pivot/SKILL.md
@@ -10,10 +10,8 @@ Only the owner invokes a pivot. Never propose one mid-implementation.
 
 1. Run `grilling` until the new direction is stated in five sentences or fewer and the
    owner confirms them verbatim.
-2. **Plan first**: `mkdir -p .claude/state && touch .claude/state/plan-session`;
-   rewrite the affected ARCHITECTURE.md sections — new DECIDED entries, invalidated
-   sections back to OPEN, diagrams updated. Rationale goes to an ADR. Then
-   `rm -f .claude/state/plan-session`.
+2. **Plan first**: rewrite the affected ARCHITECTURE.md sections — new DECIDED entries,
+   invalidated sections back to OPEN, diagrams updated. Rationale goes to an ADR.
 3. **Inventory the legacy** (read-only sweep): the code paths, docs, rules, skills,
    tickets, and milestones the old direction leaves behind. Present the inventory —
    under this model legacy is deleted, never kept running in parallel with the new

--- a/.claude/skills/propose-change/SKILL.md
+++ b/.claude/skills/propose-change/SKILL.md
@@ -20,8 +20,7 @@ this skill — route to `/align` first.
 2. **Recon, read-only.** Spawn the relevant domain experts to map current state before
    writing a word — proposals invented without reading the tree reference APIs that
    don't exist.
-3. `mkdir -p .claude/state && touch .claude/state/plan-session`, then write
-   `docs/plan/changes/<name>.md`:
+3. Write `docs/plan/changes/<name>.md`:
    - Sections typed `ADDED:` / `MODIFIED:` / `REMOVED:` against ARCHITECTURE.md.
      Every `- REMOVED: <pattern>` bullet is a grep pattern the ship gate will verify is
      gone.
@@ -30,8 +29,7 @@ this skill — route to `/align` first.
    - A factual gap you can resolve by reading the repo: resolve it. An architectural
      choice the plan doesn't state: write `[NEEDS DECISION]` with the options and your
      recommendation. **You may never resolve one yourself.**
-4. Still inside the marker window: flip the affected plan sections to
-   `IN-FLIGHT (→ <name>)`. Then `rm -f .claude/state/plan-session`.
+4. Flip the affected plan sections to `IN-FLIGHT (→ <name>)`.
 5. **Stop.** Present the proposal. The owner approves in their own words before
    `/derive-tickets` may run — and a proposal with an unresolved `[NEEDS DECISION]`
    cannot be approved yet.

--- a/.claude/skills/ship-change/SKILL.md
+++ b/.claude/skills/ship-change/SKILL.md
@@ -15,17 +15,15 @@ sequence — no improvisation:
    this skill re-runs after. Never archive with residue. `MALFORMED BULLET` is not
    residue and never becomes a ticket — the bullet cannot prove anything as written, so
    the change file is corrected in place (grammar: `docs/plan/changes/README.md`).
-2. `mkdir -p .claude/state && touch .claude/state/plan-session`
-3. Fold each `ADDED`/`MODIFIED` section into `docs/plan/ARCHITECTURE.md`; flip the
+2. Fold each `ADDED`/`MODIFIED` section into `docs/plan/ARCHITECTURE.md`; flip the
    affected sections `IN-FLIGHT` → `SHIPPED`, each with a `<!-- verify: <glob or
    command> -->` marker; delete the plan text the `REMOVED` sections retire.
-4. Update `docs/plan/diagrams/*.mmd` to match. (The Excalidraw view, when wanted, is
+3. Update `docs/plan/diagrams/*.mmd` to match. (The Excalidraw view, when wanted, is
    regenerated from the `.mmd` via mermaid-to-excalidraw or the Excalidraw app's Mermaid
    import — the `.mmd` is the source and is never edited from the Excalidraw side.)
-5. `git mv docs/plan/changes/<name>.md docs/plan/changes/archive/<YYYY-MM-DD>-<name>.md`
+4. `git mv docs/plan/changes/<name>.md docs/plan/changes/archive/<YYYY-MM-DD>-<name>.md`
    — the date is the last ticket's merge date from `gh pr view`, not today's guess.
-6. `rm -f .claude/state/plan-session`; branch, open the PR (plan changes merge only with
-   the owner's review).
+5. Branch, open the PR (plan changes merge only with the owner's review).
 
 Completion = the archive PR is open and the gate script's clean run is pasted into its
 body.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,14 @@ ONE core system per concern — extend the existing system, never build a parall
   which skill is next.
 - Source edits (`runtime/ sdk/ adapters/ xtask/`) belong inside `/implement` with an
   owner-confirmed ticket — the hook prompts via `.claude/state/active-ticket.json`.
-- Plan edits (`docs/plan/**`) belong inside `/align`, `/propose-change`,
-  `/ship-change`, or `/pivot` — the hook and the ask rules prompt.
+- Plan *decisions* belong inside `/align`, `/propose-change`, `/ship-change`, or `/pivot`.
+  Plan and doc *records* do not — see §Recording facts vs deciding. Nothing prompts on a
+  doc edit; the distinction is the session's to apply, because a path guard can't see it.
 - **Guardrails prompt; they never wall off.** Every path guard routes to the owner rather
   than refusing, so a scope written months ago can't strand work that has to land. The
   doctrine still decides what is *right* — a prompt is not permission to bend a rule.
+  Guards cover what is genuinely hard to reverse — source without a ticket, consumer
+  trees, licence files. They are not a review queue for prose.
 - Lifecycle: `/align` (decide) → `/propose-change` (delta) → `/derive-tickets` (as few
   tracer bullets as the change honestly needs) →
   `/implement` (build) → `/ship-change` (fold + prove removals). `/pivot` for direction
@@ -38,6 +41,43 @@ ONE core system per concern — extend the existing system, never build a parall
   (how does X work, with evidence), `/reconcile-understanding` (corrections that stick).
   Code is the authority on what IS; the plan on what we AGREED.
 - Full model: `docs/plan/OPERATING-MODEL.md`.
+
+## Recording facts vs deciding
+
+Writing down what is true is ordinary work. Deciding what we build is not. The lifecycle
+skills exist to sharpen decisions, not to license prose.
+
+- **A factual record needs no skill, no prompt, and no approval.** What a shipped change
+  removed, renamed, or proved — a `REMOVED:` bullet, a superseded claim, a corrected file
+  anchor, a stale reference, a doc describing code that no longer exists — is part of
+  finishing the work. Write it in the same PR as the change it describes. Leaving the
+  record wrong to avoid ceremony is the worse outcome, always.
+- **A decision goes through the lifecycle.** Adding, retracting or reversing a `DECIDED` /
+  `OPEN` entry, changing what we agreed to build, or settling a question the plan leaves
+  open belongs in `/align`, `/propose-change`, `/ship-change`, or `/pivot`.
+- The test: **could a careful reader derive it from the diff and the tree?** Then it is a
+  fact — write it, and say in the PR body that you did. Does it commit us to something we
+  have not agreed? Then it is a decision — bring it.
+- Doc hygiene inside work you are already doing — fixing a claim your own change falsified —
+  is never a separate ticket and never a question.
+
+## Asking the owner
+
+An approved design is standing authority. Implementing it, recording it, and cleaning up
+after it need no further confirmation. Re-asking is not diligence; it spends the owner's
+attention, and attention spent on settled things is unavailable for real forks.
+
+- **Ask only for a live fork the plan does not settle** — two defensible paths, materially
+  different outcomes, where guessing wrong wastes real work.
+- **Never ask** to re-confirm something already agreed, to re-approve a scope already
+  signed off, to check that work is going well, or in place of reading the tree. If the
+  answer is discoverable, discover it.
+- **Prefer a stated assumption to a blocking question.** Do the work, say plainly what you
+  assumed and where it would bite, and let the owner correct it. Reserve blocking for cases
+  where proceeding either way is unsafe or would waste the work.
+- **Batch** what genuinely must be asked into one round at the point of decision — never a
+  drip of one-question stops.
+- A finding is not a question. Non-blocking findings go in the PR description, then move on.
 
 ## Runtime-first, plan-first (MVP doctrine)
 

--- a/docs/plan/OPERATING-MODEL.md
+++ b/docs/plan/OPERATING-MODEL.md
@@ -221,8 +221,9 @@ A model can't be *forced* to invoke a skill — so the system makes the side eff
 skipping one physically fail, in layers from soft to hard:
 
 1. **Router text in CLAUDE.md** (always loaded): all work enters through `/plan`; source
-   edits happen only inside `/implement` with a confirmed ticket; plan edits happen only
-   inside `/align`, `/propose-change`, `/ship-change`, or `/pivot`.
+   edits happen only inside `/implement` with a confirmed ticket; plan *decisions* happen
+   only inside `/align`, `/propose-change`, `/ship-change`, or `/pivot`. Plan and doc
+   *records* are ordinary work and land with the change they describe.
 2. **Sharp descriptions** on the model-invoked primitives so they trigger on phrasing
    without being asked.
 3. **Hooks** (the hard layer): a PreToolUse hook rejects `Edit`/`Write` under `runtime/`,
@@ -235,15 +236,24 @@ skipping one physically fail, in layers from soft to hard:
 
 ### The plan is locked
 
-Agents cannot quietly rewrite the decision source:
+Agents cannot quietly rewrite the decision source — but the lock is on *decisions*, not on
+every keystroke under `docs/plan/`:
 
-- `settings.json` puts `Edit(docs/plan/**)` on the **ask** list — every plan write
-  surfaces a permission prompt the owner personally approves, in session, per edit.
-- The PreToolUse hook additionally rejects plan writes unless one of the four
-  plan-editing skills has set its marker — so even an approved edit can only happen
-  inside `/align`, `/propose-change`, `/ship-change`, or `/pivot`.
 - Git layer: `CODEOWNERS` on `docs/plan/**` + branch protection — no plan change merges
-  without the owner's review, even from a session the owner wasn't watching.
+  without the owner's review, even from a session the owner wasn't watching. This is the
+  whole enforcement layer, and it is the right one: it reviews the diff, which is where a
+  smuggled decision is actually visible.
+- Doctrine layer: `CLAUDE.md` §Recording facts vs deciding draws the line the machinery
+  can't. A record of what shipped lands with the work; a `DECIDED` / `OPEN` entry moves
+  only inside `/align`, `/propose-change`, `/ship-change`, or `/pivot`.
+
+> ~~`settings.json` puts `Edit(docs/plan/**)` on the **ask** list … the PreToolUse hook
+> additionally rejects plan writes unless one of the four plan-editing skills has set its
+> marker.~~ — Superseded 2026-08-11: both are removed, and the `plan-session` marker with
+> them. A path guard sees a path, never an intent, so it prompted identically on a
+> corrected file anchor and on a reversed decision. The factual majority trained the owner
+> to click through without reading — which cost the prompt its meaning on the rare edit
+> that deserved it — and trained sessions to escalate trivia instead of finishing work.
 
 ### Rules have a lifecycle
 


### PR DESCRIPTION
## Summary

Doc and plan edits no longer prompt, and recording what a change did no longer requires running a lifecycle skill. Deciding still does.

**The problem.** Three layers gated `docs/plan/**` — `permissions.ask`, the `plan-gate.sh` hook, and the CLAUDE.md router — and none could see intent. A path guard matches a path, so correcting a stale file anchor and reversing a `DECIDED` entry produced the identical prompt. Two costs, both real:

- The factual majority trained the owner to click through without reading, which costs the prompt its meaning on the rare edit that deserves it.
- It trained sessions to treat any plan-adjacent write as an owner question. #1837 stopped and escalated a two-line `- REMOVED:` record of gates it had itself deleted — a statement of fact about a merged diff, routed as a design decision.

**The fix.** Move the distinction from path matching to doctrine, because that is where it lives.

Removed: the `ask` entries for `docs/plan/**` plus `docs/logging-schema.md`, `docs/testing-hardware.md` and `docs/architecture/schema-identity-and-packaging.md`; the hook's `docs/plan` branch; and the `plan-session` marker, which `/align`, `/propose-change`, `/ship-change` and `/pivot` each created and deleted and which nothing read once the hook stopped consuming it.

Added to `CLAUDE.md` — always-on, because a `paths:`-scoped rule file loads too late to govern the decision to ask:

- **§Recording facts vs deciding** — what a shipped change removed, renamed or proved lands in the same PR as the change. Adding, retracting or reversing a `DECIDED` / `OPEN` entry goes through the lifecycle. The test: could a careful reader derive it from the diff and the tree?
- **§Asking the owner** — an approved design is standing authority. Ask only for a live fork the plan does not settle; never to re-confirm settled scope or in place of reading the tree; prefer a stated assumption to a blocking question; batch what must be asked; a finding is not a question.

**What still guards the plan.** `CODEOWNERS` on `docs/plan/**` plus branch protection — unchanged, and the layer that was always doing the real work. A prompt fired before the diff existed and asked about a path; review fires after and asks about content, which is where a smuggled decision is actually visible.

`.claude/rules/flow.md` gains the standard that keeps this from regrowing: guard only what a wrong edit makes expensive to undo, never prose, and justify a new `ask` entry or hook branch the way an agent definition is justified.

## Test plan

- `jq -e . .claude/settings.json` parses; remaining `ask` entries are consumer trees, vendored sources and licence files only
- `bash -n .claude/hooks/plan-gate.sh` clean
- Hook fed a `docs/plan/ARCHITECTURE.md` path → exit 0, no output (no prompt)
- Hook fed a source path with no `active-ticket.json` → `permissionDecision: "ask"` (unchanged)
- Hook fed a source path with `active-ticket.json` present → exit 0 (unchanged)
- All four lifecycle skills renumber 1-5 with no gaps; `grep -rn plan-session .claude/` returns nothing
- Dogfooded: the `OPERATING-MODEL.md` edit in this PR is itself a factual record and was written without a prompt

## Notes for owner

**1. This session edited the skills it had been using.** `flow.md` says a session never does that. Overriding it was your explicit instruction ("rolled in as a change to process right now"), and stopping to ask permission would have reproduced the exact behaviour being removed. Flagging it because the rule is otherwise still good.

**2. `/implement`'s two remaining stops are deliberately untouched** — the `[NEEDS DECISION]` plan gate and the one plan confirmation before building. Both are genuine forks at the point of decision, which is what §Asking the owner preserves. If those also feel like fatigue, that is a separate and larger cut.

**3. The `#1837` escalation this was triggered by still stands on its merits** — the two `- REMOVED:` bullets genuinely are missing from `docs/plan/changes/processor-class-identity.md`, and no ship gate will prove those removals until they exist. Under the new rule that is a record a session writes rather than a question it asks. Happy to add them to #1843 directly, or leave them for `/ship-change`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between factual plan records and plan decisions.
  * Documented owner routing, assumptions, batching, and handling of non-blocking findings.
  * Updated operating-model guidance to reflect the revised plan-editing approach.

* **Workflow Improvements**
  * Simplified planning, alignment, proposal, pivot, and release workflows by removing unnecessary session-state steps.
  * Made owner confirmation the primary approval point for plan decisions.
  * Added guidance for evaluating new workflow guardrails.

* **Permissions and Guardrails**
  * Removed approval prompts for selected documentation updates while retaining protections for higher-impact source changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->