### PR TITLE
fix(rhi): the extension-properties buffer outlives the names it lends

### DIFF
--- a/.github/workflows/check-no-unbounded-cstr-from-ptr.yml
+++ b/.github/workflows/check-no-unbounded-cstr-from-ptr.yml
@@ -1,0 +1,47 @@
+name: Check No Unbounded CStr From Ptr
+
+# CI gate for borrow-checked C strings in the Vulkan RHI.
+# `cargo xtask check-no-unbounded-cstr-from-ptr` walks the RHI trees and fails
+# on any `CStr::from_ptr(<owner>.as_ptr())` — that spelling returns an
+# unbounded lifetime, so the borrow outlives the storage it points into
+# (the #1846 use-after-free). `vk::StringArray::as_cstr` is the drop-in.
+#
+# Grep-shaped on purpose: sub-second on a clean runner, no workspace build.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  xtask-check-no-unbounded-cstr-from-ptr:
+    name: xtask check-no-unbounded-cstr-from-ptr
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        # A cache-service flake must never fail the job; a miss just means a cold build.
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-${{ hashFiles('xtask/Cargo.toml', 'xtask/Cargo.lock', 'Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-
+
+      - name: cargo xtask check-no-unbounded-cstr-from-ptr
+        run: cargo run --locked -q -p xtask -- check-no-unbounded-cstr-from-ptr
+
+      - name: cargo test -p xtask check_no_unbounded_cstr_from_ptr (fixture tests)
+        run: cargo test --locked -p xtask check_no_unbounded_cstr_from_ptr

--- a/runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
+++ b/runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
@@ -153,7 +153,9 @@ impl ConsumerVulkanDevice {
             .unwrap_or(physical_devices[0]);
 
         let device_props = unsafe { instance.get_physical_device_properties(physical_device) };
-        let device_name = unsafe { CStr::from_ptr(device_props.device_name.as_ptr()) }
+        let device_name = device_props
+            .device_name
+            .as_cstr()
             .to_string_lossy()
             .into_owned();
 

--- a/runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
+++ b/runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
@@ -41,6 +41,7 @@ use vulkanalia::loader::{LIBRARY, LibloadingLoader};
 use vulkanalia::prelude::v1_4::*;
 use vulkanalia::vk;
 
+use crate::vulkan_extension_names::vulkan_extension_names_borrowed_from_properties;
 use crate::{ConsumerMarker, ConsumerRhiError, Result, VulkanRhiDevice};
 
 /// Single-COLOR-aspect / single-mip / single-layer subresource range —
@@ -183,8 +184,6 @@ impl ConsumerVulkanDevice {
         // Required device extensions. All four are mandatory on the
         // carve-out path — refusing to construct the device on a driver
         // that doesn't expose them is the right shape (see module docs).
-        // Bound here rather than left a temporary because every name below
-        // borrows from it.
         let available_device_extension_properties = unsafe {
             instance
                 .enumerate_device_extension_properties(physical_device, None)
@@ -192,9 +191,8 @@ impl ConsumerVulkanDevice {
                     ConsumerRhiError::Gpu(format!("enumerate_device_extension_properties: {e}"))
                 })?
         };
-        let available_device_ext_names = crate::vulkan_extension_names_borrowed_from_properties(
-            &available_device_extension_properties,
-        );
+        let available_device_ext_names =
+            vulkan_extension_names_borrowed_from_properties(&available_device_extension_properties);
 
         const REQUIRED: &[&CStr] = &[
             c"VK_KHR_external_memory",

--- a/runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
+++ b/runtime/streamlib-consumer-rhi/src/consumer_vulkan_device.rs
@@ -183,16 +183,18 @@ impl ConsumerVulkanDevice {
         // Required device extensions. All four are mandatory on the
         // carve-out path — refusing to construct the device on a driver
         // that doesn't expose them is the right shape (see module docs).
-        let available_device_ext_names: Vec<&CStr> = unsafe {
+        // Bound here rather than left a temporary because every name below
+        // borrows from it.
+        let available_device_extension_properties = unsafe {
             instance
                 .enumerate_device_extension_properties(physical_device, None)
                 .map_err(|e| {
                     ConsumerRhiError::Gpu(format!("enumerate_device_extension_properties: {e}"))
                 })?
-        }
-        .iter()
-        .map(|ext| unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) })
-        .collect();
+        };
+        let available_device_ext_names = crate::vulkan_extension_names_borrowed_from_properties(
+            &available_device_extension_properties,
+        );
 
         const REQUIRED: &[&CStr] = &[
             c"VK_KHR_external_memory",

--- a/runtime/streamlib-consumer-rhi/src/lib.rs
+++ b/runtime/streamlib-consumer-rhi/src/lib.rs
@@ -59,6 +59,8 @@ mod consumer_vulkan_texture;
 #[cfg(target_os = "linux")]
 mod device_capability;
 #[cfg(target_os = "linux")]
+mod vulkan_extension_names;
+#[cfg(target_os = "linux")]
 mod vulkan_layout;
 
 pub use error::{ConsumerRhiError, Result};
@@ -85,6 +87,8 @@ pub use device_capability::{
     ConsumerMarker, DevicePrivilege, VulkanRhiBuffer, VulkanRhiDevice, VulkanTextureLike,
     VulkanTimelineSemaphoreLike,
 };
+#[cfg(target_os = "linux")]
+pub use vulkan_extension_names::vulkan_extension_names_borrowed_from_properties;
 #[cfg(target_os = "linux")]
 pub use vulkan_layout::VulkanLayout;
 

--- a/runtime/streamlib-consumer-rhi/src/vulkan_extension_names.rs
+++ b/runtime/streamlib-consumer-rhi/src/vulkan_extension_names.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Borrowing extension names out of an enumerated `VkExtensionProperties` buffer.
+//!
+//! Both Vulkan device bring-up paths — the host `HostVulkanDevice` and the
+//! carve-out `ConsumerVulkanDevice` — enumerate device extensions and then test
+//! the results by name. Lives in consumer-rhi so the two share one spelling
+//! rather than each re-deriving the borrow.
+
+use std::ffi::CStr;
+
+use vulkanalia::vk;
+
+/// Borrows every extension name out of an enumerated properties buffer.
+///
+/// Each `vk::ExtensionProperties` stores its name as an inline
+/// `StringArray`, so the returned `&CStr`s point into
+/// `available_extension_properties` itself. Taking the buffer by reference ties
+/// that borrow to the caller's owner: a caller that passes a temporary, or lets
+/// the owner fall out of scope first, fails to compile.
+///
+/// The trap this exists to close is `CStr::from_ptr`, whose *unbounded* return
+/// lifetime silences the borrow checker entirely and let two bring-up paths
+/// read freed memory (#1846). `StringArray::as_cstr` borrows from `&self`, so
+/// the enforcement is the type system rather than reviewer attention.
+pub fn vulkan_extension_names_borrowed_from_properties(
+    available_extension_properties: &[vk::ExtensionProperties],
+) -> Vec<&CStr> {
+    available_extension_properties
+        .iter()
+        .map(|extension_properties| extension_properties.extension_name.as_cstr())
+        .collect()
+}
+
+/// Compile-time proof that the borrow is tied to the properties buffer.
+///
+/// The negative cases below are the exact shapes that shipped as
+/// use-after-free in #1846: an owner that is a statement temporary, and an
+/// owner confined to a block that closes before the names are read. Both must
+/// stay `compile_fail`. If a future change reintroduces an unbounded lifetime
+/// (a bare `CStr::from_ptr`, or a signature taking the buffer by value), these
+/// start compiling and the suite fails.
+///
+/// The owner is a statement temporary — `ConsumerVulkanDevice::new`'s shape.
+///
+/// ```compile_fail,E0716
+/// use streamlib_consumer_rhi::vulkan_extension_names_borrowed_from_properties;
+/// use vulkanalia::vk;
+///
+/// let names = vulkan_extension_names_borrowed_from_properties(&vec![
+///     vk::ExtensionProperties::default(),
+/// ]);
+/// assert_eq!(names.len(), 1);
+/// ```
+///
+/// The owner is confined to a block — `HostVulkanDevice::new`'s shape.
+///
+/// ```compile_fail,E0597
+/// use streamlib_consumer_rhi::vulkan_extension_names_borrowed_from_properties;
+/// use vulkanalia::vk;
+///
+/// let names = {
+///     let available = vec![vk::ExtensionProperties::default()];
+///     vulkan_extension_names_borrowed_from_properties(&available)
+/// };
+/// assert_eq!(names.len(), 1);
+/// ```
+///
+/// Positive control — the owner outlives the borrow, so this compiles.
+///
+/// ```
+/// use streamlib_consumer_rhi::vulkan_extension_names_borrowed_from_properties;
+/// use vulkanalia::vk;
+///
+/// let available = vec![vk::ExtensionProperties::default()];
+/// let names = vulkan_extension_names_borrowed_from_properties(&available);
+/// assert_eq!(names.len(), 1);
+/// ```
+#[doc(hidden)]
+pub mod __extension_name_borrow_doctests {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extension_properties_named(name: &[u8]) -> vk::ExtensionProperties {
+        vk::ExtensionProperties {
+            extension_name: vk::StringArray::from_bytes(name),
+            spec_version: 1,
+        }
+    }
+
+    #[test]
+    fn borrows_each_name_in_order() {
+        let available = vec![
+            extension_properties_named(b"VK_KHR_external_memory"),
+            extension_properties_named(b"VK_KHR_external_memory_fd"),
+            extension_properties_named(b"VK_EXT_external_memory_dma_buf"),
+        ];
+
+        let names = vulkan_extension_names_borrowed_from_properties(&available);
+
+        assert_eq!(
+            names,
+            vec![
+                c"VK_KHR_external_memory",
+                c"VK_KHR_external_memory_fd",
+                c"VK_EXT_external_memory_dma_buf",
+            ]
+        );
+    }
+
+    #[test]
+    fn contains_distinguishes_a_prefix_from_a_full_name() {
+        let available = vec![extension_properties_named(b"VK_KHR_external_memory_fd")];
+
+        let names = vulkan_extension_names_borrowed_from_properties(&available);
+
+        assert!(names.contains(&c"VK_KHR_external_memory_fd"));
+        assert!(!names.contains(&c"VK_KHR_external_memory"));
+    }
+
+    #[test]
+    fn empty_properties_yield_no_names() {
+        let available: Vec<vk::ExtensionProperties> = Vec::new();
+
+        assert!(vulkan_extension_names_borrowed_from_properties(&available).is_empty());
+    }
+
+    /// A driver that fills the array to its last byte leaves no room for a
+    /// terminator; reading must stop at the array bound rather than run into
+    /// the next element.
+    #[test]
+    fn a_name_filling_the_array_stops_at_the_bound() {
+        let longest = vec![b'x'; vk::MAX_EXTENSION_NAME_SIZE];
+        let available = vec![
+            extension_properties_named(&longest),
+            extension_properties_named(b"VK_KHR_external_memory"),
+        ];
+
+        let names = vulkan_extension_names_borrowed_from_properties(&available);
+
+        assert_eq!(names[0].to_bytes().len(), vk::MAX_EXTENSION_NAME_SIZE - 1);
+        assert_eq!(names[1], c"VK_KHR_external_memory");
+    }
+
+    /// The names must stay readable after the borrow is handed across a scope
+    /// the owner outlives — the property the two #1846 sites violated.
+    #[test]
+    fn names_stay_readable_while_the_owner_lives() {
+        let available = vec![extension_properties_named(
+            b"VK_EXT_image_drm_format_modifier",
+        )];
+
+        let names = vulkan_extension_names_borrowed_from_properties(&available);
+        let observed: Vec<String> = names
+            .iter()
+            .map(|name| name.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            observed,
+            vec!["VK_EXT_image_drm_format_modifier".to_string()]
+        );
+    }
+}

--- a/runtime/streamlib-consumer-rhi/src/vulkan_extension_names.rs
+++ b/runtime/streamlib-consumer-rhi/src/vulkan_extension_names.rs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //! Borrowing extension names out of an enumerated `VkExtensionProperties` buffer.
-//!
-//! Both Vulkan device bring-up paths — the host `HostVulkanDevice` and the
-//! carve-out `ConsumerVulkanDevice` — enumerate device extensions and then test
-//! the results by name. Lives in consumer-rhi so the two share one spelling
-//! rather than each re-deriving the borrow.
 
 use std::ffi::CStr;
 
@@ -14,16 +9,10 @@ use vulkanalia::vk;
 
 /// Borrows every extension name out of an enumerated properties buffer.
 ///
-/// Each `vk::ExtensionProperties` stores its name as an inline
-/// `StringArray`, so the returned `&CStr`s point into
-/// `available_extension_properties` itself. Taking the buffer by reference ties
-/// that borrow to the caller's owner: a caller that passes a temporary, or lets
-/// the owner fall out of scope first, fails to compile.
-///
-/// The trap this exists to close is `CStr::from_ptr`, whose *unbounded* return
-/// lifetime silences the borrow checker entirely and let two bring-up paths
-/// read freed memory (#1846). `StringArray::as_cstr` borrows from `&self`, so
-/// the enforcement is the type system rather than reviewer attention.
+/// Each `vk::ExtensionProperties` stores its name as an inline `StringArray`,
+/// so the returned `&CStr`s point into `available_extension_properties`
+/// itself. The elided lifetime ties them to it: a caller that passes a
+/// temporary, or lets the owner fall out of scope first, fails to compile.
 pub fn vulkan_extension_names_borrowed_from_properties(
     available_extension_properties: &[vk::ExtensionProperties],
 ) -> Vec<&CStr> {
@@ -37,10 +26,13 @@ pub fn vulkan_extension_names_borrowed_from_properties(
 ///
 /// The negative cases below are the exact shapes that shipped as
 /// use-after-free in #1846: an owner that is a statement temporary, and an
-/// owner confined to a block that closes before the names are read. Both must
-/// stay `compile_fail`. If a future change reintroduces an unbounded lifetime
-/// (a bare `CStr::from_ptr`, or a signature taking the buffer by value), these
-/// start compiling and the suite fails.
+/// owner confined to a block that closes before the names are read.
+///
+/// What they lock is the *signature*. A signature that stops borrowing from
+/// the buffer — taking it by value, or handing back an unbounded lifetime —
+/// makes these compile and fails the suite. They say nothing about how the
+/// body spells the borrow, and nothing about call sites elsewhere: with this
+/// signature, elision ties the return to the parameter whatever the body does.
 ///
 /// The owner is a statement temporary — `ConsumerVulkanDevice::new`'s shape.
 ///
@@ -128,9 +120,9 @@ mod tests {
         assert!(vulkan_extension_names_borrowed_from_properties(&available).is_empty());
     }
 
-    /// A driver that fills the array to its last byte leaves no room for a
-    /// terminator; reading must stop at the array bound rather than run into
-    /// the next element.
+    /// An over-long name is truncated to leave room for the terminator, and
+    /// reading it stops at the array bound rather than running into the next
+    /// element.
     #[test]
     fn a_name_filling_the_array_stops_at_the_bound() {
         let longest = vec![b'x'; vk::MAX_EXTENSION_NAME_SIZE];

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -774,9 +774,7 @@ impl HostVulkanDevice {
             device_extensions.push(c"VK_KHR_portability_subset".as_ptr());
         }
 
-        // On Linux, enumerate device extensions once and enable what's available.
-        // The properties buffer is bound in this scope because every name below
-        // borrows from it.
+        // On Linux, enumerate device extensions once and enable what's available
         #[cfg(target_os = "linux")]
         let available_device_extension_properties =
             unsafe { instance.enumerate_device_extension_properties(physical_device, None) }

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -17,6 +17,9 @@ use crate::core::rhi::TextureDescriptor;
 use crate::core::{Error, Result};
 
 #[cfg(target_os = "linux")]
+use streamlib_consumer_rhi::vulkan_extension_names_borrowed_from_properties;
+
+#[cfg(target_os = "linux")]
 use super::drm_modifier_probe::{self, DrmModifierTable};
 use super::{HostMarker, HostVulkanTexture, VulkanCommandQueue, VulkanRhiDevice};
 
@@ -771,17 +774,23 @@ impl HostVulkanDevice {
             device_extensions.push(c"VK_KHR_portability_subset".as_ptr());
         }
 
-        // On Linux, enumerate device extensions once and enable what's available
+        // On Linux, enumerate device extensions once and enable what's available.
+        // The properties buffer is bound in this scope because every name below
+        // borrows from it.
         #[cfg(target_os = "linux")]
-        let available_device_ext_names: Vec<&CStr> = {
-            let available_device_extensions =
-                unsafe { instance.enumerate_device_extension_properties(physical_device, None) }
-                    .unwrap_or_default();
-            available_device_extensions
-                .iter()
-                .map(|ext| unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) })
-                .collect()
-        };
+        let available_device_extension_properties =
+            unsafe { instance.enumerate_device_extension_properties(physical_device, None) }
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "vkEnumerateDeviceExtensionProperties failed; treating this device as \
+                         exposing no optional extensions"
+                    );
+                })
+                .unwrap_or_default();
+        #[cfg(target_os = "linux")]
+        let available_device_ext_names =
+            vulkan_extension_names_borrowed_from_properties(&available_device_extension_properties);
 
         // On Linux, check for DMA-BUF external memory extensions
         #[cfg(target_os = "linux")]

--- a/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
+++ b/runtime/streamlib-engine/src/vulkan/rhi/vulkan_device.rs
@@ -419,7 +419,7 @@ impl HostVulkanDevice {
 
         let available_ext_names: Vec<&CStr> = available_extensions
             .iter()
-            .map(|ext| unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) })
+            .map(|ext| ext.extension_name.as_cstr())
             .collect();
 
         // 3. Build extension list
@@ -525,7 +525,7 @@ impl HostVulkanDevice {
         if want_validation {
             let layers = unsafe { entry.enumerate_instance_layer_properties() }.unwrap_or_default();
             let layer_present = layers.iter().any(|l| {
-                let name = unsafe { CStr::from_ptr(l.layer_name.as_ptr()) };
+                let name = l.layer_name.as_cstr();
                 name == validation_layer_name.as_c_str()
             });
             if layer_present {
@@ -579,8 +579,7 @@ impl HostVulkanDevice {
             .unwrap_or(physical_devices[0]);
 
         let device_props = unsafe { instance.get_physical_device_properties(physical_device) };
-        let device_name =
-            unsafe { CStr::from_ptr(device_props.device_name.as_ptr()) }.to_string_lossy();
+        let device_name = device_props.device_name.as_cstr().to_string_lossy();
 
         // PCI vendor IDs assigned by Khronos Vulkan registry. NVIDIA's
         // proprietary Linux driver (and currently NVK on the same

--- a/runtime/streamlib-engine/src/vulkan/video/codec_utils/vk_image_resource.rs
+++ b/runtime/streamlib-engine/src/vulkan/video/codec_utils/vk_image_resource.rs
@@ -861,19 +861,8 @@ impl Drop for VkImageResource {
     }
 }
 
-/// A device whose command table resolves to nothing.
-///
-/// Tests here exercise pure layout logic and never issue a Vulkan call, but
-/// `VkImageResource` still has to hold a `vulkanalia::Device`. That type owns
-/// two `BTreeSet`s, so `MaybeUninit::uninit().assume_init()` hands it garbage
-/// heap pointers — undefined behaviour the moment it is created, and a wild
-/// free for any caller who drops it.
-///
-/// `Device::from_created` fills the command table from the loader it is given.
-/// A loader that resolves nothing leaves every entry as vulkanalia's own
-/// panicking fallback and both name sets legitimately empty, so the value is
-/// fully initialized and safe to drop. A stray Vulkan call panics by name
-/// instead of corrupting the heap.
+/// A fully initialized device whose every command resolves to vulkanalia's
+/// panicking fallback, so a Vulkan call on it aborts by name.
 #[cfg(test)]
 fn device_with_no_loaded_commands() -> vulkanalia::Device {
     unsafe extern "system" fn resolve_nothing(
@@ -883,6 +872,10 @@ fn device_with_no_loaded_commands() -> vulkanalia::Device {
         None
     }
 
+    // SAFETY: `from_created` documents that the handle must come from a real
+    // `vkCreateDevice`; a null one deliberately does not. Nothing dereferences
+    // it — the loader ignores the handle it is passed, and the returned device
+    // is never used for a call.
     unsafe {
         vulkanalia::Device::from_created(
             resolve_nothing,

--- a/runtime/streamlib-engine/src/vulkan/video/codec_utils/vk_image_resource.rs
+++ b/runtime/streamlib-engine/src/vulkan/video/codec_utils/vk_image_resource.rs
@@ -861,21 +861,48 @@ impl Drop for VkImageResource {
     }
 }
 
+/// A device whose command table resolves to nothing.
+///
+/// Tests here exercise pure layout logic and never issue a Vulkan call, but
+/// `VkImageResource` still has to hold a `vulkanalia::Device`. That type owns
+/// two `BTreeSet`s, so `MaybeUninit::uninit().assume_init()` hands it garbage
+/// heap pointers — undefined behaviour the moment it is created, and a wild
+/// free for any caller who drops it.
+///
+/// `Device::from_created` fills the command table from the loader it is given.
+/// A loader that resolves nothing leaves every entry as vulkanalia's own
+/// panicking fallback and both name sets legitimately empty, so the value is
+/// fully initialized and safe to drop. A stray Vulkan call panics by name
+/// instead of corrupting the heap.
+#[cfg(test)]
+fn device_with_no_loaded_commands() -> vulkanalia::Device {
+    unsafe extern "system" fn resolve_nothing(
+        _device: vk::Device,
+        _name: *const std::ffi::c_char,
+    ) -> vk::PFN_vkVoidFunction {
+        None
+    }
+
+    unsafe {
+        vulkanalia::Device::from_created(
+            resolve_nothing,
+            vk::PhysicalDevice::null(),
+            &vk::DeviceCreateInfo::default(),
+            vk::Device::null(),
+        )
+    }
+    .expect("loading an empty command table cannot fail")
+}
+
 #[cfg(test)]
 impl VkImageResource {
     /// Create a test-only VkImageResource without a real Vulkan device.
     ///
-    /// SAFETY: The returned resource has `owns_resources = false` and must never
-    /// have device methods called on it. This is only for testing pure logic
-    /// (is_compatible, get_plane_layout, etc.).
-    /// Create a test-only VkImageResource that is wrapped in ManuallyDrop
-    /// to prevent the uninitialized Device from being dropped.
-    fn new_test_stub(image_create_info: vk::ImageCreateInfo) -> std::mem::ManuallyDrop<Self> {
-        // SAFETY: dummy_device is never used for Vulkan calls; owns_resources is false.
-        // ManuallyDrop prevents the uninitialized Device from being dropped.
-        let device: vulkanalia::Device = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-        std::mem::ManuallyDrop::new(Self {
-            device,
+    /// The resource has `owns_resources = false`, so `destroy` never reaches
+    /// the device.
+    fn new_test_stub(image_create_info: vk::ImageCreateInfo) -> Self {
+        Self {
+            device: device_with_no_loaded_commands(),
             image: vk::Image::null(),
             image_create_info,
             image_offset: 0,
@@ -893,7 +920,7 @@ impl VkImageResource {
             is_subsampled_y: false,
             uses_drm_format_modifier: false,
             owns_resources: false,
-        })
+        }
     }
 }
 
@@ -1363,15 +1390,6 @@ fn cleanup_views(device: &vulkanalia::Device, views: &[vk::ImageView; 4], count:
 mod tests {
     use super::*;
 
-    /// Create a dummy vulkanalia::Device for testing pure logic that never
-    /// invokes device methods. Uses MaybeUninit to avoid the zeroed-initialization
-    /// panic on function pointers.
-    ///
-    /// SAFETY: Caller must never call Vulkan methods on the returned device.
-    unsafe fn dummy_device() -> vulkanalia::Device {
-        unsafe { std::mem::MaybeUninit::uninit().assume_init() }
-    }
-
     #[test]
     fn test_ycbcr_vk_format_info_nv12() {
         let info = ycbcr_vk_format_info(vk::Format::G8_B8R8_2PLANE_420_UNORM);
@@ -1529,8 +1547,8 @@ mod tests {
         };
 
         // No DRM modifier
-        let r1 = std::mem::ManuallyDrop::new(VkImageResource::new_inner(
-            unsafe { dummy_device() },
+        let r1 = VkImageResource::new_inner(
+            device_with_no_loaded_commands(),
             &base_info,
             vk::Image::null(),
             0,
@@ -1540,12 +1558,12 @@ mod tests {
             None,
             0,
             0,
-        ));
+        );
         assert!(!r1.uses_drm_format_modifier);
 
         // With DRM modifier value
-        let r2 = std::mem::ManuallyDrop::new(VkImageResource::new_inner(
-            unsafe { dummy_device() },
+        let r2 = VkImageResource::new_inner(
+            device_with_no_loaded_commands(),
             &base_info,
             vk::Image::null(),
             0,
@@ -1555,7 +1573,7 @@ mod tests {
             None,
             1,
             2,
-        ));
+        );
         assert!(r2.uses_drm_format_modifier);
         assert_eq!(r2.drm_format_modifier, 1);
         assert_eq!(r2.memory_plane_count, 2);
@@ -1565,8 +1583,8 @@ mod tests {
             tiling: vk::ImageTiling::DRM_FORMAT_MODIFIER_EXT,
             ..base_info
         };
-        let r3 = std::mem::ManuallyDrop::new(VkImageResource::new_inner(
-            unsafe { dummy_device() },
+        let r3 = VkImageResource::new_inner(
+            device_with_no_loaded_commands(),
             &drm_info,
             vk::Image::null(),
             0,
@@ -1576,7 +1594,7 @@ mod tests {
             None,
             0,
             0,
-        ));
+        );
         assert!(r3.uses_drm_format_modifier);
     }
 
@@ -1618,8 +1636,8 @@ mod tests {
 
     #[test]
     fn test_memory_plane_layout_bounds() {
-        let resource = std::mem::ManuallyDrop::new(VkImageResource {
-            device: unsafe { dummy_device() },
+        let resource = VkImageResource {
+            device: device_with_no_loaded_commands(),
             image: vk::Image::null(),
             image_create_info: vk::ImageCreateInfo {
                 s_type: vk::StructureType::IMAGE_CREATE_INFO,
@@ -1674,7 +1692,7 @@ mod tests {
             is_subsampled_y: true,
             uses_drm_format_modifier: true,
             owns_resources: false,
-        });
+        };
 
         // Valid planes
         assert!(resource.get_memory_plane_layout(0).is_some());

--- a/xtask/src/check_no_unbounded_cstr_from_ptr.rs
+++ b/xtask/src/check_no_unbounded_cstr_from_ptr.rs
@@ -1,0 +1,339 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Bans the unbounded-lifetime spelling `CStr::from_ptr(<owner>.as_ptr())` in
+//! the Vulkan RHI trees.
+//!
+//! `CStr::from_ptr` returns an *unbounded* lifetime: the borrow checker cannot
+//! tie the resulting `&CStr` to the buffer the pointer came from, so a name
+//! read out of an enumerated `VkExtensionProperties` / `VkLayerProperties` /
+//! `VkPhysicalDeviceProperties` buffer keeps compiling after that buffer is
+//! dropped. Two device bring-up paths shipped exactly that use-after-free
+//! (#1846). Every Vulkan inline name array is a `vk::StringArray`, whose
+//! `as_cstr(&self) -> &CStr` performs the same read while borrowing from
+//! `&self` — the lifetime the compiler can then check.
+//!
+//! `.as_ptr()` inside the argument is the discriminator. A bare pointer
+//! argument — `CStr::from_ptr(extension_names_ptr)` over storage an external
+//! API owns — has no Rust owner to borrow from and is not flagged.
+//!
+//! Cheap substring scan (no `syn`/compile). Whole-line comments are skipped, and
+//! a per-line `streamlib:allow-unbounded-cstr-from-ptr` pragma is the escape
+//! hatch.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Workspace-relative roots that own every `vulkanalia` call.
+const SCAN_ROOTS: &[&str] = &[
+    "runtime/streamlib-engine/src/vulkan",
+    "runtime/streamlib-consumer-rhi/src",
+];
+
+const UNBOUNDED_CSTR_CONSTRUCTOR: &str = "CStr::from_ptr(";
+
+/// Presence of this in the argument means a Rust value owns the storage, so a
+/// borrowing accessor exists and the unbounded lifetime is unnecessary.
+const OWNED_STORAGE_POINTER_ACCESSOR: &str = ".as_ptr()";
+
+/// The borrowing accessor every `vk::StringArray` offers.
+const BORROWING_ACCESSOR: &str = "StringArray::as_cstr";
+
+/// Per-line escape hatch for a deliberate, reviewed unbounded borrow.
+const ALLOW_LINE_PRAGMA: &str = "streamlib:allow-unbounded-cstr-from-ptr";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct UnboundedCStrFromPtrViolation {
+    pub file: PathBuf,
+    pub line: usize,
+    pub call_text: String,
+}
+
+#[derive(Debug, Default)]
+pub struct UnboundedCStrFromPtrScanReport {
+    pub violations: Vec<UnboundedCStrFromPtrViolation>,
+    pub files_scanned: usize,
+    pub files_scanned_per_root: Vec<(&'static str, usize)>,
+}
+
+pub fn run(workspace_root: &Path) -> Result<()> {
+    let report = scan(workspace_root)?;
+    crate::ensure_source_walking_gate_read_source(
+        "check-no-unbounded-cstr-from-ptr",
+        &format!("{SCAN_ROOTS:?}"),
+        report.files_scanned,
+        "an unbounded-lifetime CStr borrow re-enter the Vulkan RHI",
+    )?;
+    ensure_every_scan_root_contributed(&report)?;
+
+    if report.violations.is_empty() {
+        println!(
+            "✓ check-no-unbounded-cstr-from-ptr: {} Vulkan RHI file(s) scanned, \
+             no `CStr::from_ptr(<owner>.as_ptr())`",
+            report.files_scanned,
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "✗ check-no-unbounded-cstr-from-ptr: {} violation(s)",
+        report.violations.len()
+    );
+    for violation in &report.violations {
+        eprintln!(
+            "  {}:{}: `{}` — `CStr::from_ptr` returns an unbounded lifetime, so the \
+             borrow is not tied to the storage `.as_ptr()` came from and compiles \
+             even once that storage is gone. Use the owner's borrowing accessor \
+             (`{BORROWING_ACCESSOR}`) so the lifetime is checked. See issue #1846.",
+            violation.file.display(),
+            violation.line,
+            violation.call_text,
+        );
+    }
+    anyhow::bail!(
+        "check-no-unbounded-cstr-from-ptr: {} unbounded CStr borrow(s) in the Vulkan RHI",
+        report.violations.len()
+    );
+}
+
+/// A renamed or moved root would leave the other one carrying the whole gate,
+/// which reads identically to a clean tree.
+fn ensure_every_scan_root_contributed(report: &UnboundedCStrFromPtrScanReport) -> Result<()> {
+    for (root, files_scanned) in &report.files_scanned_per_root {
+        anyhow::ensure!(
+            *files_scanned > 0,
+            "check-no-unbounded-cstr-from-ptr scanned 0 files under {root} — that scan \
+             root moved out from under the gate"
+        );
+    }
+    Ok(())
+}
+
+pub fn scan(workspace_root: &Path) -> Result<UnboundedCStrFromPtrScanReport> {
+    let mut report = UnboundedCStrFromPtrScanReport::default();
+    for root in SCAN_ROOTS {
+        let mut files_scanned_here = 0usize;
+        for entry in WalkDir::new(workspace_root.join(root))
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let body = fs::read_to_string(path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            files_scanned_here += 1;
+            for (line, call_text) in unbounded_cstr_from_ptr_calls(&body) {
+                report.violations.push(UnboundedCStrFromPtrViolation {
+                    file: path.to_path_buf(),
+                    line,
+                    call_text,
+                });
+            }
+        }
+        report.files_scanned += files_scanned_here;
+        report
+            .files_scanned_per_root
+            .push((root, files_scanned_here));
+    }
+    Ok(report)
+}
+
+/// Every `CStr::from_ptr(…)` in `body` whose argument reaches through
+/// `.as_ptr()`, as `(1-based line, whitespace-collapsed call text)`.
+fn unbounded_cstr_from_ptr_calls(body: &str) -> Vec<(usize, String)> {
+    let code = blank_out_exempt_lines(body);
+    let mut calls = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(offset) = code[search_from..].find(UNBOUNDED_CSTR_CONSTRUCTOR) {
+        let call_start = search_from + offset;
+        let open_paren = call_start + UNBOUNDED_CSTR_CONSTRUCTOR.len() - 1;
+        let Some(close_paren) = matching_close_paren(&code, open_paren) else {
+            break;
+        };
+        if code[open_paren + 1..close_paren].contains(OWNED_STORAGE_POINTER_ACCESSOR) {
+            calls.push((
+                code[..call_start].matches('\n').count() + 1,
+                code[call_start..=close_paren]
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            ));
+        }
+        search_from = close_paren + 1;
+    }
+    calls
+}
+
+/// Blank the lines the gate does not read while keeping the line count, so a
+/// reported line number still points at the source.
+fn blank_out_exempt_lines(body: &str) -> String {
+    body.lines()
+        .map(|line| {
+            if line.trim_start().starts_with("//") || line.contains(ALLOW_LINE_PRAGMA) {
+                ""
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn matching_close_paren(code: &str, open_paren: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (offset, byte) in code.as_bytes().iter().enumerate().skip(open_paren) {
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Both roots get a file, so a fixture exercises the same shape the gate
+    /// asserts on the real tree.
+    fn scan_engine_vulkan_file(rel: &str, body: &str) -> UnboundedCStrFromPtrScanReport {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), &format!("{}/{rel}", SCAN_ROOTS[0]), body);
+        write(
+            tmp.path(),
+            &format!("{}/lib.rs", SCAN_ROOTS[1]),
+            "pub fn ok() {}\n",
+        );
+        scan(tmp.path()).unwrap()
+    }
+
+    fn write(root: &Path, rel: &str, body: &str) {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, body).unwrap();
+    }
+
+    #[test]
+    fn flags_the_inline_name_array_shape_that_shipped_as_use_after_free() {
+        let report = scan_engine_vulkan_file(
+            "rhi/vulkan_device.rs",
+            "fn names(ext: &vk::ExtensionProperties) -> &CStr {\n    \
+             unsafe { CStr::from_ptr(ext.extension_name.as_ptr()) }\n}\n",
+        );
+        assert_eq!(report.violations.len(), 1, "got {:?}", report.violations);
+        assert_eq!(report.violations[0].line, 2);
+        assert_eq!(
+            report.violations[0].call_text,
+            "CStr::from_ptr(ext.extension_name.as_ptr())"
+        );
+    }
+
+    #[test]
+    fn accepts_a_bare_pointer_owned_by_an_external_api() {
+        let report = scan_engine_vulkan_file(
+            "rhi/drm_modifier_probe.rs",
+            "let exts = unsafe { CStr::from_ptr(exts_ptr) }.to_str().unwrap_or(\"\");\n",
+        );
+        assert!(
+            report.violations.is_empty(),
+            "an EGL-owned pointer has no Rust owner to borrow from: {:?}",
+            report.violations
+        );
+    }
+
+    #[test]
+    fn accepts_the_borrowing_accessor() {
+        let report = scan_engine_vulkan_file(
+            "rhi/vulkan_device.rs",
+            "let name = device_props.device_name.as_cstr();\n",
+        );
+        assert!(report.violations.is_empty(), "got {:?}", report.violations);
+    }
+
+    #[test]
+    fn skips_a_doc_comment_that_names_the_banned_spelling() {
+        let report = scan_engine_vulkan_file(
+            "rhi/vulkan_extension_names.rs",
+            "//! `CStr::from_ptr(properties.extension_name.as_ptr())` was the #1846 bug.\n\
+             /// Superseded by `CStr::from_ptr(x.as_ptr())`.\n\
+             pub fn ok() {}\n",
+        );
+        assert!(report.violations.is_empty(), "got {:?}", report.violations);
+    }
+
+    #[test]
+    fn skips_a_commented_out_call() {
+        let report = scan_engine_vulkan_file(
+            "rhi/vulkan_device.rs",
+            "    // let name = CStr::from_ptr(ext.extension_name.as_ptr());\n",
+        );
+        assert!(report.violations.is_empty(), "got {:?}", report.violations);
+    }
+
+    #[test]
+    fn flags_a_call_rustfmt_split_across_lines() {
+        let report = scan_engine_vulkan_file(
+            "rhi/vulkan_device.rs",
+            "let name = unsafe {\n    CStr::from_ptr(\n        layer_properties.layer_name.as_ptr(),\n    )\n};\n",
+        );
+        assert_eq!(report.violations.len(), 1, "got {:?}", report.violations);
+        assert_eq!(report.violations[0].line, 2);
+        assert_eq!(
+            report.violations[0].call_text,
+            "CStr::from_ptr( layer_properties.layer_name.as_ptr(), )"
+        );
+    }
+
+    #[test]
+    fn accepts_the_allow_line_pragma() {
+        let report = scan_engine_vulkan_file(
+            "rhi/vulkan_device.rs",
+            "let n = CStr::from_ptr(a.as_ptr()); // streamlib:allow-unbounded-cstr-from-ptr\n",
+        );
+        assert!(report.violations.is_empty(), "got {:?}", report.violations);
+    }
+
+    #[test]
+    fn scans_the_consumer_rhi_root() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            &format!("{}/mod.rs", SCAN_ROOTS[0]),
+            "pub fn ok() {}\n",
+        );
+        write(
+            tmp.path(),
+            &format!("{}/consumer_vulkan_device.rs", SCAN_ROOTS[1]),
+            "let name = unsafe { CStr::from_ptr(props.device_name.as_ptr()) };\n",
+        );
+        let report = scan(tmp.path()).unwrap();
+        assert_eq!(report.violations.len(), 1, "got {:?}", report.violations);
+    }
+
+    #[test]
+    fn refuses_a_tree_where_one_scan_root_read_nothing() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            &format!("{}/mod.rs", SCAN_ROOTS[0]),
+            "pub fn ok() {}\n",
+        );
+        let report = scan(tmp.path()).unwrap();
+        let err = ensure_every_scan_root_contributed(&report).unwrap_err();
+        assert!(err.to_string().contains(SCAN_ROOTS[1]), "got {err}");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ pub mod check_no_escalate_in_lifecycle;
 pub mod check_no_in_process_placement;
 pub mod check_no_inventory_submit;
 pub mod check_no_reverse_dns;
+pub mod check_no_unbounded_cstr_from_ptr;
 pub mod check_vendored_vulkanalia;
 pub mod lint_logging;
 pub mod normal_build_dep_graph;
@@ -108,6 +109,17 @@ enum Commands {
     /// reports `UNASSIGNED-Threading-Info`).
     CheckDeviceWaitIdle,
 
+    /// CI gate for the borrow-checked-C-string rule in the Vulkan RHI. Fails
+    /// on any `CStr::from_ptr(<owner>.as_ptr())` under
+    /// `runtime/streamlib-engine/src/vulkan/` or
+    /// `runtime/streamlib-consumer-rhi/src/`. `CStr::from_ptr` returns an
+    /// unbounded lifetime, so the borrow is never tied to the storage the
+    /// pointer came from and survives it — the use-after-free two device
+    /// bring-up paths shipped in #1846. `vk::StringArray::as_cstr` borrows
+    /// from `&self` and is the drop-in. A bare pointer argument owned by an
+    /// external API is not flagged.
+    CheckNoUnboundedCstrFromPtr,
+
     /// Drift trip-wire for the vendored vulkanalia fork trees
     /// (`vendor/tatolab-vulkanalia{,-sys,-vma}`): hashes each vendored crate
     /// dir and fails on any byte change vs. the recorded hash — the guard
@@ -142,6 +154,9 @@ fn main() -> Result<()> {
             check_no_escalate_in_lifecycle::run(&workspace_root()?)?
         }
         Commands::CheckDeviceWaitIdle => check_device_wait_idle::run(&workspace_root()?)?,
+        Commands::CheckNoUnboundedCstrFromPtr => {
+            check_no_unbounded_cstr_from_ptr::run(&workspace_root()?)?
+        }
         Commands::CheckVendoredVulkanalia => check_vendored_vulkanalia::run(&workspace_root()?)?,
     }
 


### PR DESCRIPTION
## Summary

Fixes a heap-use-after-free in the Vulkan device bring-up path that runs on every runtime start on Linux.

`CStr::from_ptr` returns an **unbounded** lifetime, so the borrow checker could not tie the resulting `&CStr` to the `Vec<vk::ExtensionProperties>` the pointer came from. Two sites let that buffer drop before the names were read:

- `HostVulkanDevice::new` — the owner was a block-local binding, freed at the closing brace.
- `ConsumerVulkanDevice::new` — the owner was a statement temporary, freed at the semicolon.

Both now bind the buffer and borrow through `vulkan_extension_names_borrowed_from_properties`, which maps via `StringArray::as_cstr` (safe, borrows from `&self`), so lifetime elision ties the names to the owner.

Three more sites used the same spelling and were safe only because their owner happened to be a named binding. Rather than leave the file mixed, all four moved to `as_cstr()` and `cargo xtask check-no-unbounded-cstr-from-ptr` now bans the spelling across the RHI trees — the discriminator is `.as_ptr()` in the argument, which separates an owned inline array (has a borrowing accessor) from a genuine raw FFI pointer (has none, stays allowed).

Also removes two `MaybeUninit::uninit().assume_init()` sites on `vulkanalia::Device`, which owns two `BTreeSet`s — UB at creation, and a wild free for anyone who dropped it. They now build a real device via `Device::from_created` with a loader that resolves nothing: every command slot gets vulkanalia's panicking fallback, both name sets are legitimately empty, and the value is safe to drop. The `ManuallyDrop` wrappers and the "next caller forgets the wrapper" hazard go with it.

## Closes

Closes #1846

## Exit criteria

- [x] Both use-after-free sites bind the properties buffer before borrowing from it
- [x] The broken shapes no longer compile — `compile_fail` doctests for the temporary owner (E0716) and the block-local owner (E0597)
- [x] Both `MaybeUninit` UB sites removed; rustc's `invalid_value` warnings gone
- [x] The spelling is machine-enforced, not convention

## Test plan

**ASAN red/green control pair** — the decisive evidence, run on an RTX 3090 / 24 cores:

| Run | Result |
|---|---|
| pre-fix `main` @ `c9e5fa06` | 🔴 `heap-use-after-free`, `READ of size 23`, exit 1 |
| this branch @ `c76e30f9` | 🟢 1175 passed, 0 sanitizer reports, exit 0 |

`READ of size 23` is exactly `VK_KHR_external_memory` (22 + NUL); the control's top frames land in `[i8]` slice comparison — the `&CStr` `.contains()` check.

```
CARGO_TARGET_DIR=/tmp/asan-target RUSTFLAGS="-Zsanitizer=address -Cdebuginfo=2" \
ASAN_OPTIONS="detect_leaks=0:abort_on_error=0:halt_on_error=1" \
cargo +nightly test -p streamlib-engine --lib --target x86_64-unknown-linux-gnu
```

Also run: the ticket's parallel repro loop (green, no abort); `cargo test -p streamlib-consumer-rhi` (22 lib + 9 doctests); `cargo test -p streamlib-engine --lib` (1175 passed); all 9 `cargo xtask` checks including the new one; `cargo fmt --check` clean on every changed file; `cargo doc -p streamlib --no-deps` warning-free.

The new lint was proven to fail, not just to pass: reintroducing the bug at a migrated site makes it exit 1 with the right message, and the bare-FFI-pointer site in `drm_modifier_probe.rs` is scanned but correctly not flagged.

## Notes for owner

1. **`vulkan_device.rs:422` was in your "do not fix" list.** You wrote "Checked and correct, do not 'fix'" about it. I left it until you asked for the lint — a lint that bans the spelling cannot pass while four sites still use it, so the migration and the gate landed together. Worth knowing: 422 was not the last instance as an earlier review claimed; lines 528 and 583 had the identical spelling, so the one-line change alone would have closed nothing.

2. **CI does not run `streamlib-consumer-rhi` tests at all.** `test.yml` covers `streamlib`, `streamlib-macros`, and one engine integration test. The new unit tests and `compile_fail` guards are local-only, and the ASAN repro is rig-only — so the lint is currently the only automated detector for this class. Worth closing separately.

3. **`compile_fail` error codes are not enforced on stable rustdoc.** The `E0716`/`E0597` annotations document intent; a deliberately bogus `E0999` also passes. The compile-failure property itself *is* enforced. What the doctests lock is the helper's **signature** — with it unchanged, elision ties the lifetime whatever the body does.

4. **237 pre-existing clippy `disallowed_macros` errors** (`println!`/`eprintln!` in `#[cfg(test)]`) across 26 files, present on `main`. Notably `xtask lint-logging` — the actual CI gate — reports zero on the same tree, so the gate and `cargo clippy --all-targets` disagree about test code. Not touched.

5. **macOS not cross-compile-verified.** `cargo check --target aarch64-apple-darwin` fails here in an unrelated dep (`iceoryx2-pal-posix`, missing macOS SDK). Three migrated sites are cross-platform; `StringArray::as_cstr` is platform-independent, so risk is low, but CI should confirm.

6. **`docs/testing-hardware.md`'s exclude list names 5 crates** that are no longer workspace members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vulkan extension-name handling for safer device and extension enumeration.
  * Vulkan enumeration failures now degrade gracefully without exposing optional extensions.
  * Updated test utilities to avoid unsafe dummy device construction.

* **Chores**
  * Added automated checks to detect unsafe, unbounded Vulkan string conversions.
  * Added coverage and documentation for extension-name lifetime and conversion behavior.
  * Integrated the validation into continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->