### PR TITLE
feat(sdk): every processor descriptor carries its class's import path

### DIFF
--- a/docs/plan/changes/processor-class-identity.md
+++ b/docs/plan/changes/processor-class-identity.md
@@ -44,9 +44,16 @@ the engine disambiguating duplicates within one graph.
   read at `python_processor_registration.rs:90-100`, but only to format an error.
 - **Rust identity is captured by the macro, not `std::any::type_name`.** `type_name`'s
   output format is explicitly unspecified across compiler versions and must not key a
-  registry. The `#[processor]` macro captures
-  `concat!(module_path!(), "::", stringify!(Type))` at the expansion site. Resolved by
-  reading — the plan says "derived mechanically" and this is the only stable mechanism.
+  registry. The `#[processor]` macro captures the type path at the expansion site.
+  Resolved by reading — the plan says "derived mechanically" and this is the only stable
+  mechanism.
+
+  > ~~The macro captures `concat!(module_path!(), "::", stringify!(Type))`.~~ — Superseded
+  > 2026-08-11 by #1839. The macro wraps its whole expansion in `pub mod <AuthoredType>`
+  > (`codegen.rs` binds the module name to `item.ident`), so the descriptor is emitted
+  > *inside* a module already named for the author's type: a bare `module_path!()` is the
+  > full type path, and the form above would double the type name. Asserted as literals in
+  > `runtime/streamlib-engine/tests/processor_class_import_path_test.rs`.
 
 ## Processors defined in `__main__` — REVERSED by owner, 2026-08-04
 

--- a/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
+++ b/runtime/streamlib-engine/src/core/compiler/compiler_ops/open_iceoryx2_service_op.rs
@@ -1366,7 +1366,11 @@ mod tests {
                 TypeName::new("ProfileSink").unwrap(),
                 SemVer::new(1, 0, 0),
             );
-            let mut desc = ProcessorDescriptor::new(ident.clone(), "conflicting-profile sink");
+            let mut desc = ProcessorDescriptor::new(
+                ident.clone(),
+                concat!(module_path!(), "::ProfileSink"),
+                "conflicting-profile sink",
+            );
             desc.inputs
                 .push(PortDescriptor::iceoryx2("in1", "input").with_delivery_profile(profile));
             // Idempotent: a duplicate ident (re-run in the same process) errors;

