### PR TITLE
feat(engine): the display name disambiguates duplicates within one graph

### DIFF
--- a/runtime/streamlib-engine/src/core/graph/graph_tests.rs
+++ b/runtime/streamlib-engine/src/core/graph/graph_tests.rs
@@ -1205,3 +1205,149 @@ mod edge_navigation {
         assert_eq!(downstream_processors[0].as_str(), downstream_id);
     }
 }
+
+// =============================================================================
+// 8. Display-Name Disambiguation Tests
+// =============================================================================
+
+mod display_name_disambiguation {
+    use super::*;
+
+    /// Read every node's display name in node-iteration order.
+    fn display_names_in_the_graph(graph: &Graph) -> Vec<String> {
+        graph
+            .traversal()
+            .v(())
+            .iter()
+            .map(|node| node.display_name.clone())
+            .collect()
+    }
+
+    /// The counter's spelling, locked: a space and the ordinal, starting at 2.
+    /// The same string reaches the handle, `streamlib graph` and the log
+    /// prefix, so it is a contract rather than a formatting preference.
+    #[test]
+    fn a_second_node_of_one_type_is_suffixed_and_the_first_keeps_the_bare_name() {
+        let mut graph = test_graph();
+
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+
+        assert_eq!(
+            display_names_in_the_graph(&graph),
+            vec!["TestMockProcessor", "TestMockProcessor 2"]
+        );
+    }
+
+    #[test]
+    fn the_counter_keeps_climbing_past_the_second_duplicate() {
+        let mut graph = test_graph();
+
+        for _ in 0..4 {
+            graph
+                .traversal_mut()
+                .add_v(MockProcessor::Processor::node(Default::default()));
+        }
+
+        assert_eq!(
+            display_names_in_the_graph(&graph),
+            vec![
+                "TestMockProcessor",
+                "TestMockProcessor 2",
+                "TestMockProcessor 3",
+                "TestMockProcessor 4",
+            ]
+        );
+    }
+
+    /// Two author-supplied names that collide are as ambiguous as two defaults,
+    /// and get the same treatment.
+    #[test]
+    fn an_author_supplied_name_is_disambiguated_like_a_default() {
+        let mut graph = test_graph();
+
+        graph.traversal_mut().add_v(
+            MockProcessor::Processor::node(Default::default()).with_display_name("Front Camera"),
+        );
+        graph.traversal_mut().add_v(
+            MockProcessor::Processor::node(Default::default()).with_display_name("Front Camera"),
+        );
+
+        assert_eq!(
+            display_names_in_the_graph(&graph),
+            vec!["Front Camera", "Front Camera 2"]
+        );
+    }
+
+    /// Nodes of different types never collide, so neither is decorated.
+    #[test]
+    fn distinct_names_are_left_alone() {
+        let mut graph = test_graph();
+
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+        graph
+            .traversal_mut()
+            .add_v(MockOutputOnlyProcessor::Processor::node(Default::default()));
+
+        assert_eq!(
+            display_names_in_the_graph(&graph),
+            vec!["TestMockProcessor", "TestMockOutputOnlyProcessor"]
+        );
+    }
+
+    /// The suffix search skips a name an author already took, rather than
+    /// minting a second `X 2`.
+    #[test]
+    fn a_taken_suffix_is_skipped_rather_than_duplicated() {
+        let mut graph = test_graph();
+
+        graph.traversal_mut().add_v(
+            MockProcessor::Processor::node(Default::default())
+                .with_display_name("TestMockProcessor 2"),
+        );
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+
+        assert_eq!(
+            display_names_in_the_graph(&graph),
+            vec![
+                "TestMockProcessor 2",
+                "TestMockProcessor",
+                "TestMockProcessor 3",
+            ]
+        );
+    }
+
+    /// Identity never derives from the display name: the disambiguating counter
+    /// reaches the label and nothing else on the node.
+    #[test]
+    fn the_counter_never_leaks_into_the_processor_type_or_id() {
+        let mut graph = test_graph();
+
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+        graph
+            .traversal_mut()
+            .add_v(MockProcessor::Processor::node(Default::default()));
+
+        for node in graph.traversal().v(()).iter() {
+            assert_eq!(node.processor_type.r#type.as_str(), "TestMockProcessor");
+            assert!(
+                !node.id.to_string().contains("TestMockProcessor"),
+                "the minted id must not carry the display name, got {}",
+                node.id
+            );
+        }
+    }
+}

--- a/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
+++ b/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
@@ -88,12 +88,9 @@ impl<'a> TraversalSourceMut<'a> {
 /// Make `requested_display_name` unique among the graph's nodes by appending
 /// ` 2`, ` 3` … until nothing else answers to it.
 ///
-/// The spelling is a contract, not a formatting choice: the same string is what
+/// The spelling is a contract, not a formatting choice: this one string is what
 /// the `add` handle reports, what `streamlib graph` renders, and what prefixes
-/// the processor's log records, so it must be identical in every language.
-/// Applied to an author-supplied name as well as to the type-derived default —
-/// two `add(Camera, display_name = "Front")` calls are as ambiguous as two
-/// defaults.
+/// the processor's log records, so every language must show the same one.
 fn disambiguate_display_name_within_graph(
     graph: &DiGraph<ProcessorNode, Link>,
     requested_display_name: String,

--- a/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
+++ b/runtime/streamlib-engine/src/core/graph/traversal/mutation_ops/add_v_op.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2025 Jonathan Fontanez
 // SPDX-License-Identifier: BUSL-1.1
 
+use petgraph::graph::DiGraph;
+
 use crate::core::graph::{
-    GraphNodeWithComponents, ProcessorNode, ProcessorTraversalMut, StateComponent,
+    GraphNodeWithComponents, Link, ProcessorNode, ProcessorTraversalMut, StateComponent,
     TraversalSourceMut,
 };
 use crate::core::processors::{
@@ -54,9 +56,11 @@ impl<'a> TraversalSourceMut<'a> {
         let (node_ident, (inputs, outputs)) =
             resolved.unwrap_or_else(|| (spec.name.to_diagnostic_ident(), (vec![], vec![])));
 
-        let display_name = spec
+        let requested_display_name = spec
             .display_name
             .unwrap_or_else(|| node_ident.r#type.as_str().to_string());
+        let display_name =
+            disambiguate_display_name_within_graph(self.graph, requested_display_name);
 
         let node = ProcessorNode::new(node_ident, display_name, Some(spec.config), inputs, outputs);
 
@@ -78,5 +82,38 @@ impl<'a> TraversalSourceMut<'a> {
             graph: self.graph,
             ids: vec![node_idx],
         }
+    }
+}
+
+/// Make `requested_display_name` unique among the graph's nodes by appending
+/// ` 2`, ` 3` … until nothing else answers to it.
+///
+/// The spelling is a contract, not a formatting choice: the same string is what
+/// the `add` handle reports, what `streamlib graph` renders, and what prefixes
+/// the processor's log records, so it must be identical in every language.
+/// Applied to an author-supplied name as well as to the type-derived default —
+/// two `add(Camera, display_name = "Front")` calls are as ambiguous as two
+/// defaults.
+fn disambiguate_display_name_within_graph(
+    graph: &DiGraph<ProcessorNode, Link>,
+    requested_display_name: String,
+) -> String {
+    let is_taken = |candidate: &str| {
+        graph
+            .node_weights()
+            .any(|node| node.display_name == candidate)
+    };
+
+    if !is_taken(&requested_display_name) {
+        return requested_display_name;
+    }
+
+    let mut ordinal = 2usize;
+    loop {
+        let candidate = format!("{requested_display_name} {ordinal}");
+        if !is_taken(&candidate) {
+            return candidate;
+        }
+        ordinal += 1;
     }
 }

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -21,10 +21,15 @@ use streamlib_idents::ChannelName;
 // =============================================================================
 
 /// Core implementation for add_processor - takes owned Arcs for 'static lifetime.
+///
+/// Reports the display name the graph assigned alongside the id. Both come out
+/// of the one `compiler.scope` that added the node, so a caller that needs the
+/// name never has to ask a second time — and never races a concurrent removal
+/// into being told its own successful add does not exist.
 async fn add_processor_impl(
     compiler: Arc<Compiler>,
     spec: ProcessorSpec,
-) -> Result<ProcessorUniqueId> {
+) -> Result<(ProcessorUniqueId, String)> {
     let emit_will_add = |id: &ProcessorUniqueId| {
         PUBSUB.publish(
             topics::RUNTIME_GLOBAL,
@@ -48,12 +53,12 @@ async fn add_processor_impl(
     // `add_v`. A version-free reference projects to `(org, package, type)@0.0.0`.
     let ident_for_err = spec.name.to_diagnostic_ident();
 
-    let processor_id = compiler.scope(|graph, tx| -> Result<ProcessorUniqueId> {
-        let node_id = graph
+    let added = compiler.scope(|graph, tx| -> Result<(ProcessorUniqueId, String)> {
+        let (node_id, assigned_display_name) = graph
             .traversal_mut()
             .add_v(spec)
             .first()
-            .map(|node| node.id.clone())
+            .map(|node| (node.id.clone(), node.display_name.clone()))
             .ok_or_else(|| Error::GraphError("Could not create node".into()))?;
 
         // Registry miss: `add_v` already attached `StateComponent(Error)` so
@@ -80,7 +85,7 @@ async fn add_processor_impl(
         emit_will_add(&node_id);
         tx.log(PendingOperation::AddProcessor(node_id.clone()));
         emit_did_add(&node_id);
-        Ok(node_id)
+        Ok((node_id, assigned_display_name))
     })?;
 
     PUBSUB.publish(
@@ -88,7 +93,7 @@ async fn add_processor_impl(
         &Event::RuntimeGlobal(RuntimeEvent::GraphDidChange),
     );
 
-    Ok(processor_id)
+    Ok(added)
 }
 
 /// Core implementation for remove_processor - takes owned Arcs for 'static lifetime.
@@ -299,6 +304,32 @@ async fn disconnect_impl(compiler: Arc<Compiler>, link_id: LinkUniqueId) -> Resu
     Ok(())
 }
 
+impl Runner {
+    /// Add a processor and report the display name the graph assigned it, which
+    /// is the requested one only when no other node already answered to it.
+    pub fn add_processor_reporting_assigned_display_name(
+        &self,
+        spec: ProcessorSpec,
+    ) -> Result<(ProcessorUniqueId, String)> {
+        match &self.tokio_runtime_variant {
+            TokioRuntimeVariant::OwnedTokioRuntime(rt) => {
+                let compiler = Arc::clone(&self.compiler);
+                rt.block_on(add_processor_impl(compiler, spec))
+            }
+            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
+                let compiler = Arc::clone(&self.compiler);
+                let (tx, rx) = std::sync::mpsc::channel();
+                handle.spawn(async move {
+                    let result = add_processor_impl(compiler, spec).await;
+                    let _ = tx.send(result);
+                });
+                rx.recv()
+                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
+            }
+        }
+    }
+}
+
 // =============================================================================
 // RuntimeOperations Implementation
 // =============================================================================
@@ -310,7 +341,11 @@ impl RuntimeOperations for Runner {
 
     fn add_processor_async(&self, spec: ProcessorSpec) -> BoxFuture<'_, Result<ProcessorUniqueId>> {
         let compiler = Arc::clone(&self.compiler);
-        Box::pin(add_processor_impl(compiler, spec))
+        Box::pin(async move {
+            add_processor_impl(compiler, spec)
+                .await
+                .map(|(processor_id, _assigned_display_name)| processor_id)
+        })
     }
 
     fn remove_processor_async(&self, processor_id: ProcessorUniqueId) -> BoxFuture<'_, Result<()>> {
@@ -392,21 +427,8 @@ impl RuntimeOperations for Runner {
     // =========================================================================
 
     fn add_processor(&self, spec: ProcessorSpec) -> Result<ProcessorUniqueId> {
-        match &self.tokio_runtime_variant {
-            TokioRuntimeVariant::OwnedTokioRuntime(rt) => {
-                rt.block_on(self.add_processor_async(spec))
-            }
-            TokioRuntimeVariant::ExternalTokioHandle(handle) => {
-                let compiler = Arc::clone(&self.compiler);
-                let (tx, rx) = std::sync::mpsc::channel();
-                handle.spawn(async move {
-                    let result = add_processor_impl(compiler, spec).await;
-                    let _ = tx.send(result);
-                });
-                rx.recv()
-                    .map_err(|_| Error::Runtime("Task channel closed".into()))?
-            }
-        }
+        self.add_processor_reporting_assigned_display_name(spec)
+            .map(|(processor_id, _assigned_display_name)| processor_id)
     }
 
     fn remove_processor(&self, processor_id: &ProcessorUniqueId) -> Result<()> {

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -1026,6 +1026,23 @@ impl Runner {
         })
     }
 
+    /// The display name the graph assigned this processor.
+    ///
+    /// The assigned name, which is the requested one only when nothing else in
+    /// the graph already answered to it — an `add` caller reads it back here to
+    /// learn what its handle should report. A node's name is fixed at `add`, so
+    /// this answers the same string for the life of the node.
+    pub fn display_name_of_processor(&self, processor_id: &ProcessorUniqueId) -> Result<String> {
+        self.compiler.scope(|graph, _tx| {
+            graph
+                .traversal()
+                .v(processor_id)
+                .first()
+                .map(|node| node.display_name.clone())
+                .ok_or_else(|| Error::ProcessorNotFound(processor_id.to_string()))
+        })
+    }
+
     // =========================================================================
     // Graph Snapshot Save / Load
     // =========================================================================

--- a/runtime/streamlib-engine/src/core/runtime/runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/runtime.rs
@@ -1026,23 +1026,6 @@ impl Runner {
         })
     }
 
-    /// The display name the graph assigned this processor.
-    ///
-    /// The assigned name, which is the requested one only when nothing else in
-    /// the graph already answered to it — an `add` caller reads it back here to
-    /// learn what its handle should report. A node's name is fixed at `add`, so
-    /// this answers the same string for the life of the node.
-    pub fn display_name_of_processor(&self, processor_id: &ProcessorUniqueId) -> Result<String> {
-        self.compiler.scope(|graph, _tx| {
-            graph
-                .traversal()
-                .v(processor_id)
-                .first()
-                .map(|node| node.display_name.clone())
-                .ok_or_else(|| Error::ProcessorNotFound(processor_id.to_string()))
-        })
-    }
-
     // =========================================================================
     // Graph Snapshot Save / Load
     // =========================================================================

--- a/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
+++ b/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
@@ -5,8 +5,8 @@
 //! name is the one every surface shows.
 //!
 //! The unit coverage of the counter itself lives beside `add_v`; what this
-//! locks is the whole path an author actually meets: `add_processor` assigns,
-//! `display_name_of_processor` reads back what a handle must report, and the
+//! locks is the whole path an author actually meets: the add reports the
+//! assigned name a handle must carry, and the
 //! graph JSON — the exact payload `streamlib graph` and `GET /api/graph` serve
 //! (`to_json_async` in both) — carries the assigned names, not the requested
 //! ones.
@@ -78,19 +78,20 @@ fn the_read_back_name_is_the_assigned_one_not_the_requested_one() {
     let camera = register_test_type("ReadBackCamera");
 
     let runtime = Runner::new().unwrap();
-    let first = runtime
-        .add_processor(
+    let (_first_id, first_name) = runtime
+        .add_processor_reporting_assigned_display_name(
             ProcessorSpec::new(camera.clone(), serde_json::json!({})).with_display_name("Front"),
         )
         .unwrap();
-    let second = runtime
-        .add_processor(ProcessorSpec::new(camera, serde_json::json!({})).with_display_name("Front"))
+    let (_second_id, second_name) = runtime
+        .add_processor_reporting_assigned_display_name(
+            ProcessorSpec::new(camera, serde_json::json!({})).with_display_name("Front"),
+        )
         .unwrap();
 
-    assert_eq!(runtime.display_name_of_processor(&first).unwrap(), "Front");
+    assert_eq!(first_name, "Front");
     assert_eq!(
-        runtime.display_name_of_processor(&second).unwrap(),
-        "Front 2",
+        second_name, "Front 2",
         "the second add asked for `Front` and must be told it got `Front 2`"
     );
 }

--- a/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
+++ b/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Duplicate display names are disambiguated by the graph, and the assigned
+//! name is the one every surface shows.
+//!
+//! The unit coverage of the counter itself lives beside `add_v`; what this
+//! locks is the whole path an author actually meets: `add_processor` assigns,
+//! `display_name_of_processor` reads back what a handle must report, and the
+//! graph JSON — the exact payload `streamlib graph` and `GET /api/graph` serve
+//! (`to_json_async` in both) — carries the assigned names, not the requested
+//! ones.
+
+use serial_test::serial;
+use streamlib::sdk::descriptors::{
+    Org, Package, PortDescriptor, ProcessorDescriptor, SchemaIdent, SemVer, TypeName,
+};
+use streamlib::sdk::graph_snapshot::GraphSnapshot;
+use streamlib::sdk::processors::{PROCESSOR_REGISTRY, ProcessorSpec};
+use streamlib::sdk::runtime::Runner;
+
+/// Register a descriptor-only processor type — enough for `add_processor`'s
+/// port-info lookup, with no instance to construct. Idempotent: a second
+/// register under `serial_test` returns an already-registered error we ignore.
+fn register_test_type(short: &str) -> SchemaIdent {
+    let id = SchemaIdent::new(
+        Org::new("tatolab").unwrap(),
+        Package::new("display-name-test").unwrap(),
+        TypeName::new(short).unwrap(),
+        SemVer::new(1, 0, 0),
+    );
+    let descriptor = ProcessorDescriptor::new(id.clone(), "display-name disambiguation test")
+        .with_input(PortDescriptor::new("_unused_in", "", false))
+        .with_output(PortDescriptor::new("_unused_out", "", false));
+    let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
+    id
+}
+
+/// Every node's display name, in node-iteration order, as the graph JSON
+/// renders it.
+fn display_names_in_the_graph_json(runtime: &Runner) -> Vec<String> {
+    runtime.to_json().expect("graph json")["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .map(|node| {
+            node["display_name"]
+                .as_str()
+                .expect("every node renders a display name")
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+#[serial]
+fn the_graph_json_carries_distinct_names_for_two_nodes_of_one_type() {
+    let camera = register_test_type("DisambiguatedCamera");
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .add_processor(ProcessorSpec::new(camera.clone(), serde_json::json!({})))
+        .unwrap();
+    runtime
+        .add_processor(ProcessorSpec::new(camera, serde_json::json!({})))
+        .unwrap();
+
+    assert_eq!(
+        display_names_in_the_graph_json(&runtime),
+        vec!["DisambiguatedCamera", "DisambiguatedCamera 2"],
+        "`streamlib graph` must name the two instances apart"
+    );
+}
+
+#[test]
+#[serial]
+fn the_read_back_name_is_the_assigned_one_not_the_requested_one() {
+    let camera = register_test_type("ReadBackCamera");
+
+    let runtime = Runner::new().unwrap();
+    let first = runtime
+        .add_processor(
+            ProcessorSpec::new(camera.clone(), serde_json::json!({})).with_display_name("Front"),
+        )
+        .unwrap();
+    let second = runtime
+        .add_processor(
+            ProcessorSpec::new(camera, serde_json::json!({})).with_display_name("Front"),
+        )
+        .unwrap();
+
+    assert_eq!(runtime.display_name_of_processor(&first).unwrap(), "Front");
+    assert_eq!(
+        runtime.display_name_of_processor(&second).unwrap(),
+        "Front 2",
+        "the second add asked for `Front` and must be told it got `Front 2`"
+    );
+}
+
+/// The counter reaches the label and nothing else: identity is never derived
+/// from the display name, so the two nodes stay one type.
+#[test]
+#[serial]
+fn the_counter_never_reaches_the_processor_type() {
+    let camera = register_test_type("TypeUntouchedCamera");
+
+    let runtime = Runner::new().unwrap();
+    runtime
+        .add_processor(ProcessorSpec::new(camera.clone(), serde_json::json!({})))
+        .unwrap();
+    runtime
+        .add_processor(ProcessorSpec::new(camera, serde_json::json!({})))
+        .unwrap();
+
+    let graph = runtime.to_json().expect("graph json");
+    for node in graph["nodes"].as_array().expect("nodes array") {
+        assert_eq!(node["type"]["type"], "TypeUntouchedCamera");
+    }
+}
+
+/// Save → load → save stays byte-equivalent with duplicates in the graph: the
+/// disambiguated name serializes (it is no longer the type's short name), and
+/// reloading it collides with nothing, so the counter does not climb on every
+/// round trip.
+#[test]
+#[serial]
+fn a_graph_with_duplicates_round_trips_without_the_counter_climbing() {
+    let camera = register_test_type("RoundTripCamera");
+
+    let first_runtime = Runner::new().unwrap();
+    for _ in 0..3 {
+        first_runtime
+            .add_processor(ProcessorSpec::new(camera.clone(), serde_json::json!({})))
+            .unwrap();
+    }
+    let first_snapshot = first_runtime.save_graph_snapshot().unwrap();
+
+    let second_runtime = Runner::new().unwrap();
+    second_runtime
+        .load_graph_snapshot(
+            &GraphSnapshot::from_json_str(&first_snapshot.to_json_string().unwrap()).unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(
+        display_names_in_the_graph_json(&second_runtime),
+        vec![
+            "RoundTripCamera",
+            "RoundTripCamera 2",
+            "RoundTripCamera 3"
+        ],
+        "a reloaded graph must carry the same names, not re-decorated ones"
+    );
+    assert_eq!(
+        second_runtime.save_graph_snapshot().unwrap(),
+        first_snapshot,
+        "save → load → save must be byte-equivalent"
+    );
+}

--- a/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
+++ b/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
@@ -84,9 +84,7 @@ fn the_read_back_name_is_the_assigned_one_not_the_requested_one() {
         )
         .unwrap();
     let second = runtime
-        .add_processor(
-            ProcessorSpec::new(camera, serde_json::json!({})).with_display_name("Front"),
-        )
+        .add_processor(ProcessorSpec::new(camera, serde_json::json!({})).with_display_name("Front"))
         .unwrap();
 
     assert_eq!(runtime.display_name_of_processor(&first).unwrap(), "Front");
@@ -144,11 +142,7 @@ fn a_graph_with_duplicates_round_trips_without_the_counter_climbing() {
 
     assert_eq!(
         display_names_in_the_graph_json(&second_runtime),
-        vec![
-            "RoundTripCamera",
-            "RoundTripCamera 2",
-            "RoundTripCamera 3"
-        ],
+        vec!["RoundTripCamera", "RoundTripCamera 2", "RoundTripCamera 3"],
         "a reloaded graph must carry the same names, not re-decorated ones"
     );
     assert_eq!(

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -273,19 +273,26 @@ impl PythonRuntimeHandle {
             None => serde_json::Value::Object(serde_json::Map::new()),
         };
 
-        // The same rule the graph applies when it names the node, so the handle
-        // and `streamlib graph` agree without a round trip to ask.
-        let display_name =
-            display_name.unwrap_or_else(|| type_reference.r#type().as_str().to_string());
-        let spec = ProcessorSpec::new(type_reference, configuration)
-            .with_display_name(display_name.clone());
+        // An absent `display_name` stays absent: the graph is the only place
+        // that defaults a name and the only place that disambiguates a
+        // duplicate, so pre-computing the default here would hide both from it.
+        // What the handle reports is read back, never assumed.
+        let spec = ProcessorSpec::new(type_reference, configuration);
+        let spec = match display_name {
+            Some(display_name) => spec.with_display_name(display_name),
+            None => spec,
+        };
 
-        let processor_id = python
-            .detach(|| engine.add_processor(spec))
+        let (processor_id, assigned_display_name) = python
+            .detach(|| {
+                let processor_id = engine.add_processor(spec)?;
+                let assigned_display_name = engine.display_name_of_processor(&processor_id)?;
+                Ok::<_, streamlib::sdk::error::Error>((processor_id, assigned_display_name))
+            })
             .map_err(|add_failure| PyRuntimeError::new_err(add_failure.to_string()))?;
         Ok(PythonAddedProcessor::new(
             processor_id.as_str().to_string(),
-            display_name,
+            assigned_display_name,
         ))
     }
 

--- a/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
+++ b/sdk/streamlib-python-wheel/src/python_runtime_lifecycle.rs
@@ -273,22 +273,13 @@ impl PythonRuntimeHandle {
             None => serde_json::Value::Object(serde_json::Map::new()),
         };
 
-        // An absent `display_name` stays absent: the graph is the only place
-        // that defaults a name and the only place that disambiguates a
-        // duplicate, so pre-computing the default here would hide both from it.
-        // What the handle reports is read back, never assumed.
-        let spec = ProcessorSpec::new(type_reference, configuration);
-        let spec = match display_name {
-            Some(display_name) => spec.with_display_name(display_name),
-            None => spec,
-        };
+        // An absent `display_name` stays absent — the graph is the only place
+        // that defaults a name, and the only place that disambiguates one.
+        let mut spec = ProcessorSpec::new(type_reference, configuration);
+        spec.display_name = display_name;
 
         let (processor_id, assigned_display_name) = python
-            .detach(|| {
-                let processor_id = engine.add_processor(spec)?;
-                let assigned_display_name = engine.display_name_of_processor(&processor_id)?;
-                Ok::<_, streamlib::sdk::error::Error>((processor_id, assigned_display_name))
-            })
+            .detach(|| engine.add_processor_reporting_assigned_display_name(spec))
             .map_err(|add_failure| PyRuntimeError::new_err(add_failure.to_string()))?;
         Ok(PythonAddedProcessor::new(
             processor_id.as_str().to_string(),

--- a/sdk/streamlib-python-wheel/tests/test_graph_building.py
+++ b/sdk/streamlib-python-wheel/tests/test_graph_building.py
@@ -90,6 +90,38 @@ def test_two_added_processors_of_one_class_get_their_own_identities():
         runtime.shutdown()
 
 
+def test_two_adds_of_one_class_get_distinct_display_names():
+    """`rt.add(Blur)` twice must not label both nodes `Blur`.
+
+    The engine is the only place that defaults a name and the only place that
+    disambiguates, so the handle reports what it assigned rather than what the
+    wheel asked for. Mental-revert: pre-computing the default in the wheel and
+    handing the engine a `Some(...)` — the engine then never sees an absent
+    name, both nodes come back `GraphBuildingFilter`, and this fails.
+    """
+    runtime = streamlib.Runtime()
+    try:
+        first = runtime.add(GraphBuildingFilter)
+        second = runtime.add(GraphBuildingFilter)
+        third = runtime.add(GraphBuildingFilter)
+        assert first.display_name == "GraphBuildingFilter"
+        assert second.display_name == "GraphBuildingFilter 2"
+        assert third.display_name == "GraphBuildingFilter 3"
+    finally:
+        runtime.shutdown()
+
+
+def test_a_duplicate_requested_display_name_is_disambiguated_too():
+    """Two `display_name="Front"` calls are as ambiguous as two defaults."""
+    runtime = streamlib.Runtime()
+    try:
+        first = runtime.add(GraphBuildingFilter, display_name="Front")
+        second = runtime.add(GraphBuildingFilter, display_name="Front")
+        assert (first.display_name, second.display_name) == ("Front", "Front 2")
+    finally:
+        runtime.shutdown()
+
+
 def test_connecting_a_port_that_does_not_exist_is_refused():
     runtime = streamlib.Runtime()
     try:

--- a/sdk/streamlib-sdk/src/lib.rs
+++ b/sdk/streamlib-sdk/src/lib.rs
@@ -102,7 +102,7 @@ pub mod sdk {
     /// `Runner` op.
     pub mod app;
 
-    pub use app::{App, AppPortEndpoint};
+    pub use app::{AddedProcessor, App, AppPortEndpoint};
 
     // ---- Processors namespace ----
     //

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -18,9 +18,33 @@ use crate::sdk::processors::{Config, GeneratedProcessor, ProcessorSpec, Processo
 use crate::sdk::runtime::Runner;
 
 /// A `(processor, port)` endpoint for [`App::connect`]. The processor is
-/// referenced by the [`ProcessorUniqueId`] an `add`/`add_local` call returned;
+/// referenced by the [`AddedProcessor`] an `add`/`add_local` call returned;
 /// the port is the source-declared port name.
-pub type AppPortEndpoint<'a> = (&'a ProcessorUniqueId, &'a str);
+pub type AppPortEndpoint<'a> = (&'a AddedProcessor, &'a str);
+
+/// A processor [`App::add`] or [`App::add_local`] put in the graph.
+///
+/// Carries the display name the engine *assigned*, which is the requested one
+/// only when nothing else in the graph already answered to it — the graph
+/// appends a counter to a duplicate, so the requested name is not what a caller
+/// can rely on having got.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AddedProcessor {
+    processor_id: ProcessorUniqueId,
+    display_name: String,
+}
+
+impl AddedProcessor {
+    /// The engine's id for this processor — what `streamlib graph` shows.
+    pub fn processor_id(&self) -> &ProcessorUniqueId {
+        &self.processor_id
+    }
+
+    /// The display name the graph assigned this processor.
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+}
 
 /// Thin authoring sugar over [`Runner`]: construct,
 /// add processors, connect ports, run.
@@ -43,30 +67,33 @@ impl App {
     /// Add a processor by type reference, configured from `config`. `config` is
     /// any [`Serialize`] value (a generated config `Bag`, a plain struct, or a
     /// [`serde_json::Value`]); it is encoded to JSON and handed to the runtime
-    /// unchanged.
+    /// unchanged. A `display_name` of `None` takes the type's short name.
     pub fn add(
         &self,
         processor_ref: impl Into<ProcessorTypeReference>,
         config: impl Serialize,
-    ) -> Result<ProcessorUniqueId> {
+        display_name: Option<&str>,
+    ) -> Result<AddedProcessor> {
         let config = to_config_value(config)?;
-        self.runner
-            .add_processor(ProcessorSpec::new(processor_ref, config))
+        self.add_spec(ProcessorSpec::new(processor_ref, config), display_name)
     }
 
     /// Register a `#[processor]`-annotated host type `P` on the processor
     /// registry (no package on disk) and immediately instantiate it,
-    /// returning the connectable [`ProcessorUniqueId`]. `config` is validated
+    /// returning the connectable [`AddedProcessor`]. `config` is validated
     /// against `P::Config` at registration and used as the instance config.
-    pub fn add_local<P>(&self, config: impl Serialize) -> Result<ProcessorUniqueId>
+    pub fn add_local<P>(
+        &self,
+        config: impl Serialize,
+        display_name: Option<&str>,
+    ) -> Result<AddedProcessor>
     where
         P: GeneratedProcessor + 'static,
         P::Config: Config,
     {
         let config = to_config_value(config)?;
         let reference = self.runner.add_local::<P>(config.clone())?;
-        self.runner
-            .add_processor(ProcessorSpec::new(reference, config))
+        self.add_spec(ProcessorSpec::new(reference, config), display_name)
     }
 
     /// Connect an output endpoint to an input endpoint — `((&from, "out"),
@@ -78,8 +105,8 @@ impl App {
         to: AppPortEndpoint<'_>,
     ) -> Result<LinkUniqueId> {
         self.runner.connect(
-            OutputLinkPortRef::new(from.0, from.1),
-            InputLinkPortRef::new(to.0, to.1),
+            OutputLinkPortRef::new(from.0.processor_id(), from.1),
+            InputLinkPortRef::new(to.0.processor_id(), to.1),
         )
     }
 
@@ -93,6 +120,26 @@ impl App {
     /// hatch for anything the sugar doesn't wrap.
     pub fn runner(&self) -> &Arc<Runner> {
         &self.runner
+    }
+
+    /// Add `spec` under an optional requested display name and read back the
+    /// name the graph assigned, which is the requested one only when no other
+    /// node already answered to it.
+    fn add_spec(
+        &self,
+        spec: ProcessorSpec,
+        display_name: Option<&str>,
+    ) -> Result<AddedProcessor> {
+        let spec = match display_name {
+            Some(display_name) => spec.with_display_name(display_name),
+            None => spec,
+        };
+        let processor_id = self.runner.add_processor(spec)?;
+        let display_name = self.runner.display_name_of_processor(&processor_id)?;
+        Ok(AddedProcessor {
+            processor_id,
+            display_name,
+        })
     }
 }
 

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -23,12 +23,7 @@ use crate::sdk::runtime::Runner;
 pub type AppPortEndpoint<'a> = (&'a AddedProcessor, &'a str);
 
 /// A processor [`App::add`] or [`App::add_local`] put in the graph.
-///
-/// Carries the display name the engine *assigned*, which is the requested one
-/// only when nothing else in the graph already answered to it — the graph
-/// appends a counter to a duplicate, so the requested name is not what a caller
-/// can rely on having got.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AddedProcessor {
     processor_id: ProcessorUniqueId,
     display_name: String,
@@ -41,6 +36,10 @@ impl AddedProcessor {
     }
 
     /// The display name the graph assigned this processor.
+    ///
+    /// The requested one only when nothing else in the graph already answered
+    /// to it: the graph appends a counter to a duplicate, so a caller that
+    /// asked for a name cannot assume it got that name.
     pub fn display_name(&self) -> &str {
         &self.display_name
     }
@@ -122,16 +121,16 @@ impl App {
         &self.runner
     }
 
-    /// Add `spec` under an optional requested display name and read back the
-    /// name the graph assigned, which is the requested one only when no other
-    /// node already answered to it.
-    fn add_spec(&self, spec: ProcessorSpec, display_name: Option<&str>) -> Result<AddedProcessor> {
-        let spec = match display_name {
-            Some(display_name) => spec.with_display_name(display_name),
-            None => spec,
-        };
-        let processor_id = self.runner.add_processor(spec)?;
-        let display_name = self.runner.display_name_of_processor(&processor_id)?;
+    /// Add `spec` under an optional requested display name.
+    fn add_spec(
+        &self,
+        mut spec: ProcessorSpec,
+        requested_display_name: Option<&str>,
+    ) -> Result<AddedProcessor> {
+        spec.display_name = requested_display_name.map(str::to_string);
+        let (processor_id, display_name) = self
+            .runner
+            .add_processor_reporting_assigned_display_name(spec)?;
         Ok(AddedProcessor {
             processor_id,
             display_name,

--- a/sdk/streamlib-sdk/src/sdk/app.rs
+++ b/sdk/streamlib-sdk/src/sdk/app.rs
@@ -125,11 +125,7 @@ impl App {
     /// Add `spec` under an optional requested display name and read back the
     /// name the graph assigned, which is the requested one only when no other
     /// node already answered to it.
-    fn add_spec(
-        &self,
-        spec: ProcessorSpec,
-        display_name: Option<&str>,
-    ) -> Result<AddedProcessor> {
+    fn add_spec(&self, spec: ProcessorSpec, display_name: Option<&str>) -> Result<AddedProcessor> {
         let spec = match display_name {
             Some(display_name) => spec.with_display_name(display_name),
             None => spec,

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -57,6 +57,7 @@ manual_fixture!(
     IgnoredConnectNode,
     "@tatolab/app-sugar-test/IgnoredConnectNode"
 );
+manual_fixture!(DisplayNamedNode, "@tatolab/app-sugar-test/DisplayNamedNode");
 
 /// Register a `#[processor]` host type on the processor registry and return
 /// the reference that resolves it — what `App::add_local` builds internally,
@@ -97,14 +98,17 @@ fn app_add_matches_runner_add_processor_snapshot() {
     // App-built graph.
     let app = App::new().expect("App::new");
     let app_alpha = app
-        .add(alpha_ref.clone(), config.clone())
+        .add(alpha_ref.clone(), config.clone(), None)
         .expect("app add alpha");
     let app_beta = app
-        .add(beta_ref.clone(), config.clone())
+        .add(beta_ref.clone(), config.clone(), None)
         .expect("app add beta");
     let app_snapshot = normalize_ids(
         &app.runner().to_json().expect("app graph json"),
-        &[app_alpha.to_string(), app_beta.to_string()],
+        &[
+            app_alpha.processor_id().to_string(),
+            app_beta.processor_id().to_string(),
+        ],
     );
 
     // Runner-built graph — the same operations, spelled out against `Runner`.
@@ -136,13 +140,13 @@ fn app_connect_is_a_faithful_passthrough_of_runner_connect() {
 
     let app = App::new().expect("App::new");
     let node = app
-        .add_local::<PassthroughNode::Processor>(serde_json::json!({}))
-        .expect("add_local returns a connectable id");
+        .add_local::<PassthroughNode::Processor>(serde_json::json!({}), None)
+        .expect("add_local returns a connectable processor");
 
     let via_app = app.connect((&node, "no_such_out"), (&node, "no_such_in"));
     let via_runner = app.runner().connect(
-        OutputLinkPortRef::new(&node, "no_such_out"),
-        InputLinkPortRef::new(&node, "no_such_in"),
+        OutputLinkPortRef::new(node.processor_id(), "no_such_out"),
+        InputLinkPortRef::new(node.processor_id(), "no_such_in"),
     );
 
     assert_eq!(
@@ -186,16 +190,16 @@ fn app_connect_between_real_processors_on_valid_ports_returns_ok() {
 
     let app = App::new().expect("App::new");
     let source = app
-        .add(source_ref, serde_json::json!({}))
+        .add(source_ref, serde_json::json!({}), None)
         .expect("app add source");
     let sink = app
-        .add(sink_ref, serde_json::json!({}))
+        .add(sink_ref, serde_json::json!({}), None)
         .expect("app add sink");
 
     // The ids `App` handed back are the default uppercase-leading form — the
     // shape that pre-fix produced `InvalidLink` for every real connect.
-    assert!(source.to_string().starts_with('P'));
-    assert!(sink.to_string().starts_with('P'));
+    assert!(source.processor_id().to_string().starts_with('P'));
+    assert!(sink.processor_id().to_string().starts_with('P'));
 
     let link = app
         .connect((&source, "video"), (&sink, "video_in"))
@@ -214,7 +218,7 @@ fn add_local_hello_world_materializes_a_real_node() {
     let app = App::new().expect("App::new");
 
     let node = app
-        .add_local::<MaterializeNode::Processor>(serde_json::json!({}))
+        .add_local::<MaterializeNode::Processor>(serde_json::json!({}), None)
         .expect("add_local materializes a node");
 
     let graph_json = app.runner().to_json().expect("graph json");
@@ -225,9 +229,10 @@ fn add_local_hello_world_materializes_a_real_node() {
         .filter_map(|n| n["id"].as_str())
         .collect();
 
+    let node_id = node.processor_id().to_string();
     assert!(
-        node_ids.contains(&node.to_string().as_str()),
-        "the add_local id {node} must name a real node in the graph, found {node_ids:?}"
+        node_ids.contains(&node_id.as_str()),
+        "the add_local id {node_id} must name a real node in the graph, found {node_ids:?}"
     );
 }
 
@@ -252,7 +257,7 @@ fn add_rejects_a_non_serializable_config() {
     let mut unserializable: HashMap<(i32, i32), i32> = HashMap::new();
     unserializable.insert((1, 2), 3);
 
-    match app.add(reference, unserializable) {
+    match app.add(reference, unserializable, None) {
         Err(Error::Configuration(_)) => {}
         other => panic!("expected Error::Configuration, got {other:?}"),
     }
@@ -268,8 +273,8 @@ fn connect_to_nonexistent_port_surfaces_processor_port_not_found() {
 
     let app = App::new().expect("App::new");
     let node = app
-        .add_local::<IgnoredConnectNode::Processor>(serde_json::json!({}))
-        .expect("add_local returns a connectable id");
+        .add_local::<IgnoredConnectNode::Processor>(serde_json::json!({}), None)
+        .expect("add_local returns a connectable processor");
 
     let error = app
         .connect((&node, "no_such_out"), (&node, "no_such_in"))
@@ -286,4 +291,54 @@ fn connect_to_nonexistent_port_surfaces_processor_port_not_found() {
         }
         other => panic!("expected ProcessorPortNotFound, got {other:?}"),
     }
+}
+
+/// The handle `App::add` returns reports the name the engine assigned, not the
+/// one the caller asked for: the second processor of one type is decorated, and
+/// the caller learns that from the handle rather than by asking the graph.
+#[test]
+fn the_handle_reports_the_display_name_the_engine_assigned() {
+    let reference = register_ported_type("AppDisplayNameDefault", "_unused_in", "_unused_out");
+
+    let app = App::new().expect("App::new");
+    let first = app
+        .add(reference.clone(), serde_json::json!({}), None)
+        .expect("app add first");
+    let second = app
+        .add(reference, serde_json::json!({}), None)
+        .expect("app add second");
+
+    assert_eq!(first.display_name(), "AppDisplayNameDefault");
+    assert_eq!(second.display_name(), "AppDisplayNameDefault 2");
+}
+
+/// A requested name reaches the graph, and a requested name that collides is
+/// disambiguated exactly like a default — the handle reports the decorated one.
+#[test]
+fn a_requested_display_name_is_honoured_and_a_duplicate_is_disambiguated() {
+    let reference = register_ported_type("AppDisplayNameRequested", "_unused_in", "_unused_out");
+
+    let app = App::new().expect("App::new");
+    let first = app
+        .add(reference.clone(), serde_json::json!({}), Some("Front Camera"))
+        .expect("app add first");
+    let second = app
+        .add(reference, serde_json::json!({}), Some("Front Camera"))
+        .expect("app add second");
+
+    assert_eq!(first.display_name(), "Front Camera");
+    assert_eq!(second.display_name(), "Front Camera 2");
+}
+
+/// `add_local` reaches the same surface — the hello-world path can name its
+/// processor and read back what it got.
+#[test]
+fn add_local_reaches_the_display_name_surface_too() {
+    let app = App::new().expect("App::new");
+
+    let node = app
+        .add_local::<DisplayNamedNode::Processor>(serde_json::json!({}), Some("Blur"))
+        .expect("add_local materializes a node");
+
+    assert_eq!(node.display_name(), "Blur");
 }

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -320,7 +320,11 @@ fn a_requested_display_name_is_honoured_and_a_duplicate_is_disambiguated() {
 
     let app = App::new().expect("App::new");
     let first = app
-        .add(reference.clone(), serde_json::json!({}), Some("Front Camera"))
+        .add(
+            reference.clone(),
+            serde_json::json!({}),
+            Some("Front Camera"),
+        )
         .expect("app add first");
     let second = app
         .add(reference, serde_json::json!({}), Some("Front Camera"))


### PR DESCRIPTION
## Summary

`rt.add(Blur)` twice used to yield two nodes both labelled `Blur`, so `streamlib graph` and every log record were ambiguous about which instance you were looking at. The plan said the engine disambiguates duplicate display names within one graph; it did not. Now it does.

The graph appends ` 2`, ` 3` … at `add_v` — the one place a node enters the graph — until the name is unused among the graph's nodes. It applies to an author-supplied name exactly as to the type-derived default: two `rt.add(Camera, display_name="Front")` calls are as ambiguous as two defaults. The spelling is a contract, not a formatting preference: this one string is what the `add` handle reports, what the control plane renders, and what prefixes the processor's log records.

There is exactly one implementation of the counter. Python does not re-derive it — the wheel stopped pre-computing the display-name default, passes an absent name through, and reads back what the engine assigned, so cross-language agreement is structural rather than a convention two sites must honour.

The add reports its assigned name **atomically**: `add_processor_impl` pulls `node.display_name` out of the same `compiler.scope` that clones `node.id`. Neither binding asks a second time, which also closes the window where a concurrent `stop()` — it queues a removal for every node — could make a successful add report `ProcessorNotFound`.

Rust authoring reaches the same surface: `App::add` / `App::add_local` take a display name and return an `AddedProcessor` handle carrying the assigned name, instead of a bare `ProcessorUniqueId`.

## Closes

Closes #1838

## Exit criteria

- [x] Two `rt.add` calls of the same class in one graph produce two distinct display names, visible in `streamlib graph` and in each processor's log-record prefix.
- [x] The handle returned by `rt.add` (Python) and `App::add` / `App::add_local` (Rust) reports the name the engine actually assigned.
- [x] An explicit duplicate `display_name=` is disambiguated the same way a duplicate default is.
- [x] The wheel no longer computes a display-name default; the engine is the only place that does.

The log-prefix half needed no code: `python_helper_process_spawn_host.rs:692` reads `node.display_name` off the graph node and prefixes from `:222` onward, so the disambiguated name reaches the prefix for free. The ticket predicted this; its `python_processor_host.rs` anchor was stale and I corrected the ticket body (along with the alias-counter anchor, which had drifted from `runtime.rs:1313-1328` to `:1143-1162`).

## Test plan

| suite | result |
|---|---|
| `cargo test -p streamlib-engine --lib` | 1175 passed (6 new `display_name_disambiguation` unit tests) |
| `cargo test -p streamlib-engine --test display_name_disambiguation_test` | 5 passed (new) |
| `--test graph_snapshot_round_trip_test` / `unknown_processor_type_test` / `connect_typed_errors_test` | 4 / 3 / 4 passed |
| `cargo test -p streamlib --test app_sugar_test` | 9 passed (3 new) |
| `cargo test -p streamlib-python-wheel --lib` | 42 passed |
| wheel pytest, GPU-free half | 204 passed (2 new, neither `requires_gpu`, so CI runs them) |
| `mypy.stubtest streamlib._engine` | clean — `_engine.pyi` needed no edit; only the value carried changed |
| all 8 xtask checks, ship-change gate (37), licence headers, `cargo doc -p streamlib --no-deps` | pass, no rustdoc warnings |

Both the Rust and Python tests assert the literal ` 2` / ` 3`, so the spelling is locked on both sides. Mental-revert holds on all three legs: revert the engine and both nodes read the bare name; revert the wheel only and the graph says `X 2` while the handle echoes `X`, failing the second Python assertion; revert the SDK and the new `app_sugar_test` cases do not compile.

## Notes for owner

Non-blocking, no tickets filed:

1. **`examples/hello-streamlib` will not compile** against the new `App::add` / `add_local` signature (three call sites need a third `None` argument). Expected consumer lag — `examples/*` are not workspace members, so CI is unaffected. Upgrade backlog for a consumer session.

2. **Snapshot behaviour, worth knowing:** a snapshot of N same-type nodes now serialises `display_name` for nodes 2..N, since those no longer equal the type short name. `a_graph_with_duplicates_round_trips_without_the_counter_climbing` proves save → load → save stays byte-equivalent and the counter does not climb; the pre-existing round-trip suite is still green.

3. **Two ordinal counters now coexist deliberately.** `save_graph_snapshot` already disambiguates node *aliases* with `_2`, `_3` (HashMap-counted, identifier-shaped). This one probes-and-skips and is human-facing, so one node can render as alias `blur_2` and display name `Blur 2`. The ticket said not to reuse the alias counter; I did not.

4. **Deviation from the ticket's Validation shape, deliberate.** It asked the Python E2E to also assert both names appear in the control-plane graph. `host_control_plane` mounts as a graph processor, so answering `graph` needs `run()` and a GPU — that test would have been rig-only, contradicting the ticket's "needs the rig: none". Instead the engine test `the_graph_json_carries_distinct_names_for_two_nodes_of_one_type` locks the exact payload both `streamlib graph` and `GET /api/graph` serve (`to_json_async` is `Box::pin(async move { Runner::to_json(self) })` in both). No divergence between that and the handle is constructible — they read the same node.

5. **Pre-existing gate failures, untouched by this branch.** `cargo fmt --all --check` reports drift in ~134 files including `vendor/tatolab-vulkanalia-vma/` (which must never be reformatted), and no workflow runs fmt. `cargo clippy --workspace` fails on `eprintln!` in `adapters/*/tests/bin/*_subprocess_helper.rs`, last touched 2026-08-05. I fixed only the fmt diffs my own additions introduced and left the rest alone.

6. **Review-item disagreements you may want to settle.** `rust-craftsmanship-reviewer` suggested five low-severity changes I declined: `impl Into<Option<&str>>` for the display-name parameter (kept `Option<&str>` — explicit over terse); wrapping `PythonAddedProcessor` around the SDK's `AddedProcessor`; adding `AddedProcessor::output(port)`; an `AsRef<ProcessorUniqueId>` impl to un-narrow `AppPortEndpoint` (the narrowing is what the change file commissioned, and `App::runner()` is the escape hatch); and a `HashSet` fast path on the collision loop (the cubic path needs ~1000 same-named nodes in one hand-authored graph). Each is a small, separable follow-up if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Processor display names are now automatically made unique when duplicates occur, including default and custom names.
  - Added SDK support for optional display names when creating processors.
  - Processor creation results now provide both the processor ID and the final assigned display name.
  - Added an `AddedProcessor` handle for accessing processor identity and display name.

- **Bug Fixes**
  - Preserved display names consistently across graph exports and save/load cycles.
  - Prevented display-name suffixes from affecting processor types or IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Correction to the test plan — `streamlib-engine --lib` is not a trustworthy gate

The `1175 passed` line above is a real result, but it under-reports. That binary aborts intermittently, and I characterised it after opening this PR:

```
corrupted size vs. prev_size while consolidating
process didn't exit successfully: .../streamlib_engine-df60bb05133d9432
  (signal: 6, SIGABRT: process abort signal)
```

- **This branch: 2 aborts in 5 runs. `main` at `96717c8f`: 1 abort in 6 runs.** Same glibc message, same signal. **Pre-existing, not introduced here** — samples are too small to claim any rate difference between the two.
- `corrupted size vs. prev_size` is glibc's heap-corruption detector, not a test assertion or a timeout. It is memory corruption in the test process, surfacing under the default parallel test threads. The known-flake note in the repo's lore calls this a "rare SIGABRT"; at 1-in-3 to 1-in-6 it is not rare.
- Consequence for this PR: a green `--lib` run is weak evidence. The load-bearing coverage for #1838 is the integration binaries and the wheel suite, which are deterministic and did not abort in any run.

**Filed as #1846** (owner confirmed P0; a separate session takes the fix). Root cause found: a heap-use-after-free in `HostVulkanDevice::new` — `CStr::from_ptr`'s unbounded lifetime lets `&CStr`s outlive the `Vec<vk::ExtensionProperties>` they borrow from, at `vulkan_device.rs:775-784` and again at `consumer_vulkan_device.rs:186-195`. It is on the real GPU bring-up path, not test-only. `--test-threads=1` is clean 6/6 and is the trustworthy invocation until it lands.

Original recommendation, kept for the record: worth treating as P0 rather than test-hygiene, because heap corruption in the engine's own process is a shipped-code risk and not only a CI annoyance. Suggested first step is a run under ASAN or `valgrind`, or bisecting by module subset to find which co-scheduled tests trigger it — the unsafe FFI paths (Vulkan, iceoryx2, the vendored VMA bindings) are the places to look first.