### PR TITLE
perf(xtask): optimize the lint gates so the test suite stops paying for them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,3 +188,11 @@ hyper = "1.7.0"
 # YUV/RGB conversion - REMOVED (now using GPU-accelerated VTPixelTransferSession)
 # yuv = "0.8"
 
+
+# The lint gates walk the whole tree — ~7400 files against every banned shape —
+# so they are the one dev-profile build where codegen dominates. Three xtask
+# tests each do a full-workspace scan, which unoptimised costs 155s of the
+# workspace test run's 207s; at opt-level 3 the same binary finishes in 7.6s.
+# Scoped to xtask alone so nothing else pays the compile time.
+[profile.dev.package.xtask]
+opt-level = 3


### PR DESCRIPTION
## Summary

`cargo test --workspace` spent **155.58s of its 207s in one binary** — xtask. Not many tests: three, each walking the whole tree (~7400 files) against every banned shape. Every other gate module finishes in 0.14s, and the engine's 1175 lib tests finish in 23s.

The scan is slow only because xtask is built unoptimised. Nothing about the gates changes — same checks, same files, same results — they are just compiled with codegen on, scoped to xtask so no other crate pays the compile time.

| | before | after |
|---|---|---|
| xtask test binary | 155.58s | **9.58s** |
| workspace test run | ~207s | **~60s** |

## Test plan

- `cargo test -p xtask` — 192 passed, 0 failed, 9.58s (was 155.58s).
- All nine gates run individually, exit 0, byte-identical summaries: `check-boundaries` (5800 files), `check-vendored-vulkanalia`, `check-device-wait-idle` (342), `check-no-escalate-in-lifecycle`, `check-no-in-process-placement` (7381 files, 3 allow-file'd, 19 exempt), `check-no-inventory-submit`, `check-no-reverse-dns`, `check-no-unbounded-cstr-from-ptr` (113), `lint-logging` (433).

Isolation of the cause, for the record — three tests at ~155s each, run in parallel so the binary's wall clock is one scan:

```
155.58s  the whole xtask binary (192 tests)
154.82s  every_scan_root_contributes_files_in_the_real_tree
159.28s  the_allow_file_set_is_exactly_the_expected_documents
154.27s  the_real_workspace_has_no_banned_placement_vocabulary
  0.12s  any single fixture test
  0.14s  every other check_* module, all tests
```

Same gate binary, debug vs release: 153.41s → 17.85s.

## Notes for owner

Two follow-ons I deliberately left out of this change, both smaller than the one-line win:

1. **The three tests each repeat the same full-tree scan.** Sharing one result through a `OnceLock` would cut CPU 3× — but not wall clock, since they already run in parallel. Worth doing when someone is next in that file.
2. **The matcher is 13 shapes × ~500k lines.** Even optimised that is 7.6s of substring searching; a single aho-corasick pass would put it near a second.

Separately: this measured **run** time only. Link time across the workspace's 67 integration-test binaries is a different axis and is not quantified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the build performance of the development tooling by enabling optimized compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->