--- a/runtime/streamlib-engine/src/core/compiler/scheduling.rs
+++ b/runtime/streamlib-engine/src/core/compiler/scheduling.rs
@@ -68,10 +68,14 @@ mod tests {
     #[test]
     fn strategy_reads_priority_from_registered_descriptor() {
         let id = ident("Widgetron");
-        let descriptor =
-            ProcessorDescriptor::new(id.clone(), "fixture").with_scheduling(ProcessorScheduling {
-                priority: ThreadPriority::RealTime,
-            });
+        let descriptor = ProcessorDescriptor::new(
+            id.clone(),
+            concat!(module_path!(), "::Widgetron"),
+            "fixture",
+        )
+        .with_scheduling(ProcessorScheduling {
+            priority: ThreadPriority::RealTime,
+        });
         PROCESSOR_REGISTRY
             .register_descriptor_only(descriptor)
             .expect("fixture descriptor registers cleanly");

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -624,7 +624,10 @@ mod tests {
     }
 
     fn unit_descriptor(name: SchemaIdent) -> ProcessorDescriptor {
-        ProcessorDescriptor::new(name, "test")
+        // Distinct per type so these fixtures keep the property production
+        // descriptors have: one import path names one class.
+        let import_path = format!("{}::{}", module_path!(), name.r#type.as_str());
+        ProcessorDescriptor::new(name, import_path, "test")
     }
 
     #[test]

--- a/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
+++ b/runtime/streamlib-engine/src/core/processors/processor_instance_factory.rs
@@ -339,6 +339,9 @@ impl ProcessorInstanceFactory {
 
         let outputs: Vec<PortInfo> = descriptor.outputs.iter().map(PortInfo::from).collect();
 
+        // Read before the descriptor moves into the map.
+        let processor_class_import_path = descriptor.processor_class_import_path.clone();
+
         self.port_info
             .write()
             .insert(type_name.clone(), (inputs.clone(), outputs.clone()));
@@ -352,7 +355,12 @@ impl ProcessorInstanceFactory {
             RegistrationKind::LegacyDyn { constructor },
         );
 
+        // A processor's class is reached by import and nothing else, so
+        // "which class is this?" is a question the record has to answer; a
+        // display name cannot, and by the time a helper fails to import one
+        // the app is long past `add`.
         tracing::info!(
+            %processor_class_import_path,
             "[register_dynamic] new processor type registered '{}'",
             type_name
         );

--- a/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
+++ b/runtime/streamlib-engine/src/core/runtime/operations_runtime.rs
@@ -566,8 +566,11 @@ mod connect_wires_without_inspecting_a_port_tests {
 
     /// Register the producer and consumer descriptors this module wires.
     fn register_producer_and_consumer_descriptors() {
-        let mut producer =
-            ProcessorDescriptor::new(ident("connectcheck", PRODUCER_TYPE), "producer");
+        let mut producer = ProcessorDescriptor::new(
+            ident("connectcheck", PRODUCER_TYPE),
+            concat!(module_path!(), "::ConnectCheckProducer"),
+            "producer",
+        );
         producer
             .outputs
             .push(PortDescriptor::iceoryx2("out", "output"));
@@ -575,8 +578,11 @@ mod connect_wires_without_inspecting_a_port_tests {
             .register_descriptor_only(producer)
             .expect("register producer descriptor");
 
-        let mut consumer =
-            ProcessorDescriptor::new(ident("connectcheck", CONSUMER_TYPE), "consumer");
+        let mut consumer = ProcessorDescriptor::new(
+            ident("connectcheck", CONSUMER_TYPE),
+            concat!(module_path!(), "::ConnectCheckConsumer"),
+            "consumer",
+        );
         consumer
             .inputs
             .push(PortDescriptor::iceoryx2("in", "input").with_delivery_profile("latest"));

--- a/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
+++ b/runtime/streamlib-engine/src/iceoryx2/delivery_profile.rs
@@ -247,7 +247,11 @@ mod tests {
             if let Some(profile) = declared_profile {
                 port = port.with_delivery_profile(profile);
             }
-            let mut descriptor = ProcessorDescriptor::new(ident.clone(), type_name);
+            let mut descriptor = ProcessorDescriptor::new(
+                ident.clone(),
+                format!("{}::{type_name}", module_path!()),
+                type_name,
+            );
             descriptor.inputs.push(port);
             PROCESSOR_REGISTRY
                 .register_descriptor_only(descriptor)

--- a/runtime/streamlib-engine/tests/connect_typed_errors_test.rs
+++ b/runtime/streamlib-engine/tests/connect_typed_errors_test.rs
@@ -46,7 +46,11 @@ fn register_test_type(short: &str, input: &str, output: &str) -> SchemaIdent {
         TypeName::new(short).unwrap(),
         SemVer::new(1, 0, 0),
     );
-    let descriptor = ProcessorDescriptor::new(id.clone(), "connect typed-errors test")
+    let descriptor = ProcessorDescriptor::new(
+        id.clone(),
+        format!("{}::{short}", module_path!()),
+        "connect typed-errors test",
+    )
         .with_input(PortDescriptor::new(input, "", false))
         .with_output(PortDescriptor::new(output, "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);

--- a/runtime/streamlib-engine/tests/connect_typed_errors_test.rs
+++ b/runtime/streamlib-engine/tests/connect_typed_errors_test.rs
@@ -51,8 +51,8 @@ fn register_test_type(short: &str, input: &str, output: &str) -> SchemaIdent {
         format!("{}::{short}", module_path!()),
         "connect typed-errors test",
     )
-        .with_input(PortDescriptor::new(input, "", false))
-        .with_output(PortDescriptor::new(output, "", false));
+    .with_input(PortDescriptor::new(input, "", false))
+    .with_output(PortDescriptor::new(output, "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
     id
 }

--- a/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
+++ b/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
@@ -29,7 +29,11 @@ fn register_test_type(short: &str) -> SchemaIdent {
         TypeName::new(short).unwrap(),
         SemVer::new(1, 0, 0),
     );
-    let descriptor = ProcessorDescriptor::new(id.clone(), "display-name disambiguation test")
+    let descriptor = ProcessorDescriptor::new(
+        id.clone(),
+        format!("{}::{short}", module_path!()),
+        "display-name disambiguation test",
+    )
         .with_input(PortDescriptor::new("_unused_in", "", false))
         .with_output(PortDescriptor::new("_unused_out", "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);

--- a/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
+++ b/runtime/streamlib-engine/tests/display_name_disambiguation_test.rs
@@ -34,8 +34,8 @@ fn register_test_type(short: &str) -> SchemaIdent {
         format!("{}::{short}", module_path!()),
         "display-name disambiguation test",
     )
-        .with_input(PortDescriptor::new("_unused_in", "", false))
-        .with_output(PortDescriptor::new("_unused_out", "", false));
+    .with_input(PortDescriptor::new("_unused_in", "", false))
+    .with_output(PortDescriptor::new("_unused_out", "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
     id
 }

--- a/runtime/streamlib-engine/tests/graph_readiness_signal_test.rs
+++ b/runtime/streamlib-engine/tests/graph_readiness_signal_test.rs
@@ -34,7 +34,11 @@ fn register_test_type(short: &str) -> SchemaIdent {
         TypeName::new(short).unwrap(),
         SemVer::new(1, 0, 0),
     );
-    let descriptor = ProcessorDescriptor::new(id.clone(), "graph readiness signal test")
+    let descriptor = ProcessorDescriptor::new(
+        id.clone(),
+        format!("{}::{short}", module_path!()),
+        "graph readiness signal test",
+    )
         .with_input(PortDescriptor::new("bags_from_upstream", "", false))
         .with_output(PortDescriptor::new("bags_to_downstream", "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);

--- a/runtime/streamlib-engine/tests/graph_readiness_signal_test.rs
+++ b/runtime/streamlib-engine/tests/graph_readiness_signal_test.rs
@@ -39,8 +39,8 @@ fn register_test_type(short: &str) -> SchemaIdent {
         format!("{}::{short}", module_path!()),
         "graph readiness signal test",
     )
-        .with_input(PortDescriptor::new("bags_from_upstream", "", false))
-        .with_output(PortDescriptor::new("bags_to_downstream", "", false));
+    .with_input(PortDescriptor::new("bags_from_upstream", "", false))
+    .with_output(PortDescriptor::new("bags_to_downstream", "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
     id
 }

--- a/runtime/streamlib-engine/tests/graph_snapshot_round_trip_test.rs
+++ b/runtime/streamlib-engine/tests/graph_snapshot_round_trip_test.rs
@@ -38,7 +38,11 @@ fn ident(short: &str) -> SchemaIdent {
 /// `connect`'s port existence check. Idempotent under `serial_test`.
 fn register_test_type(short: &str, input: &str, output: &str) -> SchemaIdent {
     let id = ident(short);
-    let descriptor = ProcessorDescriptor::new(id.clone(), "snapshot round-trip test")
+    let descriptor = ProcessorDescriptor::new(
+        id.clone(),
+        format!("{}::{short}", module_path!()),
+        "snapshot round-trip test",
+    )
         .with_input(PortDescriptor::new(input, "", false))
         .with_output(PortDescriptor::new(output, "", false));
     // Idempotent across `serial_test` runs — second register returns

--- a/runtime/streamlib-engine/tests/graph_snapshot_round_trip_test.rs
+++ b/runtime/streamlib-engine/tests/graph_snapshot_round_trip_test.rs
@@ -43,8 +43,8 @@ fn register_test_type(short: &str, input: &str, output: &str) -> SchemaIdent {
         format!("{}::{short}", module_path!()),
         "snapshot round-trip test",
     )
-        .with_input(PortDescriptor::new(input, "", false))
-        .with_output(PortDescriptor::new(output, "", false));
+    .with_input(PortDescriptor::new(input, "", false))
+    .with_output(PortDescriptor::new(output, "", false));
     // Idempotent across `serial_test` runs — second register returns
     // `Error::Configuration("Processor 'X' already registered")` which
     // we ignore.

--- a/runtime/streamlib-engine/tests/processor_class_import_path_test.rs
+++ b/runtime/streamlib-engine/tests/processor_class_import_path_test.rs
@@ -3,13 +3,10 @@
 
 //! A Rust processor's identity is its type path, captured by the macro.
 //!
-//! Asserted as whole literal strings rather than against a helper that
-//! rebuilds the same path: the point of capturing at expansion time is that
-//! the string is fixed by the source, so a test that recomputes it would
-//! agree with any mechanism — including `std::any::type_name`, whose output
-//! format rustc is free to change between versions. Spelled out, this test
-//! fails on a toolchain bump that moved the string, which is the whole reason
-//! identity is a macro concern.
+//! Asserted as whole literal strings rather than against a helper that rebuilds
+//! the same path: a test that recomputed the identity would agree with any
+//! mechanism that produced one, including a reflected one. Spelled out, these
+//! fail on a toolchain bump that moved the string.
 
 use streamlib_engine::core::GeneratedProcessor;
 use streamlib_engine::core::{Result, RuntimeContextFullAccess};
@@ -24,12 +21,6 @@ mod video_filters {
     pub struct BlurProcessor;
 
     impl streamlib_engine::ManualProcessor for BlurProcessor::Processor {
-        fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-            Ok(())
-        }
-        fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-            Ok(())
-        }
         fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
             Ok(())
         }
@@ -40,12 +31,6 @@ mod video_filters {
 pub struct CrateRootProcessor;
 
 impl streamlib_engine::ManualProcessor for CrateRootProcessor::Processor {
-    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        Ok(())
-    }
-    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
-        Ok(())
-    }
     fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
         Ok(())
     }
@@ -70,29 +55,5 @@ fn a_processor_at_the_crate_root_carries_crate_and_type() {
     assert_eq!(
         import_path_of::<CrateRootProcessor::Processor>(),
         "processor_class_import_path_test::CrateRootProcessor"
-    );
-}
-
-/// The identity names the type the author wrote, not the `Processor` struct
-/// the macro generates inside the module it wraps them in. Getting this wrong
-/// is invisible until a user reads a graph and finds every processor called
-/// `Processor`.
-#[test]
-fn the_captured_path_ends_at_the_authored_type_name() {
-    let import_path = import_path_of::<video_filters::BlurProcessor::Processor>();
-    assert!(
-        import_path.ends_with("::BlurProcessor"),
-        "the identity must end at the name the author declared: {import_path}"
-    );
-}
-
-/// Two processors, two identities. A capture that lost the module or the type
-/// name would collapse these into one string, and the migrate ticket keys the
-/// registry on it.
-#[test]
-fn two_processors_never_share_an_import_path() {
-    assert_ne!(
-        import_path_of::<video_filters::BlurProcessor::Processor>(),
-        import_path_of::<CrateRootProcessor::Processor>()
     );
 }

--- a/runtime/streamlib-engine/tests/processor_class_import_path_test.rs
+++ b/runtime/streamlib-engine/tests/processor_class_import_path_test.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! A Rust processor's identity is its type path, captured by the macro.
+//!
+//! Asserted as whole literal strings rather than against a helper that
+//! rebuilds the same path: the point of capturing at expansion time is that
+//! the string is fixed by the source, so a test that recomputes it would
+//! agree with any mechanism — including `std::any::type_name`, whose output
+//! format rustc is free to change between versions. Spelled out, this test
+//! fails on a toolchain bump that moved the string, which is the whole reason
+//! identity is a macro concern.
+
+use streamlib_engine::core::GeneratedProcessor;
+use streamlib_engine::core::{Result, RuntimeContextFullAccess};
+
+/// Declared in a nested module, because that is the part the crate name alone
+/// cannot prove: the capture has to carry the author's module path, not just
+/// the crate.
+mod video_filters {
+    use super::*;
+
+    #[streamlib::sdk::processor("@tatolab/import-path-test/BlurProcessor", execution = manual)]
+    pub struct BlurProcessor;
+
+    impl streamlib_engine::ManualProcessor for BlurProcessor::Processor {
+        fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+            Ok(())
+        }
+        fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+            Ok(())
+        }
+        fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+            Ok(())
+        }
+    }
+}
+
+#[streamlib::sdk::processor("@tatolab/import-path-test/CrateRootProcessor", execution = manual)]
+pub struct CrateRootProcessor;
+
+impl streamlib_engine::ManualProcessor for CrateRootProcessor::Processor {
+    fn setup(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+    fn teardown(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+    fn start(&mut self, _ctx: &RuntimeContextFullAccess<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn import_path_of<P: GeneratedProcessor>() -> String {
+    P::descriptor()
+        .expect("the macro emits a descriptor for every processor")
+        .processor_class_import_path
+}
+
+#[test]
+fn a_processor_in_a_nested_module_carries_crate_module_and_type() {
+    assert_eq!(
+        import_path_of::<video_filters::BlurProcessor::Processor>(),
+        "processor_class_import_path_test::video_filters::BlurProcessor"
+    );
+}
+
+#[test]
+fn a_processor_at_the_crate_root_carries_crate_and_type() {
+    assert_eq!(
+        import_path_of::<CrateRootProcessor::Processor>(),
+        "processor_class_import_path_test::CrateRootProcessor"
+    );
+}
+
+/// The identity names the type the author wrote, not the `Processor` struct
+/// the macro generates inside the module it wraps them in. Getting this wrong
+/// is invisible until a user reads a graph and finds every processor called
+/// `Processor`.
+#[test]
+fn the_captured_path_ends_at_the_authored_type_name() {
+    let import_path = import_path_of::<video_filters::BlurProcessor::Processor>();
+    assert!(
+        import_path.ends_with("::BlurProcessor"),
+        "the identity must end at the name the author declared: {import_path}"
+    );
+}
+
+/// Two processors, two identities. A capture that lost the module or the type
+/// name would collapse these into one string, and the migrate ticket keys the
+/// registry on it.
+#[test]
+fn two_processors_never_share_an_import_path() {
+    assert_ne!(
+        import_path_of::<video_filters::BlurProcessor::Processor>(),
+        import_path_of::<CrateRootProcessor::Processor>()
+    );
+}

--- a/runtime/streamlib-engine/tests/schema_ident_any_version_macro_test.rs
+++ b/runtime/streamlib-engine/tests/schema_ident_any_version_macro_test.rs
@@ -58,12 +58,16 @@ fn macro_resolves_to_highest_registered_version() {
     // succeed when this test runs after a sibling has already inserted
     // the same entries. Either direction is fine — what matters is that
     // by the time the macro fires, all three versions are present.
-    let _ =
-        PROCESSOR_REGISTRY.register_descriptor_only(ProcessorDescriptor::new(v1.clone(), "test"));
-    let _ =
-        PROCESSOR_REGISTRY.register_descriptor_only(ProcessorDescriptor::new(v3.clone(), "test"));
-    let _ =
-        PROCESSOR_REGISTRY.register_descriptor_only(ProcessorDescriptor::new(v2.clone(), "test"));
+    // One import path across all three: three versions of one tuple are three
+    // registrations of the same class.
+    let fixture_import_path = concat!(module_path!(), "::FixtureProc");
+    for version in [&v1, &v3, &v2] {
+        let _ = PROCESSOR_REGISTRY.register_descriptor_only(ProcessorDescriptor::new(
+            version.clone(),
+            fixture_import_path,
+            "test",
+        ));
+    }
 
     let resolved: SchemaIdent = streamlib::sdk::schema_ident_any_version!(
         "schema-ident-any-version-test",

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -667,16 +667,10 @@ fn generate_descriptor_from_schema(
         }
     });
 
-    // The identity capture. `module_path!()` resolves here to
-    // `<the author's module>::<the authored type name>`, because this
-    // expansion lands inside the `pub mod` the macro names after the
-    // author's struct — so the generated module's own path *is* the type
+    // `module_path!()` resolves here to `<author's module>::<authored type>`,
+    // because this expansion lands inside the `pub mod` the macro names after
+    // the author's struct — the generated module's own path *is* the type
     // path, with no `stringify!` needed to append the name.
-    //
-    // Never `std::any::type_name`: its output format is documented as
-    // unspecified and free to change between compiler versions, and an
-    // identity the toolchain can silently rewrite is a registry key that
-    // breaks with no failing test. `module_path!` is specified.
     quote! {
         fn descriptor() -> Option<__streamlib_sdk::descriptors::ProcessorDescriptor> {
             Some(
@@ -1438,11 +1432,9 @@ mod processor_struct_emit_tests {
         ))
     }
 
-    /// The mechanism, not just the result. What the string comes out as is
+    /// The mechanism, not the result — what the string comes out as is
     /// asserted where a real `#[processor]` can be expanded and read back
-    /// (`streamlib-engine/tests/processor_class_import_path_test.rs`); what
-    /// this pins is that it came from the one capture whose output format
-    /// rustc guarantees.
+    /// (`streamlib-engine/tests/processor_class_import_path_test.rs`).
     #[test]
     fn the_descriptor_captures_its_identity_with_module_path() {
         let rendered = rendered_descriptor();

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -667,10 +667,24 @@ fn generate_descriptor_from_schema(
         }
     });
 
+    // The identity capture. `module_path!()` resolves here to
+    // `<the author's module>::<the authored type name>`, because this
+    // expansion lands inside the `pub mod` the macro names after the
+    // author's struct — so the generated module's own path *is* the type
+    // path, with no `stringify!` needed to append the name.
+    //
+    // Never `std::any::type_name`: its output format is documented as
+    // unspecified and free to change between compiler versions, and an
+    // identity the toolchain can silently rewrite is a registry key that
+    // breaks with no failing test. `module_path!` is specified.
     quote! {
         fn descriptor() -> Option<__streamlib_sdk::descriptors::ProcessorDescriptor> {
             Some(
-                __streamlib_sdk::descriptors::ProcessorDescriptor::new(Processor::schema_ident(), #description)
+                __streamlib_sdk::descriptors::ProcessorDescriptor::new(
+                    Processor::schema_ident(),
+                    ::core::module_path!(),
+                    #description,
+                )
                     .with_version(#version)
                     .with_repository(#repository)
                     #config_schema

--- a/sdk/streamlib-macros/src/codegen.rs
+++ b/sdk/streamlib-macros/src/codegen.rs
@@ -1428,4 +1428,40 @@ mod processor_struct_emit_tests {
             }
         }
     }
+
+    fn rendered_descriptor() -> String {
+        render_token_stream_without_whitespace(generate_descriptor_from_schema(
+            &minimal_schema(),
+            "a probe",
+            "0.0.0",
+            None,
+        ))
+    }
+
+    /// The mechanism, not just the result. What the string comes out as is
+    /// asserted where a real `#[processor]` can be expanded and read back
+    /// (`streamlib-engine/tests/processor_class_import_path_test.rs`); what
+    /// this pins is that it came from the one capture whose output format
+    /// rustc guarantees.
+    #[test]
+    fn the_descriptor_captures_its_identity_with_module_path() {
+        let rendered = rendered_descriptor();
+        assert!(
+            rendered.contains("module_path!()"),
+            "identity must be captured at the expansion site — got: {rendered}"
+        );
+    }
+
+    /// `std::any::type_name`'s output format is documented as unspecified and
+    /// free to change between compiler versions. Keying a registry on it means
+    /// a toolchain bump silently renames every processor, with nothing failing
+    /// to say so — which is why this is a test and not a comment.
+    #[test]
+    fn the_descriptor_never_reaches_for_type_name() {
+        let rendered = rendered_descriptor();
+        assert!(
+            !rendered.contains("type_name"),
+            "identity must never be reflected at runtime — got: {rendered}"
+        );
+    }
 }

--- a/sdk/streamlib-processor-schema/src/descriptors.rs
+++ b/sdk/streamlib-processor-schema/src/descriptors.rs
@@ -120,8 +120,8 @@ pub struct ProcessorDescriptor {
     ///
     /// Derived mechanically by the authoring surface — the `#[processor]`
     /// macro captures it at the expansion site, the wheel reads it off the
-    /// class — and never authored. Required at construction so no descriptor
-    /// can reach the registry without one.
+    /// class — and never authored. Taken by `new` rather than by a builder so
+    /// that adding a descriptor without deriving one does not compile.
     pub processor_class_import_path: String,
     pub description: String,
     pub version: String,

--- a/sdk/streamlib-processor-schema/src/descriptors.rs
+++ b/sdk/streamlib-processor-schema/src/descriptors.rs
@@ -114,6 +114,15 @@ impl ConfigDescriptor for () {
 pub struct ProcessorDescriptor {
     /// Structured processor identity — `@org/package/Type@version`.
     pub name: SchemaIdent,
+    /// The processor class's fully-qualified import path —
+    /// `my_app.filters:BlurProcessor` in Python,
+    /// `my_app::filters::BlurProcessor` in Rust.
+    ///
+    /// Derived mechanically by the authoring surface — the `#[processor]`
+    /// macro captures it at the expansion site, the wheel reads it off the
+    /// class — and never authored. Required at construction so no descriptor
+    /// can reach the registry without one.
+    pub processor_class_import_path: String,
     pub description: String,
     pub version: String,
     pub repository: String,
@@ -137,9 +146,14 @@ pub struct ProcessorDescriptor {
 }
 
 impl ProcessorDescriptor {
-    pub fn new(name: SchemaIdent, description: impl Into<String>) -> Self {
+    pub fn new(
+        name: SchemaIdent,
+        processor_class_import_path: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
         Self {
             name,
+            processor_class_import_path: processor_class_import_path.into(),
             description: description.into(),
             version: String::new(),
             repository: String::new(),

--- a/sdk/streamlib-python-wheel/src/lib.rs
+++ b/sdk/streamlib-python-wheel/src/lib.rs
@@ -8,6 +8,8 @@ use pyo3::prelude::*;
 
 mod python_added_processor;
 mod python_bag_conversion;
+#[cfg(test)]
+mod python_class_from_source_for_tests;
 mod python_control_plane_hosting;
 #[cfg(target_os = "linux")]
 mod python_cuda_pixel_exchange;

--- a/sdk/streamlib-python-wheel/src/python_class_from_source_for_tests.rs
+++ b/sdk/streamlib-python-wheel/src/python_class_from_source_for_tests.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Jonathan Fontanez
+// SPDX-License-Identifier: BUSL-1.1
+
+//! Building a class the way a user's module would, for tests that read
+//! attributes CPython assigns rather than attributes a test set by hand.
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+/// Run `source` as a module body and hand back the class it bound to
+/// `class_name`.
+///
+/// Running Python is the point: `__module__` and `__qualname__` are what
+/// CPython actually assigns, so a test asserting on them is not asserting on
+/// its own setup.
+pub(crate) fn class_from_source<'py>(
+    python: Python<'py>,
+    source: &str,
+    class_name: &str,
+) -> Bound<'py, PyAny> {
+    let namespace = PyDict::new(python);
+    python
+        .run(
+            &std::ffi::CString::new(source).unwrap(),
+            Some(&namespace),
+            None,
+        )
+        .unwrap();
+    namespace.get_item(class_name).unwrap().unwrap()
+}

--- a/sdk/streamlib-python-wheel/src/python_helper_process_spawn_host.rs
+++ b/sdk/streamlib-python-wheel/src/python_helper_process_spawn_host.rs
@@ -744,6 +744,7 @@ mod tests {
                     streamlib::sdk::descriptors::TypeName::new("BlurProcessor").unwrap(),
                     streamlib::sdk::descriptors::SemVer::new(0, 0, 0),
                 ),
+                "my_app.filters:BlurProcessor",
                 "a test double",
             ),
             child_execution_config: ExecutionConfig::new(ProcessExecution::Reactive),

--- a/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
@@ -38,6 +38,13 @@ impl PythonProcessorDeclaration {
         let type_reference = read_type_reference(processor_class)?;
         let execution_config = read_execution_config(processor_class)?;
 
+        // Derived once and spent twice. The two fields are different
+        // contracts — identity is what the registry names the type by,
+        // `entrypoint` is what the child interpreter imports — so they are
+        // separate fields, but a second derivation call is a second chance
+        // for them to disagree.
+        let class_import_path = processor_class_import_path(processor_class)?;
+
         let mut descriptor = ProcessorDescriptor::new(
             SchemaIdent::new(
                 type_reference.org().clone(),
@@ -45,13 +52,13 @@ impl PythonProcessorDeclaration {
                 type_reference.r#type().clone(),
                 VERSION_FREE_SENTINEL,
             ),
+            class_import_path.clone(),
             read_string_attribute(processor_class, "__streamlib_processor_description__")?,
         )
         .with_runtime(ProcessorRuntime::Python)
-        // The class's own import path: what the child interpreter imports to
-        // reach the class, and what refusing an unimportable class here rather
-        // than at spawn buys — the author names the class, not a pid.
-        .with_entrypoint(processor_class_import_path(processor_class)?)
+        // Refusing an unimportable class here rather than at spawn is what
+        // lets the author be told about the class they named, not about a pid.
+        .with_entrypoint(class_import_path)
         .with_scheduling(ProcessorScheduling {
             priority: read_thread_priority(processor_class)?,
         });

--- a/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
@@ -203,3 +203,61 @@ fn read_dict_string(dictionary: &Bound<'_, PyDict>, key: &str) -> PyResult<Strin
 fn ident_error(failure: impl std::fmt::Display) -> PyErr {
     PyTypeError::new_err(failure.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::PyDict;
+
+    /// A class carrying what `@streamlib.processor` attaches, built by running
+    /// Python rather than by setting attributes from Rust, so `__module__` and
+    /// `__qualname__` are whatever CPython actually assigns.
+    const DECLARED_CLASS_SOURCE: &str = "\
+__name__ = 'my_app.filters'
+
+
+class BlurProcessor:
+    __streamlib_processor_type_reference__ = {
+        'org': 'app', 'package': 'local', 'type': 'BlurProcessor'
+    }
+    __streamlib_processor_description__ = 'blurs'
+    __streamlib_processor_execution__ = {'mode': 'reactive'}
+    __streamlib_processor_scheduling_priority__ = None
+    __streamlib_processor_input_ports__ = []
+    __streamlib_processor_output_ports__ = []
+";
+
+    fn declared_class<'py>(python: Python<'py>) -> Bound<'py, PyAny> {
+        let namespace = PyDict::new(python);
+        python
+            .run(
+                &std::ffi::CString::new(DECLARED_CLASS_SOURCE).unwrap(),
+                Some(&namespace),
+                None,
+            )
+            .unwrap();
+        namespace.get_item("BlurProcessor").unwrap().unwrap()
+    }
+
+    /// The two fields are separate contracts — identity is what the registry
+    /// names the type by, `entrypoint` is what the child interpreter imports —
+    /// but they are one derivation, so a class that drifted between them would
+    /// mean a processor registered under a name its own helper cannot import.
+    #[test]
+    fn the_identity_and_the_entrypoint_are_the_same_derived_string() {
+        Python::initialize();
+        Python::attach(|python| {
+            let declaration =
+                PythonProcessorDeclaration::read_from_class(&declared_class(python)).unwrap();
+
+            assert_eq!(
+                declaration.descriptor.processor_class_import_path,
+                "my_app.filters:BlurProcessor"
+            );
+            assert_eq!(
+                Some(declaration.descriptor.processor_class_import_path.clone()),
+                declaration.descriptor.entrypoint,
+            );
+        });
+    }
+}

--- a/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_declaration.rs
@@ -38,11 +38,8 @@ impl PythonProcessorDeclaration {
         let type_reference = read_type_reference(processor_class)?;
         let execution_config = read_execution_config(processor_class)?;
 
-        // Derived once and spent twice. The two fields are different
-        // contracts — identity is what the registry names the type by,
-        // `entrypoint` is what the child interpreter imports — so they are
-        // separate fields, but a second derivation call is a second chance
-        // for them to disagree.
+        // Identity and `entrypoint` are separate contracts, but one
+        // derivation: a second call is a second chance for them to disagree.
         let class_import_path = processor_class_import_path(processor_class)?;
 
         let mut descriptor = ProcessorDescriptor::new(
@@ -56,8 +53,6 @@ impl PythonProcessorDeclaration {
             read_string_attribute(processor_class, "__streamlib_processor_description__")?,
         )
         .with_runtime(ProcessorRuntime::Python)
-        // Refusing an unimportable class here rather than at spawn is what
-        // lets the author be told about the class they named, not about a pid.
         .with_entrypoint(class_import_path)
         .with_scheduling(ProcessorScheduling {
             priority: read_thread_priority(processor_class)?,
@@ -207,11 +202,9 @@ fn ident_error(failure: impl std::fmt::Display) -> PyErr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::types::PyDict;
+    use crate::python_class_from_source_for_tests::class_from_source;
 
-    /// A class carrying what `@streamlib.processor` attaches, built by running
-    /// Python rather than by setting attributes from Rust, so `__module__` and
-    /// `__qualname__` are whatever CPython actually assigns.
+    /// A class carrying what `@streamlib.processor` attaches.
     const DECLARED_CLASS_SOURCE: &str = "\
 __name__ = 'my_app.filters'
 
@@ -227,28 +220,14 @@ class BlurProcessor:
     __streamlib_processor_output_ports__ = []
 ";
 
-    fn declared_class<'py>(python: Python<'py>) -> Bound<'py, PyAny> {
-        let namespace = PyDict::new(python);
-        python
-            .run(
-                &std::ffi::CString::new(DECLARED_CLASS_SOURCE).unwrap(),
-                Some(&namespace),
-                None,
-            )
-            .unwrap();
-        namespace.get_item("BlurProcessor").unwrap().unwrap()
-    }
-
-    /// The two fields are separate contracts — identity is what the registry
-    /// names the type by, `entrypoint` is what the child interpreter imports —
-    /// but they are one derivation, so a class that drifted between them would
-    /// mean a processor registered under a name its own helper cannot import.
+    /// A class that drifted between the two fields would be a processor
+    /// registered under a name its own helper process cannot import.
     #[test]
     fn the_identity_and_the_entrypoint_are_the_same_derived_string() {
         Python::initialize();
         Python::attach(|python| {
-            let declaration =
-                PythonProcessorDeclaration::read_from_class(&declared_class(python)).unwrap();
+            let declared_class = class_from_source(python, DECLARED_CLASS_SOURCE, "BlurProcessor");
+            let declaration = PythonProcessorDeclaration::read_from_class(&declared_class).unwrap();
 
             assert_eq!(
                 declaration.descriptor.processor_class_import_path,

--- a/sdk/streamlib-python-wheel/src/python_processor_import_path.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_import_path.rs
@@ -109,26 +109,7 @@ fn suggested_module_name(qualname: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pyo3::types::PyDict;
-
-    /// Build a class the way a user's module would, so `__module__` and
-    /// `__qualname__` are whatever CPython actually assigns rather than
-    /// attributes a test set by hand.
-    fn class_from_source<'py>(
-        python: Python<'py>,
-        source: &str,
-        class_name: &str,
-    ) -> Bound<'py, PyAny> {
-        let namespace = PyDict::new(python);
-        python
-            .run(
-                &std::ffi::CString::new(source).unwrap(),
-                Some(&namespace),
-                None,
-            )
-            .unwrap();
-        namespace.get_item(class_name).unwrap().unwrap()
-    }
+    use crate::python_class_from_source_for_tests::class_from_source;
 
     #[test]
     fn a_module_scope_class_derives_module_colon_qualname() {

--- a/sdk/streamlib-python-wheel/src/python_processor_registration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_registration.rs
@@ -101,15 +101,6 @@ pub(crate) fn register_processor_class(
         )
         .map_err(|registration_failure| PyValueError::new_err(registration_failure.to_string()))?;
 
-    // The identity, on the record. A processor's class is reached by import
-    // and nothing else, so "which class is this node actually running?" is a
-    // question a log has to be able to answer — a display name cannot, and by
-    // the time a helper fails to import, the app has already exited `add`.
-    tracing::info!(
-        processor_class_import_path = %declaration.descriptor.processor_class_import_path,
-        "registered a python processor class"
-    );
-
     registered.insert(identity, held_processor_class);
     Ok(type_reference)
 }

--- a/sdk/streamlib-python-wheel/src/python_processor_registration.rs
+++ b/sdk/streamlib-python-wheel/src/python_processor_registration.rs
@@ -101,6 +101,15 @@ pub(crate) fn register_processor_class(
         )
         .map_err(|registration_failure| PyValueError::new_err(registration_failure.to_string()))?;
 
+    // The identity, on the record. A processor's class is reached by import
+    // and nothing else, so "which class is this node actually running?" is a
+    // question a log has to be able to answer — a display name cannot, and by
+    // the time a helper fails to import, the app has already exited `add`.
+    tracing::info!(
+        processor_class_import_path = %declaration.descriptor.processor_class_import_path,
+        "registered a python processor class"
+    );
+
     registered.insert(identity, held_processor_class);
     Ok(type_reference)
 }

--- a/sdk/streamlib-python-wheel/tests/app_under_test.py
+++ b/sdk/streamlib-python-wheel/tests/app_under_test.py
@@ -160,19 +160,55 @@ class AppUnderTest:
                 pipe.close()
 
 
-def start_app(app_path: Path, *arguments: str) -> AppUnderTest:
-    """Spawn `python <app_path> <arguments...>` in its own process group.
+def start_command(command: "list[str]", *, working_directory: Path) -> AppUnderTest:
+    """Spawn `command` in its own process group, output on one pipe.
 
     Its own group so a SIGINT aimed at the app cannot reach the test runner that
     spawned it — and so the group can be checked for survivors afterwards.
     """
     process = subprocess.Popen(
-        [sys.executable, str(app_path), *arguments],
+        command,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
         start_new_session=True,
+        cwd=str(working_directory),
     )
     return AppUnderTest(process)
+
+
+def start_app(app_path: Path, *arguments: str) -> AppUnderTest:
+    """Spawn `python <app_path> <arguments...>` — the arrangement the
+    interpreter-lifecycle contract was proven against."""
+    return start_command(
+        [sys.executable, str(app_path), *arguments],
+        working_directory=app_path.parent,
+    )
+
+
+def start_app_as_module(app_path: Path, *arguments: str) -> AppUnderTest:
+    """Spawn `python -m <app> <arguments...>` from the app's own directory.
+
+    A different arrangement, not a different app: `-m` puts the *working
+    directory* on `sys.path` where a script path puts the script's own
+    directory. Naming the same file two ways is what makes them comparable.
+    """
+    return start_command(
+        [sys.executable, "-m", app_path.stem, *arguments],
+        working_directory=app_path.parent,
+    )
+
+
+def start_app_under_the_streamlib_cli(app_path: Path, *arguments: str) -> AppUnderTest:
+    """Spawn `streamlib dev -f <app_path>` — the launcher the MVP blesses.
+
+    Reached as a module rather than through the console script so the app runs
+    under the interpreter this test session is using, whether or not the venv's
+    `bin` is on PATH.
+    """
+    return start_command(
+        [sys.executable, "-m", "streamlib.cli", "dev", "-f", str(app_path), *arguments],
+        working_directory=app_path.parent,
+    )

--- a/sdk/streamlib-python-wheel/tests/app_under_test.py
+++ b/sdk/streamlib-python-wheel/tests/app_under_test.py
@@ -160,11 +160,18 @@ class AppUnderTest:
                 pipe.close()
 
 
-def start_command(command: "list[str]", *, working_directory: Path) -> AppUnderTest:
+def start_command(
+    command: "list[str]", *, working_directory: "Path | None" = None
+) -> AppUnderTest:
     """Spawn `command` in its own process group, output on one pipe.
 
     Its own group so a SIGINT aimed at the app cannot reach the test runner that
     spawned it — and so the group can be checked for survivors afterwards.
+
+    `working_directory` stays unset unless an arrangement genuinely needs it: a
+    helper child inherits the app's cwd, and cwd leads `sys.path` in the child's
+    `-m` launch, so pointing it at the processor modules would import them for
+    free and mask a break in the `PYTHONPATH` the spawn host sets.
     """
     process = subprocess.Popen(
         command,
@@ -174,26 +181,28 @@ def start_command(command: "list[str]", *, working_directory: Path) -> AppUnderT
         text=True,
         bufsize=1,
         start_new_session=True,
-        cwd=str(working_directory),
+        cwd=None if working_directory is None else str(working_directory),
     )
     return AppUnderTest(process)
 
 
 def start_app(app_path: Path, *arguments: str) -> AppUnderTest:
     """Spawn `python <app_path> <arguments...>` — the arrangement the
-    interpreter-lifecycle contract was proven against."""
-    return start_command(
-        [sys.executable, str(app_path), *arguments],
-        working_directory=app_path.parent,
-    )
+    interpreter-lifecycle contract was proven against.
+
+    A script path puts the script's own directory on `sys.path`, so this needs
+    no working directory of its own.
+    """
+    return start_command([sys.executable, str(app_path), *arguments])
 
 
 def start_app_as_module(app_path: Path, *arguments: str) -> AppUnderTest:
     """Spawn `python -m <app> <arguments...>` from the app's own directory.
 
-    A different arrangement, not a different app: `-m` puts the *working
-    directory* on `sys.path` where a script path puts the script's own
-    directory. Naming the same file two ways is what makes them comparable.
+    A different arrangement, not a different app. `-m` resolves the module
+    against the *working directory* where a script path resolves against the
+    file, which is the only reason this arm sets one — and why it is the only
+    arm that does.
     """
     return start_command(
         [sys.executable, "-m", app_path.stem, *arguments],
@@ -206,9 +215,9 @@ def start_app_under_the_streamlib_cli(app_path: Path, *arguments: str) -> AppUnd
 
     Reached as a module rather than through the console script so the app runs
     under the interpreter this test session is using, whether or not the venv's
-    `bin` is on PATH.
+    `bin` is on PATH. The launcher puts the entry file's own directory on
+    `sys.path` itself, so this arm needs no working directory either.
     """
     return start_command(
-        [sys.executable, "-m", "streamlib.cli", "dev", "-f", str(app_path), *arguments],
-        working_directory=app_path.parent,
+        [sys.executable, "-m", "streamlib.cli", "dev", "-f", str(app_path), *arguments]
     )

--- a/sdk/streamlib-python-wheel/tests/conftest.py
+++ b/sdk/streamlib-python-wheel/tests/conftest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from typing import Callable
+
 from app_under_test import AppUnderTest, start_app
 
 
@@ -17,11 +19,19 @@ def start_app_under_test():
     Without the teardown a failed assertion strands a live engine holding a GPU
     context, an iceoryx2 node and a socket, silently contaminating every later
     run on the same rig.
+
+    `launcher` picks the launch arrangement — `python app.py` unless a suite
+    names one of `app_under_test`'s others. The reaping is the same whichever
+    it is, which is the point of routing them all through here.
     """
     started: "list[AppUnderTest]" = []
 
-    def start(app_path: Path, *arguments: str) -> AppUnderTest:
-        app = start_app(app_path, *arguments)
+    def start(
+        app_path: Path,
+        *arguments: str,
+        launcher: "Callable[..., AppUnderTest]" = start_app,
+    ) -> AppUnderTest:
+        app = launcher(app_path, *arguments)
         started.append(app)
         return app
 

--- a/sdk/streamlib-python-wheel/tests/conftest.py
+++ b/sdk/streamlib-python-wheel/tests/conftest.py
@@ -4,10 +4,9 @@
 """Fixtures shared by the suites that drive an app out of process."""
 
 from pathlib import Path
+from typing import Callable
 
 import pytest
-
-from typing import Callable
 
 from app_under_test import AppUnderTest, start_app
 

--- a/sdk/streamlib-python-wheel/tests/identity_stability_app.py
+++ b/sdk/streamlib-python-wheel/tests/identity_stability_app.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""One app, launched three ways, adding one class.
+
+`streamlib dev` executes this file under the name `__main__` too — it runs the
+entry file exactly as `python app.py` does, then calls its `setup(rt)`. So the
+direct arms announce themselves with an argument rather than with `__name__`:
+the launcher narrows `sys.argv` to the entry file alone, and an app that keyed
+off `__name__` would build a second runtime inside the launcher's process.
+
+The direct arms stop after `add`. Identity is derived there, and `run()` would
+buy the test nothing but a GPU context.
+"""
+
+import sys
+
+import streamlib
+from identity_stable_processor import IdentityStableProcessor
+
+DIRECT_LAUNCH_ARGUMENT = "add-then-exit"
+
+
+def setup(rt) -> None:
+    """The pipeline, as `streamlib dev` and the direct arms alike build it."""
+    rt.add(IdentityStableProcessor)
+    print("MARKER:ADDED", flush=True)
+
+
+def add_then_exit() -> None:
+    runtime = streamlib.Runtime()
+    try:
+        setup(runtime)
+    finally:
+        runtime.shutdown()
+    print("MARKER:CLEAN_EXIT", flush=True)
+
+
+if __name__ == "__main__" and sys.argv[1:2] == [DIRECT_LAUNCH_ARGUMENT]:
+    add_then_exit()

--- a/sdk/streamlib-python-wheel/tests/identity_stable_processor.py
+++ b/sdk/streamlib-python-wheel/tests/identity_stable_processor.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Jonathan Fontanez
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The one class every launch arrangement adds.
+
+It lives in its own module beside the entry file rather than inside it, which
+is the only legal home for a processor: a helper process reaches its class by
+importing this name, and a class in the entry file identifies as `__main__`,
+which names the child's own entry file instead.
+"""
+
+from streamlib import processor
+
+
+@processor(execution="continuous", interval_ms=1)
+class IdentityStableProcessor:
+    """Does nothing per tick. Identity is the whole subject here."""
+
+    def process(self, ctx) -> None: ...

--- a/sdk/streamlib-python-wheel/tests/test_processor_identity.py
+++ b/sdk/streamlib-python-wheel/tests/test_processor_identity.py
@@ -31,8 +31,8 @@ from identity_stability_app import DIRECT_LAUNCH_ARGUMENT
 ENTRY_FILE_PROCESSOR_APP = Path(__file__).parent / "entry_file_processor_app.py"
 IDENTITY_STABILITY_APP = Path(__file__).parent / "identity_stability_app.py"
 
-# The engine's own record of what it derived. Asserting on `__module__` from
-# the app would agree with a derivation that never ran.
+# The engine's own registration record. Asserting on `__module__` from the app
+# would agree with a derivation that never ran.
 DERIVED_IDENTITY_PATTERN = re.compile(r'processor_class_import_path="([^"]+)"')
 
 

--- a/sdk/streamlib-python-wheel/tests/test_processor_identity.py
+++ b/sdk/streamlib-python-wheel/tests/test_processor_identity.py
@@ -8,13 +8,32 @@ Every Python processor runs in its own child process, which reaches the class by
 importing it. A class the child cannot import has no host anywhere, so the
 refusal belongs at `add` — where the author is naming the class — rather than at
 spawn, where it would surface as a failed child.
+
+The other half is that an accepted name does not move. Identity is what the
+registry, the control plane and the helper spawn all agree on, so one that
+varied with how the user happened to start their app would be three processors
+wearing one name.
 """
 
+import re
+import socket
 from pathlib import Path
 
 import pytest
 
+from app_under_test import (
+    start_app,
+    start_app_as_module,
+    start_app_under_the_streamlib_cli,
+)
+from identity_stability_app import DIRECT_LAUNCH_ARGUMENT
+
 ENTRY_FILE_PROCESSOR_APP = Path(__file__).parent / "entry_file_processor_app.py"
+IDENTITY_STABILITY_APP = Path(__file__).parent / "identity_stability_app.py"
+
+# The engine's own record of what it derived. Asserting on `__module__` from
+# the app would agree with a derivation that never ran.
+DERIVED_IDENTITY_PATTERN = re.compile(r'processor_class_import_path="([^"]+)"')
 
 
 @pytest.fixture
@@ -68,4 +87,71 @@ def test_the_same_class_in_an_importable_module_is_accepted(entry_file_processor
 
     assert not [marker for marker in app.markers() if marker.startswith("REFUSED=")], (
         f"an importable class must not be refused; output:\n{app.output}"
+    )
+
+
+def _free_port() -> int:
+    """A port the OS reports free. The control plane increments on collision,
+    so a caller that loses the race still binds nearby."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def _derived_identity(app) -> str:
+    """The identity the engine derived, read off its own log record."""
+    app.await_marker("ADDED")
+    for line in app.output_lines:
+        found = DERIVED_IDENTITY_PATTERN.search(line)
+        if found:
+            return found.group(1)
+    raise AssertionError(
+        f"the engine logged no derived identity; output:\n{app.output}"
+    )
+
+
+def _identity_under(launcher, start_app_under_test, *arguments: str) -> str:
+    app = start_app_under_test(
+        IDENTITY_STABILITY_APP, *arguments, launcher=launcher
+    )
+    return _derived_identity(app)
+
+
+# Every arm is observed at `add`, which is where identity is derived — well
+# before `run()` would initialize a GPU context. That is what keeps the launcher
+# arm, which does go on to boot a node, off the rig: the fixture reaps its
+# process group, so nothing here waits for a device or a clean exit.
+def test_a_class_run_as_a_script_identifies_by_its_module(start_app_under_test):
+    assert (
+        _identity_under(start_app, start_app_under_test, DIRECT_LAUNCH_ARGUMENT)
+        == "identity_stable_processor:IdentityStableProcessor"
+    )
+
+
+def test_the_launch_arrangement_never_changes_the_identity(start_app_under_test):
+    """`python app.py`, `python -m app`, and `streamlib dev` — one name.
+
+    Three arrangements that put a different thing on `sys.path` and give the
+    entry file a different provenance. What must not move is the *processor's*
+    module, because that is what the helper imports and what the registry keys
+    on — and the class lives in an importable module in all three, which is the
+    property the entry-file refusal above exists to guarantee.
+    """
+    as_a_script = _identity_under(
+        start_app, start_app_under_test, DIRECT_LAUNCH_ARGUMENT
+    )
+    as_a_module = _identity_under(
+        start_app_as_module, start_app_under_test, DIRECT_LAUNCH_ARGUMENT
+    )
+    under_the_launcher = _identity_under(
+        start_app_under_the_streamlib_cli,
+        start_app_under_test,
+        "--port",
+        str(_free_port()),
+    )
+
+    assert as_a_script == as_a_module == under_the_launcher, (
+        f"one class, three launch arrangements, three names: "
+        f"script={as_a_script!r} module={as_a_module!r} "
+        f"launcher={under_the_launcher!r}"
     )

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -177,8 +177,8 @@ fn register_ported_type(short: &str, input: &str, output: &str) -> ProcessorType
         format!("{}::{short}", module_path!()),
         "app-sugar connect test",
     )
-        .with_input(PortDescriptor::new(input, "", false))
-        .with_output(PortDescriptor::new(output, "", false));
+    .with_input(PortDescriptor::new(input, "", false))
+    .with_output(PortDescriptor::new(output, "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);
     id.into()
 }

--- a/sdk/streamlib-sdk/tests/app_sugar_test.rs
+++ b/sdk/streamlib-sdk/tests/app_sugar_test.rs
@@ -172,7 +172,11 @@ fn register_ported_type(short: &str, input: &str, output: &str) -> ProcessorType
         TypeName::new(short).unwrap(),
         SemVer::new(1, 0, 0),
     );
-    let descriptor = ProcessorDescriptor::new(id.clone(), "app-sugar connect test")
+    let descriptor = ProcessorDescriptor::new(
+        id.clone(),
+        format!("{}::{short}", module_path!()),
+        "app-sugar connect test",
+    )
         .with_input(PortDescriptor::new(input, "", false))
         .with_output(PortDescriptor::new(output, "", false));
     let _ = PROCESSOR_REGISTRY.register_descriptor_only(descriptor);


### PR DESCRIPTION
## Summary

The **expand** step of processor-class-identity. Both authoring languages now derive a processor's class import path and hang it on the descriptor. Nothing keys on it — the registry, the graph, and the control plane are untouched, and `name: SchemaIdent` stays the key until the migrate ticket.

- **`ProcessorDescriptor`** gains `processor_class_import_path: String`, taken as a **required argument to `new`** rather than a `with_*` builder. A builder plus a serde default would make `""` the silent value for the string the migrate ticket keys the registry on; arity makes omitting it a compile error instead of a runtime key collision. All 17 call sites are in-workspace (2 authoring surfaces, 15 fixtures) — nothing in `packages/` or `examples/` constructs one.
- **Rust** — `#[processor]` captures `::core::module_path!()` at the expansion site. Not `std::any::type_name`: its output format is documented as unspecified across compiler versions, so a toolchain bump would silently rewrite every registry key with nothing failing to say so.
- **Python** — the wheel derives the path once and spends it on both the new field and `entrypoint`. They stay separate contracts (identity is what the registry names the type by; `entrypoint` is what the child interpreter imports), but one call means they cannot disagree.
- **The registration record** now names the derived class, on the engine's existing `register_dynamic` log rather than a second one in the wheel — so Rust processors get it too.

### Divergence from the ticket text, and why

The ticket names the Rust capture as `concat!(module_path!(), "::", stringify!(Type))`. The macro wraps its whole expansion in `pub mod <AuthoredType>`, so the descriptor is emitted *inside* a module already named for the author's type — a bare `module_path!()` **is** the full type path, and the ticket's form would yield `…::BlurProcessor::BlurProcessor`. Same two inputs, same string, correct spelling for where the code lands. The change file carried the same wrong mechanism; corrected there in place with an annotated supersession, since this change is what falsified it.

## Closes

Closes #1839

## Exit criteria

- [x] Every descriptor from either authoring language carries a non-empty import path — and one without it does not compile.
- [x] A `#[processor]` type reports `<crate/module path>::<TypeName>`, asserted as whole literal strings so a rustc bump that moved it fails here.
- [x] A Python class's identity field and its `entrypoint` are the same string, from the same derivation call.
- [x] Registry, graph, and control plane unchanged — every engine hunk in this diff is inside a `mod tests`, and `ProcessorDescriptorOutput` is untouched.

## Test plan

| Check | Result |
|---|---|
| `cargo test --workspace --no-fail-fast` | 1941 passed, 0 failed |
| `processor_class_import_path_test` (new) | 2 passed — nested module + crate root, literal assertions |
| `streamlib-macros --lib` | 44 passed, incl. 2 new: `module_path!` present, `type_name` absent |
| `streamlib-python-wheel --lib` | 43 passed, incl. identity == entrypoint |
| wheel `pytest -m "not requires_gpu"` | 206 passed |
| `mypy.stubtest streamlib._engine`, `pyright` | clean |
| `cargo clippy` on the three changed crates | 0 warnings in any changed file |
| `rustfmt --check` on every branch-touched file | clean |
| `check-no-in-process-placement`, `lint-logging`, all other xtask gates | pass |

**Needs the rig: no.** Identity is derived at `rt.add`, before `run()` initializes a GPU context — so all three launch arms of the identity-stability E2E run in CI. Verified non-vacuous by deliberate break: `STREAMLIB_QUIET=1` turns all five identity tests red.

## Notes for owner

Non-blocking findings, batched. None of these need an answer to merge.

1. **Should the identity string be a newtype before the migrate ticket keys on it?** Both reviewers raised this independently and I think it's a real call for you. `new(name, import_path, description)` has two adjacent `impl Into<String>` params, so a swap compiles; and nothing enforces non-emptiness. Neither production site can produce either mistake (both are exact-literal tested), so the hazard is confined to fixtures *today* — but the migrate ticket turns this string into the registry key. A `ProcessorClassImportPath` newtype with a fallible constructor would close misassignment and emptiness together, and pre-1.0 is the cheap moment. I left it out because the change file doesn't name it and this is the expand step. `PortDescriptor::new(name, description, required)` in the same file already has the adjacent-strings shape, so precedent cuts both ways.

2. **Two grammars in one field.** Rust yields `a::b::C`, Python yields `a.b:C`, discriminated only by the sibling `runtime` field. That's what `ARCHITECTURE.md` §Processor model & scheduling decides, so it isn't a defect — but the migrate ticket needs to know the registry key is not parseable under a single grammar.

3. **A Rust processor's identity embeds the crate name**, so renaming a crate rewrites every one of its processors' future registry keys. Plan-sanctioned ("the type path in Rust"), worth confirming before migrate keys on it.

4. **Rust has no equivalent of Python's unimportable-class refusal.** A `#[processor]` declared inside a function body still expands, and function names aren't part of a module path — so two such processors in one module produce the *same* import path, and neither is reachable by `use`. Distinct `SchemaIdent`s mean today's duplicate check won't catch it. Nothing actionable from tokens alone; the migrate ticket should either add a collision check at registration or state that a Rust processor must be declared at module scope.

5. **Pre-existing dead branch, deliberately left alone.** `python_processor_registration.rs` reads the spawn string via `descriptor.entrypoint.clone().ok_or_else(…)`, but `read_from_class` — the only constructor — has always set it unconditionally, so that error is unreachable and was already so on `main`. A reviewer proposed fixing it by pointing the spawn at the new identity field; that is precisely what the ticket forbids ("Do not 'unify' this by reusing `entrypoint` as the identity field in this ticket"), so I did neither. It dies naturally in the contract ticket.

6. **`ProcessorDescriptor` has no `#[serde(default)]` on the new field**, so previously-serialized descriptor JSON would fail to decode. Verified inert: nothing in the tree deserializes a `ProcessorDescriptor`, and pre-1.0 takes no back-compat shims. Stating it rather than leaving it to be discovered.

7. **Test-infra change worth knowing about.** `start_app_under_test` gained a `launcher=` keyword (defaults to today's behaviour, so no existing suite changes). Separately, my first pass set a working directory on every launcher, which would have silently masked a break in the `PYTHONPATH` the helper spawn host sets — a helper child inherits the app's cwd. Caught in review; only the `-m` arm sets one now, because only it resolves the app by module name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processor metadata now preserves the complete import path, including package, module, and class name.
  * Processor identity remains consistent when applications are launched directly, as modules, or through the Streamlib CLI.
  * Python processor registration now uses a consistent class path for descriptors and entrypoints.

* **Tests**
  * Added coverage for identity stability, nested modules, crate-root processors, and multiple launch methods.

* **Documentation**
  * Clarified how processor identity is derived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->